### PR TITLE
Split/12 jaffle staging

### DIFF
--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/__sources.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/__sources.yml
@@ -1,0 +1,26 @@
+version: 2
+
+sources:
+  - name: ecom
+    schema: "{{ target.schema }}_raw"
+    description: E-commerce data for the Jaffle Shop
+    tables:
+      - name: raw_customers
+        description: One record per person who has purchased one or more items
+      - name: raw_orders
+        description: One record per order (consisting of one or more order items)
+        loaded_at_field: ordered_at
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
+      - name: raw_items
+        description: Items included in an order
+      - name: raw_stores
+        loaded_at_field: opened_at
+        freshness:
+          warn_after: {count: 72, period: hour}
+          error_after: {count: 168, period: hour}
+      - name: raw_products
+        description: One record per SKU for items sold in stores
+      - name: raw_supplies
+        description: One record per supply per SKU of items sold in stores

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/__sources.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/__sources.yml
@@ -1,0 +1,35 @@
+version: 2
+
+sources:
+  - name: finance
+    schema: "{{ target.schema }}_raw"
+    description: Finance and payments data for the Jaffle Shop
+    tables:
+      - name: raw_invoices
+        description: One record per invoice generated from an order
+        loaded_at_field: issued_at
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
+      - name: raw_invoice_line_items
+        description: Individual line items on each invoice
+      - name: raw_refunds
+        description: Refund requests and their resolution
+      - name: raw_tax_rates
+        description: Tax rate configuration by jurisdiction
+      - name: raw_gift_cards
+        description: Gift card issuance and balance tracking
+      - name: raw_payment_transactions
+        description: Individual payment transactions against orders
+        loaded_at_field: processed_at
+        freshness:
+          warn_after: {count: 12, period: hour}
+          error_after: {count: 24, period: hour}
+      - name: raw_accounts_receivable
+        description: Outstanding receivables from corporate/catering customers
+      - name: raw_expense_categories
+        description: Expense classification categories
+      - name: raw_expenses
+        description: Operating expenses by store
+      - name: raw_budgets
+        description: Monthly budget targets by store and category

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/_finance__models.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/_finance__models.yml
@@ -1,0 +1,222 @@
+models:
+  - name: stg_invoices
+    description: Invoices generated from orders, one row per invoice.
+    columns:
+      - name: invoice_id
+        description: The unique key for each invoice.
+        data_tests:
+          - not_null
+          - unique
+      - name: order_id
+        description: Foreign key to the order this invoice was generated from.
+      - name: customer_id
+        description: Foreign key to the customer billed on the invoice.
+      - name: invoice_status
+        description: Current status of the invoice (e.g., draft, sent, paid, overdue).
+      - name: subtotal
+        description: Invoice subtotal in USD before tax.
+      - name: tax_amount
+        description: Tax amount in USD applied to the invoice.
+      - name: total_amount
+        description: Total invoice amount in USD including tax.
+      - name: amount_paid
+        description: Amount paid against this invoice in USD.
+      - name: amount_due
+        description: Remaining amount due on this invoice in USD.
+      - name: issued_date
+        description: Date the invoice was issued.
+      - name: due_date
+        description: Date the invoice payment is due.
+      - name: paid_date
+        description: Date the invoice was fully paid.
+
+  - name: stg_invoice_line_items
+    description: Individual line items on each invoice, one row per line item.
+    columns:
+      - name: invoice_line_item_id
+        description: The unique key for each invoice line item.
+        data_tests:
+          - not_null
+          - unique
+      - name: invoice_id
+        description: Foreign key to the parent invoice.
+      - name: product_id
+        description: Foreign key to the product on this line item.
+      - name: line_item_description
+        description: Description of the line item.
+      - name: quantity
+        description: Quantity of the product on this line item.
+      - name: unit_price
+        description: Unit price in USD.
+      - name: line_total
+        description: Total for this line item in USD (quantity x unit price).
+
+  - name: stg_refunds
+    description: Refund requests and their resolution, one row per refund.
+    columns:
+      - name: refund_id
+        description: The unique key for each refund.
+        data_tests:
+          - not_null
+          - unique
+      - name: order_id
+        description: Foreign key to the order being refunded.
+      - name: invoice_id
+        description: Foreign key to the invoice being refunded.
+      - name: refund_reason
+        description: Reason provided for the refund request.
+      - name: refund_status
+        description: Current status of the refund (e.g., pending, approved, denied).
+      - name: refund_amount
+        description: Refund amount in USD.
+      - name: requested_date
+        description: Date the refund was requested.
+      - name: resolved_date
+        description: Date the refund was resolved.
+
+  - name: stg_tax_rates
+    description: Tax rate configuration by jurisdiction, one row per tax rate.
+    columns:
+      - name: tax_rate_id
+        description: The unique key for each tax rate configuration.
+        data_tests:
+          - not_null
+          - unique
+      - name: jurisdiction
+        description: The jurisdiction this tax rate applies to (e.g., state, city).
+      - name: tax_type
+        description: Type of tax (e.g., sales tax, excise tax).
+      - name: tax_rate_pct
+        description: The tax rate as a decimal percentage.
+      - name: effective_from_date
+        description: Date this tax rate became effective.
+      - name: effective_to_date
+        description: Date this tax rate expires (null if currently active).
+
+  - name: stg_gift_cards
+    description: Gift card issuance and balance tracking, one row per gift card.
+    columns:
+      - name: gift_card_id
+        description: The unique key for each gift card.
+        data_tests:
+          - not_null
+          - unique
+      - name: customer_id
+        description: Foreign key to the customer who purchased the gift card.
+      - name: card_number
+        description: The gift card number.
+      - name: gift_card_status
+        description: Current status of the gift card (e.g., active, redeemed, expired).
+      - name: initial_balance
+        description: Original balance loaded onto the gift card in USD.
+      - name: current_balance
+        description: Current remaining balance on the gift card in USD.
+      - name: issued_date
+        description: Date the gift card was issued.
+      - name: expires_date
+        description: Date the gift card expires.
+
+  - name: stg_payment_transactions
+    description: Individual payment transactions against orders, one row per transaction.
+    columns:
+      - name: payment_transaction_id
+        description: The unique key for each payment transaction.
+        data_tests:
+          - not_null
+          - unique
+      - name: order_id
+        description: Foreign key to the order this payment applies to.
+      - name: gift_card_id
+        description: Foreign key to the gift card used (null if not a gift card payment).
+      - name: payment_method
+        description: Payment method used (e.g., credit_card, debit_card, gift_card, cash).
+      - name: payment_status
+        description: Current status of the transaction (e.g., completed, pending, failed).
+      - name: reference_number
+        description: External reference number from the payment processor.
+      - name: payment_amount
+        description: Transaction amount in USD.
+      - name: processed_date
+        description: Date the payment was processed.
+
+  - name: stg_accounts_receivable
+    description: Outstanding receivables from corporate/catering customers, one row per receivable.
+    columns:
+      - name: receivable_id
+        description: The unique key for each accounts receivable record.
+        data_tests:
+          - not_null
+          - unique
+      - name: customer_id
+        description: Foreign key to the corporate/catering customer.
+      - name: invoice_id
+        description: Foreign key to the associated invoice.
+      - name: receivable_status
+        description: Current status of the receivable (e.g., open, partial, paid, written_off).
+      - name: amount_due
+        description: Original amount due in USD.
+      - name: amount_paid
+        description: Amount paid so far in USD.
+      - name: amount_outstanding
+        description: Remaining outstanding balance in USD.
+      - name: due_date
+        description: Date the payment is due.
+      - name: created_date
+        description: Date the receivable record was created.
+
+  - name: stg_expense_categories
+    description: Expense classification categories, one row per category.
+    columns:
+      - name: expense_category_id
+        description: The unique key for each expense category.
+        data_tests:
+          - not_null
+          - unique
+      - name: category_name
+        description: Name of the expense category.
+      - name: category_description
+        description: Description of what this category covers.
+      - name: is_operating_expense
+        description: Whether this category is an operating expense.
+      - name: is_cost_of_goods_sold
+        description: Whether this category is a cost of goods sold.
+
+  - name: stg_expenses
+    description: Operating expenses by store, one row per expense.
+    columns:
+      - name: expense_id
+        description: The unique key for each expense.
+        data_tests:
+          - not_null
+          - unique
+      - name: location_id
+        description: Foreign key to the store location.
+      - name: expense_category_id
+        description: Foreign key to the expense category.
+      - name: expense_description
+        description: Description of the expense.
+      - name: vendor
+        description: Vendor or supplier for this expense.
+      - name: expense_amount
+        description: Expense amount in USD.
+      - name: incurred_date
+        description: Date the expense was incurred.
+
+  - name: stg_budgets
+    description: Monthly budget targets by store and category, one row per budget entry.
+    columns:
+      - name: budget_id
+        description: The unique key for each budget entry.
+        data_tests:
+          - not_null
+          - unique
+      - name: location_id
+        description: Foreign key to the store location.
+      - name: expense_category_id
+        description: Foreign key to the budget category.
+      - name: budget_type
+        description: Type of budget (e.g., revenue, expense).
+      - name: budgeted_amount
+        description: Budgeted amount in USD.
+      - name: budget_month
+        description: The month this budget applies to.

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_accounts_receivable.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_accounts_receivable.sql
@@ -1,0 +1,34 @@
+with
+
+source as (
+
+    select * from {{ source('finance', 'raw_accounts_receivable') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as receivable_id,
+        cast(customer_id as varchar) as customer_id,
+        cast(invoice_id as varchar) as invoice_id,
+
+        ---------- text
+        status as receivable_status,
+
+        ---------- numerics
+        {{ cents_to_dollars('amount_due') }} as amount_due,
+        {{ cents_to_dollars('amount_paid') }} as amount_paid,
+        {{ cents_to_dollars('amount_outstanding') }} as amount_outstanding,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'due_at') }} as due_date,
+        {{ dbt.date_trunc('day', 'created_at') }} as created_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_budgets.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_budgets.sql
@@ -1,0 +1,31 @@
+with
+
+source as (
+
+    select * from {{ source('finance', 'raw_budgets') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as budget_id,
+        cast(store_id as varchar) as location_id,
+        cast(category_id as varchar) as expense_category_id,
+
+        ---------- text
+        budget_type,
+
+        ---------- numerics
+        {{ cents_to_dollars('budgeted_amount') }} as budgeted_amount,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'month_start') }} as budget_month
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_expense_categories.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_expense_categories.sql
@@ -1,0 +1,28 @@
+with
+
+source as (
+
+    select * from {{ source('finance', 'raw_expense_categories') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as expense_category_id,
+
+        ---------- text
+        name as category_name,
+        description as category_description,
+
+        ---------- booleans
+        coalesce(is_operating, false) as is_operating_expense,
+        coalesce(is_cogs, false) as is_cost_of_goods_sold
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_expenses.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_expenses.sql
@@ -1,0 +1,32 @@
+with
+
+source as (
+
+    select * from {{ source('finance', 'raw_expenses') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as expense_id,
+        cast(store_id as varchar) as location_id,
+        cast(category_id as varchar) as expense_category_id,
+
+        ---------- text
+        description as expense_description,
+        vendor,
+
+        ---------- numerics
+        {{ cents_to_dollars('amount') }} as expense_amount,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'incurred_at') }} as incurred_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_gift_cards.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_gift_cards.sql
@@ -1,0 +1,33 @@
+with
+
+source as (
+
+    select * from {{ source('finance', 'raw_gift_cards') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as gift_card_id,
+        cast(customer_id as varchar) as customer_id,
+
+        ---------- text
+        card_number,
+        status as gift_card_status,
+
+        ---------- numerics
+        {{ cents_to_dollars('initial_balance') }} as initial_balance,
+        {{ cents_to_dollars('current_balance') }} as current_balance,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'issued_at') }} as issued_date,
+        {{ dbt.date_trunc('day', 'expires_at') }} as expires_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_invoice_line_items.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_invoice_line_items.sql
@@ -1,0 +1,30 @@
+with
+
+source as (
+
+    select * from {{ source('finance', 'raw_invoice_line_items') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as invoice_line_item_id,
+        cast(invoice_id as varchar) as invoice_id,
+        cast(product_id as varchar) as product_id,
+
+        ---------- text
+        description as line_item_description,
+
+        ---------- numerics
+        quantity,
+        {{ cents_to_dollars('unit_price') }} as unit_price,
+        {{ cents_to_dollars('line_total') }} as line_total
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_invoices.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_invoices.sql
@@ -1,0 +1,37 @@
+with
+
+source as (
+
+    select * from {{ source('finance', 'raw_invoices') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as invoice_id,
+        cast(order_id as varchar) as order_id,
+        cast(customer_id as varchar) as customer_id,
+
+        ---------- text
+        status as invoice_status,
+
+        ---------- numerics
+        {{ cents_to_dollars('subtotal') }} as subtotal,
+        {{ cents_to_dollars('tax_amount') }} as tax_amount,
+        {{ cents_to_dollars('total_amount') }} as total_amount,
+        {{ cents_to_dollars('amount_paid') }} as amount_paid,
+        {{ cents_to_dollars('amount_due') }} as amount_due,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'issued_at') }} as issued_date,
+        {{ dbt.date_trunc('day', 'due_at') }} as due_date,
+        {{ dbt.date_trunc('day', 'paid_at') }} as paid_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_payment_transactions.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_payment_transactions.sql
@@ -1,0 +1,33 @@
+with
+
+source as (
+
+    select * from {{ source('finance', 'raw_payment_transactions') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as payment_transaction_id,
+        cast(order_id as varchar) as order_id,
+        cast(gift_card_id as varchar) as gift_card_id,
+
+        ---------- text
+        payment_method,
+        status as payment_status,
+        reference_number,
+
+        ---------- numerics
+        {{ cents_to_dollars('amount') }} as payment_amount,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'processed_at') }} as processed_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_refunds.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_refunds.sql
@@ -1,0 +1,33 @@
+with
+
+source as (
+
+    select * from {{ source('finance', 'raw_refunds') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as refund_id,
+        cast(order_id as varchar) as order_id,
+        cast(invoice_id as varchar) as invoice_id,
+
+        ---------- text
+        reason as refund_reason,
+        status as refund_status,
+
+        ---------- numerics
+        {{ cents_to_dollars('refund_amount') }} as refund_amount,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'requested_at') }} as requested_date,
+        {{ dbt.date_trunc('day', 'resolved_at') }} as resolved_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_tax_rates.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_tax_rates.sql
@@ -1,0 +1,31 @@
+with
+
+source as (
+
+    select * from {{ source('finance', 'raw_tax_rates') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as tax_rate_id,
+
+        ---------- text
+        jurisdiction,
+        tax_type,
+
+        ---------- numerics
+        rate as tax_rate_pct,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'effective_from') }} as effective_from_date,
+        {{ dbt.date_trunc('day', 'effective_to') }} as effective_to_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/__sources.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/__sources.yml
@@ -1,0 +1,39 @@
+version: 2
+
+sources:
+  - name: hr_ops
+    schema: "{{ target.schema }}_raw"
+    description: HR and store operations data for the Jaffle Shop
+    tables:
+      - name: raw_employees
+        description: Employee records including name, hire date, role, and store assignment
+      - name: raw_departments
+        description: Department definitions (operations, kitchen, front-of-house, management)
+      - name: raw_positions
+        description: Job position definitions with pay grades
+      - name: raw_shifts
+        description: Scheduled and actual shift records
+      - name: raw_timecards
+        description: Clock-in/clock-out records for employees
+        loaded_at_field: work_date
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
+      - name: raw_payroll
+        description: Payroll records per employee per pay period
+        loaded_at_field: pay_date
+        freshness:
+          warn_after: {count: 48, period: hour}
+          error_after: {count: 168, period: hour}
+      - name: raw_performance_reviews
+        description: Employee performance review scores
+      - name: raw_training_courses
+        description: Available training courses for employees
+      - name: raw_training_completions
+        description: Employee training completion records
+      - name: raw_equipment
+        description: Store equipment inventory (espresso machines, grinders, etc.)
+      - name: raw_maintenance_logs
+        description: Equipment maintenance and repair records
+      - name: raw_store_hours
+        description: Operating hours by store by day of week

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/_hr_ops__models.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/_hr_ops__models.yml
@@ -1,0 +1,292 @@
+models:
+  - name: stg_employees
+    description: Employee records with basic cleaning applied, one row per employee.
+    columns:
+      - name: employee_id
+        description: The unique key for each employee.
+        data_tests:
+          - not_null
+          - unique
+      - name: location_id
+        description: Foreign key to the store location where the employee works.
+      - name: department_id
+        description: Foreign key to the employee's department.
+      - name: position_id
+        description: Foreign key to the employee's position.
+      - name: first_name
+        description: Employee's first name.
+      - name: last_name
+        description: Employee's last name.
+      - name: full_name
+        description: Employee's full name (first + last).
+      - name: email
+        description: Employee's email address.
+      - name: employment_status
+        description: Current employment status (e.g., active, terminated, on_leave).
+      - name: hire_date
+        description: Date the employee was hired.
+      - name: termination_date
+        description: Date the employee was terminated (null if still active).
+
+  - name: stg_departments
+    description: Department definitions, one row per department.
+    columns:
+      - name: department_id
+        description: The unique key for each department.
+        data_tests:
+          - not_null
+          - unique
+      - name: department_name
+        description: Name of the department.
+      - name: department_description
+        description: Description of the department's function.
+
+  - name: stg_positions
+    description: Job position definitions with pay grades, one row per position.
+    columns:
+      - name: position_id
+        description: The unique key for each position.
+        data_tests:
+          - not_null
+          - unique
+      - name: department_id
+        description: Foreign key to the department this position belongs to.
+      - name: position_title
+        description: Title of the position.
+      - name: pay_grade
+        description: Pay grade classification for the position.
+      - name: min_hourly_rate
+        description: Minimum hourly pay rate in USD.
+      - name: max_hourly_rate
+        description: Maximum hourly pay rate in USD.
+      - name: is_management
+        description: Whether this position is a management role.
+
+  - name: stg_shifts
+    description: Scheduled and actual shift records, one row per shift.
+    columns:
+      - name: shift_id
+        description: The unique key for each shift.
+        data_tests:
+          - not_null
+          - unique
+      - name: employee_id
+        description: Foreign key to the employee assigned to the shift.
+      - name: location_id
+        description: Foreign key to the store location for the shift.
+      - name: shift_type
+        description: Type of shift (e.g., morning, afternoon, evening, closing).
+      - name: shift_status
+        description: Status of the shift (e.g., scheduled, completed, no_show).
+      - name: shift_date
+        description: Date of the shift.
+      - name: scheduled_start
+        description: Scheduled start time of the shift.
+      - name: scheduled_end
+        description: Scheduled end time of the shift.
+      - name: actual_start
+        description: Actual start time of the shift.
+      - name: actual_end
+        description: Actual end time of the shift.
+      - name: scheduled_hours
+        description: Number of hours the shift is scheduled for.
+
+  - name: stg_timecards
+    description: Clock-in/clock-out records, one row per timecard entry.
+    columns:
+      - name: timecard_id
+        description: The unique key for each timecard entry.
+        data_tests:
+          - not_null
+          - unique
+      - name: employee_id
+        description: Foreign key to the employee.
+      - name: location_id
+        description: Foreign key to the store location.
+      - name: work_date
+        description: Date of the work entry.
+      - name: clock_in
+        description: Clock-in timestamp.
+      - name: clock_out
+        description: Clock-out timestamp.
+      - name: hours_worked
+        description: Total hours worked for this entry.
+      - name: break_minutes
+        description: Total break time in minutes.
+      - name: timecard_status
+        description: Status of the timecard (e.g., approved, pending, rejected).
+
+  - name: stg_payroll
+    description: Payroll records per employee per pay period, one row per payroll entry.
+    columns:
+      - name: payroll_id
+        description: The unique key for each payroll record.
+        data_tests:
+          - not_null
+          - unique
+      - name: employee_id
+        description: Foreign key to the employee.
+      - name: pay_period_start
+        description: Start date of the pay period.
+      - name: pay_period_end
+        description: End date of the pay period.
+      - name: pay_date
+        description: Date the payment was issued.
+      - name: payroll_hours
+        description: Total regular hours worked in the pay period.
+      - name: payroll_overtime_hours
+        description: Total overtime hours in the pay period.
+      - name: gross_pay
+        description: Gross pay amount in USD.
+      - name: deductions
+        description: Total deductions in USD.
+      - name: net_pay
+        description: Net pay amount in USD.
+
+  - name: stg_performance_reviews
+    description: Employee performance review scores, one row per review.
+    columns:
+      - name: review_id
+        description: The unique key for each performance review.
+        data_tests:
+          - not_null
+          - unique
+      - name: employee_id
+        description: Foreign key to the employee being reviewed.
+      - name: reviewer_id
+        description: Foreign key to the employee conducting the review.
+      - name: review_period
+        description: Period the review covers (e.g., Q1 2024).
+      - name: review_comments
+        description: Reviewer comments.
+      - name: overall_score
+        description: Overall performance score.
+      - name: attendance_score
+        description: Attendance component score.
+      - name: quality_score
+        description: Work quality component score.
+      - name: teamwork_score
+        description: Teamwork component score.
+      - name: review_date
+        description: Date the review was conducted.
+
+  - name: stg_training_courses
+    description: Available training courses, one row per course.
+    columns:
+      - name: training_course_id
+        description: The unique key for each training course.
+        data_tests:
+          - not_null
+          - unique
+      - name: course_name
+        description: Name of the training course.
+      - name: course_description
+        description: Description of the training course.
+      - name: course_category
+        description: Category of the course (e.g., safety, barista, management).
+      - name: duration_hours
+        description: Duration of the course in hours.
+      - name: is_required
+        description: Whether the course is required for all employees.
+      - name: is_active
+        description: Whether the course is currently active.
+
+  - name: stg_training_completions
+    description: Employee training completion records, one row per completion.
+    columns:
+      - name: training_completion_id
+        description: The unique key for each training completion record.
+        data_tests:
+          - not_null
+          - unique
+      - name: employee_id
+        description: Foreign key to the employee.
+      - name: training_course_id
+        description: Foreign key to the training course.
+      - name: completion_status
+        description: Status of the training (e.g., in_progress, completed, failed).
+      - name: completion_score
+        description: Score achieved on the training assessment.
+      - name: started_date
+        description: Date the employee started the training.
+      - name: completed_date
+        description: Date the employee completed the training.
+
+  - name: stg_equipment
+    description: Store equipment inventory, one row per piece of equipment.
+    columns:
+      - name: equipment_id
+        description: The unique key for each piece of equipment.
+        data_tests:
+          - not_null
+          - unique
+      - name: location_id
+        description: Foreign key to the store location.
+      - name: equipment_name
+        description: Name of the equipment.
+      - name: equipment_type
+        description: Type of equipment (e.g., espresso_machine, grinder, oven).
+      - name: manufacturer
+        description: Equipment manufacturer.
+      - name: model_number
+        description: Equipment model number.
+      - name: serial_number
+        description: Equipment serial number.
+      - name: equipment_status
+        description: Current status (e.g., operational, maintenance, retired).
+      - name: purchase_cost
+        description: Purchase cost in USD.
+      - name: purchase_date
+        description: Date the equipment was purchased.
+      - name: warranty_expiry_date
+        description: Date the warranty expires.
+      - name: last_maintenance_date
+        description: Date of the last maintenance performed.
+
+  - name: stg_maintenance_logs
+    description: Equipment maintenance and repair records, one row per log entry.
+    columns:
+      - name: maintenance_log_id
+        description: The unique key for each maintenance log entry.
+        data_tests:
+          - not_null
+          - unique
+      - name: equipment_id
+        description: Foreign key to the equipment.
+      - name: technician_id
+        description: ID of the technician who performed the maintenance.
+      - name: maintenance_type
+        description: Type of maintenance (e.g., preventive, corrective, emergency).
+      - name: maintenance_description
+        description: Description of the maintenance performed.
+      - name: maintenance_status
+        description: Status of the maintenance (e.g., scheduled, in_progress, completed).
+      - name: maintenance_cost
+        description: Cost of the maintenance in USD.
+      - name: downtime_hours
+        description: Hours of equipment downtime due to this maintenance.
+      - name: scheduled_date
+        description: Date the maintenance was scheduled.
+      - name: completed_date
+        description: Date the maintenance was completed.
+
+  - name: stg_store_hours
+    description: Operating hours by store by day of week, one row per store-day combination.
+    columns:
+      - name: store_hours_id
+        description: The unique key for each store hours record.
+        data_tests:
+          - not_null
+          - unique
+      - name: location_id
+        description: Foreign key to the store location.
+      - name: day_of_week
+        description: Day of week as integer (0=Sunday, 6=Saturday).
+      - name: day_name
+        description: Day of week as human-readable name.
+      - name: open_time
+        description: Store opening time.
+      - name: close_time
+        description: Store closing time.
+      - name: is_closed
+        description: Whether the store is closed on this day.

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_departments.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_departments.sql
@@ -1,0 +1,24 @@
+with
+
+source as (
+
+    select * from {{ source('hr_ops', 'raw_departments') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as department_id,
+
+        ---------- text
+        name as department_name,
+        description as department_description
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_employees.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_employees.sql
@@ -1,0 +1,34 @@
+with
+
+source as (
+
+    select * from {{ source('hr_ops', 'raw_employees') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as employee_id,
+        cast(store_id as varchar) as location_id,
+        cast(department_id as varchar) as department_id,
+        cast(position_id as varchar) as position_id,
+
+        ---------- text
+        first_name,
+        last_name,
+        first_name || ' ' || last_name as full_name,
+        email,
+        employment_status,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'hire_date') }} as hire_date,
+        {{ dbt.date_trunc('day', 'termination_date') }} as termination_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_equipment.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_equipment.sql
@@ -1,0 +1,37 @@
+with
+
+source as (
+
+    select * from {{ source('hr_ops', 'raw_equipment') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as equipment_id,
+        cast(store_id as varchar) as location_id,
+
+        ---------- text
+        name as equipment_name,
+        type as equipment_type,
+        manufacturer,
+        model_number,
+        serial_number,
+        status as equipment_status,
+
+        ---------- numerics
+        {{ cents_to_dollars('purchase_cost') }} as purchase_cost,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'purchase_date') }} as purchase_date,
+        {{ dbt.date_trunc('day', 'warranty_expiry') }} as warranty_expiry_date,
+        {{ dbt.date_trunc('day', 'last_maintenance_date') }} as last_maintenance_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_maintenance_logs.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_maintenance_logs.sql
@@ -1,0 +1,35 @@
+with
+
+source as (
+
+    select * from {{ source('hr_ops', 'raw_maintenance_logs') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as maintenance_log_id,
+        cast(equipment_id as varchar) as equipment_id,
+        cast(performed_by as varchar) as technician_id,
+
+        ---------- text
+        maintenance_type,
+        description as maintenance_description,
+        status as maintenance_status,
+
+        ---------- numerics
+        {{ cents_to_dollars('cost') }} as maintenance_cost,
+        downtime_hours,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'scheduled_date') }} as scheduled_date,
+        {{ dbt.date_trunc('day', 'completed_date') }} as completed_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_payroll.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_payroll.sql
@@ -1,0 +1,33 @@
+with
+
+source as (
+
+    select * from {{ source('hr_ops', 'raw_payroll') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as payroll_id,
+        cast(employee_id as varchar) as employee_id,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'pay_period_start') }} as pay_period_start,
+        {{ dbt.date_trunc('day', 'pay_period_end') }} as pay_period_end,
+        {{ dbt.date_trunc('day', 'pay_date') }} as pay_date,
+
+        ---------- numerics
+        hours_worked as payroll_hours,
+        overtime_hours as payroll_overtime_hours,
+        {{ cents_to_dollars('gross_pay') }} as gross_pay,
+        {{ cents_to_dollars('deductions') }} as deductions,
+        {{ cents_to_dollars('net_pay') }} as net_pay
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_performance_reviews.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_performance_reviews.sql
@@ -1,0 +1,35 @@
+with
+
+source as (
+
+    select * from {{ source('hr_ops', 'raw_performance_reviews') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as review_id,
+        cast(employee_id as varchar) as employee_id,
+        cast(reviewer_id as varchar) as reviewer_id,
+
+        ---------- text
+        review_period,
+        comments as review_comments,
+
+        ---------- numerics
+        overall_score,
+        attendance_score,
+        quality_score,
+        teamwork_score,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'review_date') }} as review_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_positions.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_positions.sql
@@ -1,0 +1,32 @@
+with
+
+source as (
+
+    select * from {{ source('hr_ops', 'raw_positions') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as position_id,
+        cast(department_id as varchar) as department_id,
+
+        ---------- text
+        title as position_title,
+        pay_grade,
+
+        ---------- numerics
+        {{ cents_to_dollars('min_pay_rate') }} as min_hourly_rate,
+        {{ cents_to_dollars('max_pay_rate') }} as max_hourly_rate,
+
+        ---------- booleans
+        is_management
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_shifts.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_shifts.sql
@@ -1,0 +1,36 @@
+with
+
+source as (
+
+    select * from {{ source('hr_ops', 'raw_shifts') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as shift_id,
+        cast(employee_id as varchar) as employee_id,
+        cast(store_id as varchar) as location_id,
+
+        ---------- text
+        shift_type,
+        status as shift_status,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'shift_date') }} as shift_date,
+        scheduled_start,
+        scheduled_end,
+        actual_start,
+        actual_end,
+
+        ---------- numerics
+        {{ dbt.datediff('scheduled_start', 'scheduled_end', 'hour') }} as scheduled_hours
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_store_hours.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_store_hours.sql
@@ -1,0 +1,42 @@
+with
+
+source as (
+
+    select * from {{ source('hr_ops', 'raw_store_hours') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as store_hours_id,
+        cast(store_id as varchar) as location_id,
+
+        ---------- numerics
+        day_of_week,
+
+        ---------- text
+        case day_of_week
+            when 0 then 'Sunday'
+            when 1 then 'Monday'
+            when 2 then 'Tuesday'
+            when 3 then 'Wednesday'
+            when 4 then 'Thursday'
+            when 5 then 'Friday'
+            when 6 then 'Saturday'
+        end as day_name,
+
+        ---------- timestamps
+        open_time,
+        close_time,
+
+        ---------- booleans
+        is_closed
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_timecards.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_timecards.sql
@@ -1,0 +1,34 @@
+with
+
+source as (
+
+    select * from {{ source('hr_ops', 'raw_timecards') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as timecard_id,
+        cast(employee_id as varchar) as employee_id,
+        cast(store_id as varchar) as location_id,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'work_date') }} as work_date,
+        clock_in,
+        clock_out,
+
+        ---------- numerics
+        hours_worked,
+        break_minutes,
+
+        ---------- text
+        status as timecard_status
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_training_completions.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_training_completions.sql
@@ -1,0 +1,32 @@
+with
+
+source as (
+
+    select * from {{ source('hr_ops', 'raw_training_completions') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as training_completion_id,
+        cast(employee_id as varchar) as employee_id,
+        cast(course_id as varchar) as training_course_id,
+
+        ---------- text
+        status as completion_status,
+
+        ---------- numerics
+        score as completion_score,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'started_at') }} as started_date,
+        {{ dbt.date_trunc('day', 'completed_at') }} as completed_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_training_courses.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_training_courses.sql
@@ -1,0 +1,32 @@
+with
+
+source as (
+
+    select * from {{ source('hr_ops', 'raw_training_courses') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as training_course_id,
+
+        ---------- text
+        name as course_name,
+        description as course_description,
+        category as course_category,
+
+        ---------- numerics
+        duration_hours,
+
+        ---------- booleans
+        is_required,
+        is_active
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/__sources.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/__sources.yml
@@ -1,0 +1,35 @@
+version: 2
+
+sources:
+  - name: marketing
+    schema: "{{ target.schema }}_raw"
+    description: Marketing and loyalty program data for the Jaffle Shop
+    tables:
+      - name: raw_campaigns
+        description: Marketing campaigns across email, social, and in-store channels
+      - name: raw_campaign_spend
+        description: Daily spend per campaign per channel
+      - name: raw_coupons
+        description: Coupon definitions including code, discount type, amount, and validity
+      - name: raw_coupon_redemptions
+        description: Each time a coupon is used on an order
+      - name: raw_loyalty_members
+        description: Loyalty program membership records
+      - name: raw_loyalty_transactions
+        description: Points earned and redeemed by loyalty members
+        loaded_at_field: transacted_at
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
+      - name: raw_loyalty_tiers
+        description: Tier definitions for the loyalty program (Bronze, Silver, Gold, Platinum)
+      - name: raw_email_events
+        description: Email interaction events including sends, opens, clicks, and unsubscribes
+        loaded_at_field: event_at
+        freshness:
+          warn_after: {count: 12, period: hour}
+          error_after: {count: 24, period: hour}
+      - name: raw_social_media_posts
+        description: Social media content and engagement metrics
+      - name: raw_referrals
+        description: Customer referral tracking records

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/_marketing__models.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/_marketing__models.yml
@@ -1,0 +1,204 @@
+models:
+  - name: stg_campaigns
+    description: Cleaned marketing campaigns with renamed columns, one row per campaign.
+    columns:
+      - name: campaign_id
+        description: The unique key for each campaign.
+        data_tests:
+          - not_null
+          - unique
+      - name: campaign_name
+        description: Human-readable campaign name.
+      - name: campaign_channel
+        description: The channel used for the campaign (email, social, in-store).
+      - name: campaign_status
+        description: Current status of the campaign (draft, active, paused, completed).
+      - name: budget
+        description: Total campaign budget in dollars.
+      - name: campaign_start_date
+        description: Date the campaign starts.
+      - name: campaign_end_date
+        description: Date the campaign ends.
+
+  - name: stg_campaign_spend
+    description: Daily campaign spend records by channel, one row per spend entry.
+    columns:
+      - name: campaign_spend_id
+        description: The unique key for each spend record.
+        data_tests:
+          - not_null
+          - unique
+      - name: campaign_id
+        description: Foreign key to campaigns.
+        data_tests:
+          - not_null
+      - name: spend_amount
+        description: Amount spent in dollars.
+      - name: spend_date
+        description: Date the spend occurred.
+
+  - name: stg_coupons
+    description: Coupon definitions with discount details and validity windows, one row per coupon.
+    columns:
+      - name: coupon_id
+        description: The unique key for each coupon.
+        data_tests:
+          - not_null
+          - unique
+      - name: coupon_code
+        description: The code customers enter to redeem the coupon.
+      - name: discount_type
+        description: Type of discount (percentage, fixed_amount).
+      - name: discount_amount
+        description: Fixed discount amount in dollars (null for percentage discounts).
+      - name: discount_percent
+        description: Percentage discount (null for fixed amount discounts).
+      - name: valid_from
+        description: Date the coupon becomes active.
+      - name: valid_until
+        description: Date the coupon expires.
+
+  - name: stg_coupon_redemptions
+    description: Coupon redemption events, one row per redemption.
+    columns:
+      - name: redemption_id
+        description: The unique key for each redemption.
+        data_tests:
+          - not_null
+          - unique
+      - name: coupon_id
+        description: Foreign key to coupons.
+        data_tests:
+          - not_null
+      - name: order_id
+        description: Foreign key to orders.
+        data_tests:
+          - not_null
+      - name: discount_applied
+        description: Actual discount amount applied in dollars.
+      - name: redeemed_at
+        description: Date the coupon was redeemed.
+
+  - name: stg_loyalty_members
+    description: Loyalty program membership records, one row per member.
+    columns:
+      - name: loyalty_member_id
+        description: The unique key for each loyalty member.
+        data_tests:
+          - not_null
+          - unique
+      - name: customer_id
+        description: Foreign key to customers.
+        data_tests:
+          - not_null
+      - name: current_tier_id
+        description: Foreign key to the member's current loyalty tier.
+      - name: membership_status
+        description: Current membership status (active, inactive, suspended).
+      - name: lifetime_points
+        description: Total points earned over the lifetime of membership.
+      - name: enrolled_at
+        description: Date the customer enrolled in the loyalty program.
+
+  - name: stg_loyalty_transactions
+    description: Points earned and redeemed by loyalty members, one row per transaction.
+    columns:
+      - name: loyalty_transaction_id
+        description: The unique key for each loyalty transaction.
+        data_tests:
+          - not_null
+          - unique
+      - name: loyalty_member_id
+        description: Foreign key to loyalty members.
+        data_tests:
+          - not_null
+      - name: transaction_type
+        description: Type of transaction (earn, redeem, expire, bonus).
+      - name: points
+        description: Number of points (positive for earn, negative for redeem/expire).
+      - name: transacted_at
+        description: Date the transaction occurred.
+
+  - name: stg_loyalty_tiers
+    description: Loyalty tier definitions, one row per tier.
+    columns:
+      - name: tier_id
+        description: The unique key for each tier.
+        data_tests:
+          - not_null
+          - unique
+      - name: tier_name
+        description: Name of the tier (Bronze, Silver, Gold, Platinum).
+      - name: minimum_points
+        description: Minimum points required to reach this tier.
+      - name: maximum_points
+        description: Maximum points for this tier (null for top tier).
+      - name: points_multiplier
+        description: Points earning multiplier for this tier.
+      - name: annual_reward
+        description: Annual reward value in dollars for this tier.
+
+  - name: stg_email_events
+    description: Email interaction events, one row per event.
+    columns:
+      - name: email_event_id
+        description: The unique key for each email event.
+        data_tests:
+          - not_null
+          - unique
+      - name: campaign_id
+        description: Foreign key to campaigns.
+      - name: customer_id
+        description: Foreign key to customers.
+      - name: email_event_type
+        description: Type of email event (sent, opened, clicked, unsubscribed, bounced).
+      - name: event_date
+        description: Date the event occurred.
+
+  - name: stg_social_media_posts
+    description: Social media posts and engagement metrics, one row per post.
+    columns:
+      - name: post_id
+        description: The unique key for each social media post.
+        data_tests:
+          - not_null
+          - unique
+      - name: campaign_id
+        description: Foreign key to campaigns (null for organic posts).
+      - name: platform
+        description: Social media platform (instagram, twitter, facebook, tiktok).
+      - name: impressions
+        description: Number of times the post was displayed.
+      - name: reach
+        description: Number of unique users who saw the post.
+      - name: likes
+        description: Number of likes on the post.
+      - name: shares
+        description: Number of shares/retweets.
+      - name: posted_at
+        description: Date the post was published.
+
+  - name: stg_referrals
+    description: Customer referral records, one row per referral.
+    columns:
+      - name: referral_id
+        description: The unique key for each referral.
+        data_tests:
+          - not_null
+          - unique
+      - name: referrer_customer_id
+        description: Foreign key to the customer who made the referral.
+        data_tests:
+          - not_null
+      - name: referee_customer_id
+        description: Foreign key to the customer who was referred.
+        data_tests:
+          - not_null
+      - name: referral_status
+        description: Status of the referral (pending, converted, expired).
+      - name: reward_amount
+        description: Reward amount in dollars for a successful referral.
+      - name: referred_at
+        description: Date the referral was created.
+      - name: converted_at
+        description: Date the referral was converted (referee made a purchase).

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_campaign_spend.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_campaign_spend.sql
@@ -1,0 +1,30 @@
+with
+
+source as (
+
+    select * from {{ source('marketing', 'raw_campaign_spend') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as campaign_spend_id,
+        cast(campaign_id as varchar) as campaign_id,
+
+        ---------- text
+        channel as spend_channel,
+
+        ---------- numerics
+        {{ cents_to_dollars('amount') }} as spend_amount,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'spend_date') }} as spend_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_campaigns.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_campaigns.sql
@@ -1,0 +1,34 @@
+with
+
+source as (
+
+    select * from {{ source('marketing', 'raw_campaigns') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as campaign_id,
+
+        ---------- text
+        name as campaign_name,
+        channel as campaign_channel,
+        status as campaign_status,
+        description as campaign_description,
+
+        ---------- numerics
+        {{ cents_to_dollars('budget') }} as budget,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'start_date') }} as campaign_start_date,
+        {{ dbt.date_trunc('day', 'end_date') }} as campaign_end_date,
+        {{ dbt.date_trunc('day', 'created_at') }} as created_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_coupon_redemptions.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_coupon_redemptions.sql
@@ -1,0 +1,29 @@
+with
+
+source as (
+
+    select * from {{ source('marketing', 'raw_coupon_redemptions') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as redemption_id,
+        cast(coupon_id as varchar) as coupon_id,
+        cast(order_id as varchar) as order_id,
+        cast(customer_id as varchar) as customer_id,
+
+        ---------- numerics
+        {{ cents_to_dollars('discount_applied') }} as discount_applied,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'redeemed_at') }} as redeemed_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_coupons.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_coupons.sql
@@ -1,0 +1,37 @@
+with
+
+source as (
+
+    select * from {{ source('marketing', 'raw_coupons') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as coupon_id,
+        cast(campaign_id as varchar) as campaign_id,
+
+        ---------- text
+        code as coupon_code,
+        discount_type,
+        status as coupon_status,
+
+        ---------- numerics
+        {{ cents_to_dollars('discount_amount') }} as discount_amount,
+        discount_percent,
+        {{ cents_to_dollars('minimum_order_amount') }} as minimum_order_amount,
+        max_redemptions,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'valid_from') }} as valid_from,
+        {{ dbt.date_trunc('day', 'valid_until') }} as valid_until,
+        {{ dbt.date_trunc('day', 'created_at') }} as created_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_email_events.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_email_events.sql
@@ -1,0 +1,30 @@
+with
+
+source as (
+
+    select * from {{ source('marketing', 'raw_email_events') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as email_event_id,
+        cast(campaign_id as varchar) as campaign_id,
+        cast(customer_id as varchar) as customer_id,
+
+        ---------- text
+        event_type as email_event_type,
+        email_subject,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'event_at') }} as event_date,
+        event_at as event_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_loyalty_members.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_loyalty_members.sql
@@ -1,0 +1,32 @@
+with
+
+source as (
+
+    select * from {{ source('marketing', 'raw_loyalty_members') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as loyalty_member_id,
+        cast(customer_id as varchar) as customer_id,
+        cast(tier_id as varchar) as current_tier_id,
+
+        ---------- text
+        status as membership_status,
+
+        ---------- numerics
+        lifetime_points,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'enrolled_at') }} as enrolled_at,
+        {{ dbt.date_trunc('day', 'last_activity_at') }} as last_activity_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_loyalty_tiers.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_loyalty_tiers.sql
@@ -1,0 +1,30 @@
+with
+
+source as (
+
+    select * from {{ source('marketing', 'raw_loyalty_tiers') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as tier_id,
+
+        ---------- text
+        name as tier_name,
+        description as tier_description,
+
+        ---------- numerics
+        min_points as minimum_points,
+        max_points as maximum_points,
+        points_multiplier,
+        {{ cents_to_dollars('annual_reward') }} as annual_reward
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_loyalty_transactions.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_loyalty_transactions.sql
@@ -1,0 +1,32 @@
+with
+
+source as (
+
+    select * from {{ source('marketing', 'raw_loyalty_transactions') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as loyalty_transaction_id,
+        cast(loyalty_member_id as varchar) as loyalty_member_id,
+        cast(order_id as varchar) as order_id,
+
+        ---------- text
+        transaction_type,
+        description as transaction_description,
+
+        ---------- numerics
+        points,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'transacted_at') }} as transacted_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_referrals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_referrals.sql
@@ -1,0 +1,34 @@
+with
+
+source as (
+
+    select * from {{ source('marketing', 'raw_referrals') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as referral_id,
+        cast(referrer_customer_id as varchar) as referrer_customer_id,
+        cast(referee_customer_id as varchar) as referee_customer_id,
+        cast(campaign_id as varchar) as campaign_id,
+
+        ---------- text
+        status as referral_status,
+        referral_code,
+
+        ---------- numerics
+        {{ cents_to_dollars('reward_amount') }} as reward_amount,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'referred_at') }} as referred_at,
+        {{ dbt.date_trunc('day', 'converted_at') }} as converted_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_social_media_posts.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_social_media_posts.sql
@@ -1,0 +1,38 @@
+with
+
+source as (
+
+    select * from {{ source('marketing', 'raw_social_media_posts') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as post_id,
+        cast(campaign_id as varchar) as campaign_id,
+
+        ---------- text
+        platform,
+        post_type,
+        content as post_content,
+        url as post_url,
+
+        ---------- numerics
+        impressions,
+        reach,
+        likes,
+        shares,
+        comments as comment_count,
+        clicks as click_count,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'posted_at') }} as posted_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/__sources.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/__sources.yml
@@ -1,0 +1,35 @@
+version: 2
+
+sources:
+  - name: product
+    schema: "{{ target.schema }}_raw"
+    description: Product and menu analytics data for the Jaffle Shop
+    tables:
+      - name: raw_recipes
+        description: Recipe definitions linking menu items to required ingredients
+      - name: raw_recipe_ingredients
+        description: Ingredient quantities per recipe
+      - name: raw_ingredients
+        description: Master ingredient list (flour, coffee beans, milk, etc.)
+      - name: raw_ingredient_prices
+        description: Historical price records for each ingredient from suppliers
+      - name: raw_menu_items
+        description: Menu items (may differ from products — includes combos, seasonal)
+      - name: raw_menu_categories
+        description: Menu category hierarchy (hot drinks, cold drinks, food, pastries)
+      - name: raw_seasonal_menus
+        description: Seasonal and limited-time menu configurations
+      - name: raw_nutritional_info
+        description: Nutritional data per menu item (calories, fat, protein, etc.)
+      - name: raw_pricing_history
+        description: Historical price changes for products
+        loaded_at_field: changed_at
+        freshness:
+          warn_after: {count: 48, period: hour}
+          error_after: {count: 168, period: hour}
+      - name: raw_product_reviews
+        description: Customer reviews and ratings per product
+        loaded_at_field: reviewed_at
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/_product__models.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/_product__models.yml
@@ -1,0 +1,230 @@
+models:
+  - name: stg_recipes
+    description: Recipe definitions linking menu items to required ingredients, one row per recipe.
+    columns:
+      - name: recipe_id
+        description: The unique key for each recipe.
+        data_tests:
+          - not_null
+          - unique
+      - name: menu_item_id
+        description: Foreign key to the menu item this recipe produces.
+      - name: recipe_name
+        description: Name of the recipe.
+      - name: recipe_description
+        description: Description of the recipe.
+      - name: serving_size
+        description: Number of servings the recipe produces.
+      - name: is_active_recipe
+        description: Whether this recipe is currently in use.
+      - name: created_date
+        description: Date the recipe was created.
+      - name: updated_date
+        description: Date the recipe was last updated.
+
+  - name: stg_recipe_ingredients
+    description: Ingredient quantities per recipe, one row per recipe-ingredient combination.
+    columns:
+      - name: recipe_ingredient_id
+        description: The unique key for each recipe ingredient entry.
+        data_tests:
+          - not_null
+          - unique
+      - name: recipe_id
+        description: Foreign key to the recipe.
+      - name: ingredient_id
+        description: Foreign key to the ingredient.
+      - name: quantity
+        description: Quantity of the ingredient required.
+      - name: quantity_unit
+        description: Unit of measure for the quantity (e.g., grams, ml, units).
+
+  - name: stg_ingredients
+    description: Master ingredient list, one row per ingredient.
+    columns:
+      - name: ingredient_id
+        description: The unique key for each ingredient.
+        data_tests:
+          - not_null
+          - unique
+      - name: ingredient_name
+        description: Name of the ingredient.
+      - name: ingredient_category
+        description: Category of the ingredient (e.g., dairy, grain, produce).
+      - name: default_unit
+        description: Default unit of measure for this ingredient.
+      - name: is_perishable
+        description: Whether the ingredient is perishable.
+      - name: is_allergen
+        description: Whether the ingredient is a common allergen.
+
+  - name: stg_ingredient_prices
+    description: Historical price records for each ingredient from suppliers, one row per price record.
+    columns:
+      - name: ingredient_price_id
+        description: The unique key for each ingredient price record.
+        data_tests:
+          - not_null
+          - unique
+      - name: ingredient_id
+        description: Foreign key to the ingredient.
+      - name: supplier_id
+        description: Foreign key to the supplier providing this price.
+      - name: unit_cost
+        description: Cost per unit of the ingredient in USD.
+      - name: minimum_order_quantity
+        description: Minimum order quantity for this price tier.
+      - name: effective_from_date
+        description: Date this price became effective.
+      - name: effective_to_date
+        description: Date this price expires (null if currently active).
+
+  - name: stg_menu_items
+    description: Menu items including combos and seasonal offerings, one row per menu item.
+    columns:
+      - name: menu_item_id
+        description: The unique key for each menu item.
+        data_tests:
+          - not_null
+          - unique
+      - name: product_id
+        description: Foreign key to the base product (null for combos).
+      - name: menu_category_id
+        description: Foreign key to the menu category.
+      - name: menu_item_name
+        description: Display name of the menu item.
+      - name: menu_item_description
+        description: Description shown on the menu.
+      - name: menu_item_size
+        description: Size variant (e.g., small, medium, large).
+      - name: menu_item_price
+        description: Current menu price in USD.
+      - name: display_order
+        description: Sort order for menu display.
+      - name: is_available
+        description: Whether the item is currently available.
+      - name: is_combo
+        description: Whether this is a combo/bundle item.
+      - name: is_seasonal
+        description: Whether this is a seasonal item.
+
+  - name: stg_menu_categories
+    description: Menu category hierarchy, one row per category.
+    columns:
+      - name: menu_category_id
+        description: The unique key for each menu category.
+        data_tests:
+          - not_null
+          - unique
+      - name: parent_category_id
+        description: Foreign key to the parent category (null for top-level).
+      - name: category_name
+        description: Name of the menu category.
+      - name: category_description
+        description: Description of the menu category.
+      - name: category_display_order
+        description: Sort order for category display.
+      - name: category_depth
+        description: Depth in the category hierarchy (0 for top-level).
+      - name: is_active_category
+        description: Whether this category is currently active.
+
+  - name: stg_seasonal_menus
+    description: Seasonal and limited-time menu configurations, one row per seasonal menu entry.
+    columns:
+      - name: seasonal_menu_id
+        description: The unique key for each seasonal menu entry.
+        data_tests:
+          - not_null
+          - unique
+      - name: menu_item_id
+        description: Foreign key to the menu item included in the seasonal menu.
+      - name: season_name
+        description: Name of the season (e.g., summer, holiday, spring).
+      - name: promotion_name
+        description: Name of the seasonal promotion.
+      - name: promotion_start_date
+        description: Start date of the seasonal promotion.
+      - name: promotion_end_date
+        description: End date of the seasonal promotion.
+      - name: is_active_promotion
+        description: Whether this seasonal promotion is currently active.
+
+  - name: stg_nutritional_info
+    description: Nutritional data per menu item, one row per menu item.
+    columns:
+      - name: nutritional_info_id
+        description: The unique key for each nutritional info record.
+        data_tests:
+          - not_null
+          - unique
+      - name: menu_item_id
+        description: Foreign key to the menu item.
+      - name: calories
+        description: Total calories per serving.
+      - name: total_fat_g
+        description: Total fat in grams per serving.
+      - name: saturated_fat_g
+        description: Saturated fat in grams per serving.
+      - name: trans_fat_g
+        description: Trans fat in grams per serving.
+      - name: cholesterol_mg
+        description: Cholesterol in milligrams per serving.
+      - name: sodium_mg
+        description: Sodium in milligrams per serving.
+      - name: total_carbs_g
+        description: Total carbohydrates in grams per serving.
+      - name: dietary_fiber_g
+        description: Dietary fiber in grams per serving.
+      - name: total_sugars_g
+        description: Total sugars in grams per serving.
+      - name: protein_g
+        description: Protein in grams per serving.
+      - name: caffeine_mg
+        description: Caffeine in milligrams per serving.
+      - name: serving_size_description
+        description: Description of the serving size.
+      - name: updated_date
+        description: Date the nutritional info was last updated.
+
+  - name: stg_pricing_history
+    description: Historical price changes for products, one row per price change.
+    columns:
+      - name: pricing_history_id
+        description: The unique key for each pricing history record.
+        data_tests:
+          - not_null
+          - unique
+      - name: product_id
+        description: Foreign key to the product.
+      - name: old_price
+        description: Previous price in USD.
+      - name: new_price
+        description: New price in USD.
+      - name: change_reason
+        description: Reason for the price change.
+      - name: price_changed_date
+        description: Date the price change took effect.
+
+  - name: stg_product_reviews
+    description: Customer reviews and ratings per product, one row per review.
+    columns:
+      - name: review_id
+        description: The unique key for each review.
+        data_tests:
+          - not_null
+          - unique
+      - name: product_id
+        description: Foreign key to the product being reviewed.
+      - name: customer_id
+        description: Foreign key to the customer who wrote the review.
+      - name: order_id
+        description: Foreign key to the order associated with the review.
+      - name: rating
+        description: Numeric rating (1-5 scale).
+      - name: review_title
+        description: Title of the review.
+      - name: review_body
+        description: Full text of the review.
+      - name: reviewed_date
+        description: Date the review was submitted.

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_ingredient_prices.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_ingredient_prices.sql
@@ -1,0 +1,30 @@
+with
+
+source as (
+
+    select * from {{ source('product', 'raw_ingredient_prices') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as ingredient_price_id,
+        cast(ingredient_id as varchar) as ingredient_id,
+        cast(supplier_id as varchar) as supplier_id,
+
+        ---------- numerics
+        {{ cents_to_dollars('unit_cost') }} as unit_cost,
+        quantity as minimum_order_quantity,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'effective_from') }} as effective_from_date,
+        {{ dbt.date_trunc('day', 'effective_to') }} as effective_to_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_ingredients.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_ingredients.sql
@@ -1,0 +1,29 @@
+with
+
+source as (
+
+    select * from {{ source('product', 'raw_ingredients') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as ingredient_id,
+
+        ---------- text
+        name as ingredient_name,
+        category as ingredient_category,
+        unit as default_unit,
+
+        ---------- booleans
+        coalesce(is_perishable, false) as is_perishable,
+        coalesce(is_allergen, false) as is_allergen
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_menu_categories.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_menu_categories.sql
@@ -1,0 +1,32 @@
+with
+
+source as (
+
+    select * from {{ source('product', 'raw_menu_categories') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as menu_category_id,
+        cast(parent_category_id as varchar) as parent_category_id,
+
+        ---------- text
+        name as category_name,
+        description as category_description,
+
+        ---------- numerics
+        display_order as category_display_order,
+        depth as category_depth,
+
+        ---------- booleans
+        coalesce(is_active, false) as is_active_category
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_menu_items.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_menu_items.sql
@@ -1,0 +1,36 @@
+with
+
+source as (
+
+    select * from {{ source('product', 'raw_menu_items') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as menu_item_id,
+        cast(product_id as varchar) as product_id,
+        cast(category_id as varchar) as menu_category_id,
+
+        ---------- text
+        name as menu_item_name,
+        description as menu_item_description,
+        size as menu_item_size,
+
+        ---------- numerics
+        {{ cents_to_dollars('price') }} as menu_item_price,
+        display_order,
+
+        ---------- booleans
+        coalesce(is_available, false) as is_available,
+        coalesce(is_combo, false) as is_combo,
+        coalesce(is_seasonal, false) as is_seasonal
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_nutritional_info.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_nutritional_info.sql
@@ -1,0 +1,40 @@
+with
+
+source as (
+
+    select * from {{ source('product', 'raw_nutritional_info') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as nutritional_info_id,
+        cast(menu_item_id as varchar) as menu_item_id,
+
+        ---------- numerics
+        calories,
+        total_fat_g,
+        saturated_fat_g,
+        trans_fat_g,
+        cholesterol_mg,
+        sodium_mg,
+        total_carbs_g,
+        dietary_fiber_g,
+        total_sugars_g,
+        protein_g,
+        caffeine_mg,
+
+        ---------- text
+        serving_size_description,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'updated_at') }} as updated_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_pricing_history.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_pricing_history.sql
@@ -1,0 +1,31 @@
+with
+
+source as (
+
+    select * from {{ source('product', 'raw_pricing_history') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as pricing_history_id,
+        cast(product_id as varchar) as product_id,
+
+        ---------- numerics
+        {{ cents_to_dollars('old_price') }} as old_price,
+        {{ cents_to_dollars('new_price') }} as new_price,
+
+        ---------- text
+        change_reason,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'changed_at') }} as price_changed_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_product_reviews.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_product_reviews.sql
@@ -1,0 +1,33 @@
+with
+
+source as (
+
+    select * from {{ source('product', 'raw_product_reviews') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as review_id,
+        cast(product_id as varchar) as product_id,
+        cast(customer_id as varchar) as customer_id,
+        cast(order_id as varchar) as order_id,
+
+        ---------- numerics
+        rating,
+
+        ---------- text
+        review_title,
+        review_body,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'reviewed_at') }} as reviewed_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_recipe_ingredients.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_recipe_ingredients.sql
@@ -1,0 +1,26 @@
+with
+
+source as (
+
+    select * from {{ source('product', 'raw_recipe_ingredients') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as recipe_ingredient_id,
+        cast(recipe_id as varchar) as recipe_id,
+        cast(ingredient_id as varchar) as ingredient_id,
+
+        ---------- numerics
+        quantity,
+        unit as quantity_unit
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_recipes.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_recipes.sql
@@ -1,0 +1,35 @@
+with
+
+source as (
+
+    select * from {{ source('product', 'raw_recipes') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as recipe_id,
+        cast(menu_item_id as varchar) as menu_item_id,
+
+        ---------- text
+        name as recipe_name,
+        description as recipe_description,
+
+        ---------- numerics
+        serving_size,
+
+        ---------- booleans
+        coalesce(is_active, false) as is_active_recipe,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'created_at') }} as created_date,
+        {{ dbt.date_trunc('day', 'updated_at') }} as updated_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_seasonal_menus.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_seasonal_menus.sql
@@ -1,0 +1,32 @@
+with
+
+source as (
+
+    select * from {{ source('product', 'raw_seasonal_menus') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as seasonal_menu_id,
+        cast(menu_item_id as varchar) as menu_item_id,
+
+        ---------- text
+        season_name,
+        promotion_name,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'start_date') }} as promotion_start_date,
+        {{ dbt.date_trunc('day', 'end_date') }} as promotion_end_date,
+
+        ---------- booleans
+        coalesce(is_active, false) as is_active_promotion
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_customers.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_customers.sql
@@ -1,0 +1,23 @@
+with
+
+source as (
+
+    select * from {{ source('ecom', 'raw_customers') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as customer_id,
+
+        ---------- text
+        name as customer_name
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_customers.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_customers.yml
@@ -1,0 +1,9 @@
+models:
+  - name: stg_customers
+    description: Customer data with basic cleaning and transformation applied, one row per customer.
+    columns:
+      - name: customer_id
+        description: The unique key for each customer.
+        data_tests:
+          - not_null
+          - unique

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_locations.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_locations.sql
@@ -1,0 +1,29 @@
+with
+
+source as (
+
+    select * from {{ source('ecom', 'raw_stores') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as location_id,
+
+        ---------- text
+        name as location_name,
+
+        ---------- numerics
+        tax_rate,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'opened_at') }} as opened_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_locations.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_locations.yml
@@ -1,0 +1,43 @@
+models:
+  - name: stg_locations
+    description: List of open locations with basic cleaning and transformation applied, one row per location.
+    columns:
+      - name: location_id
+        description: The unique key for each location.
+        data_tests:
+          - not_null
+          - unique
+
+unit_tests:
+  - name: test_does_location_opened_at_trunc_to_date
+    description: "Check that opened_at timestamp is properly truncated to a date."
+    model: stg_locations
+    given:
+      - input: source('ecom', 'raw_stores')
+        rows:
+          - {
+              id: 1,
+              name: "Vice City",
+              tax_rate: 0.2,
+              opened_at: "2016-09-01T00:00:00",
+            }
+          - {
+              id: 2,
+              name: "San Andreas",
+              tax_rate: 0.1,
+              opened_at: "2079-10-27T23:59:59.9999",
+            }
+    expect:
+      rows:
+        - {
+            location_id: 1,
+            location_name: "Vice City",
+            tax_rate: 0.2,
+            opened_date: "2016-09-01",
+          }
+        - {
+            location_id: 2,
+            location_name: "San Andreas",
+            tax_rate: 0.1,
+            opened_date: "2079-10-27",
+          }

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_order_items.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_order_items.sql
@@ -1,0 +1,22 @@
+with
+
+source as (
+
+    select * from {{ source('ecom', 'raw_items') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as order_item_id,
+        cast(order_id as varchar) as order_id,
+        cast(sku as varchar) as product_id
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_order_items.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_order_items.yml
@@ -1,0 +1,17 @@
+models:
+  - name: stg_order_items
+    description: Individual food and drink items that make up our orders, one row per item.
+    columns:
+      - name: order_item_id
+        description: The unique key for each order item.
+        data_tests:
+          - not_null
+          - unique
+      - name: order_id
+        description: The corresponding order each order item belongs to
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_orders')
+                field: order_id

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_orders.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_orders.sql
@@ -1,0 +1,33 @@
+with
+
+source as (
+
+    select * from {{ source('ecom', 'raw_orders') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as order_id,
+        cast(store_id as varchar) as location_id,
+        cast(customer as varchar) as customer_id,
+
+        ---------- numerics
+        subtotal as subtotal_cents,
+        tax_paid as tax_paid_cents,
+        order_total as order_total_cents,
+        {{ cents_to_dollars('subtotal') }} as subtotal,
+        {{ cents_to_dollars('tax_paid') }} as tax_paid,
+        {{ cents_to_dollars('order_total') }} as order_total,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day','ordered_at') }} as ordered_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_orders.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_orders.yml
@@ -1,0 +1,13 @@
+models:
+  - name: stg_orders
+    description: Order data with basic cleaning and transformation applied, one row per order.
+    data_tests:
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "order_total - tax_paid = subtotal"
+    columns:
+      - name: order_id
+        description: The unique key for each order.
+        data_tests:
+          - not_null
+          - unique

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_products.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_products.sql
@@ -1,0 +1,34 @@
+with
+
+source as (
+
+    select * from {{ source('ecom', 'raw_products') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(sku as varchar) as product_id,
+
+        ---------- text
+        name as product_name,
+        type as product_type,
+        description as product_description,
+
+
+        ---------- numerics
+        {{ cents_to_dollars('price') }} as product_price,
+
+        ---------- booleans
+        coalesce(type = 'jaffle', false) as is_food_item,
+
+        coalesce(type = 'beverage', false) as is_drink_item
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_products.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_products.yml
@@ -1,0 +1,9 @@
+models:
+  - name: stg_products
+    description: Product (food and drink items that can be ordered) data with basic cleaning and transformation applied, one row per product.
+    columns:
+      - name: product_id
+        description: The unique key for each product.
+        data_tests:
+          - not_null
+          - unique

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_supplies.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_supplies.sql
@@ -1,0 +1,31 @@
+with
+
+source as (
+
+    select * from {{ source('ecom', 'raw_supplies') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        {{ dbt_utils.generate_surrogate_key(['id', 'sku']) }} as supply_uuid,
+        cast(id as varchar) as supply_id,
+        cast(sku as varchar) as product_id,
+
+        ---------- text
+        name as supply_name,
+
+        ---------- numerics
+        {{ cents_to_dollars('cost') }} as supply_cost,
+
+        ---------- booleans
+        perishable as is_perishable_supply
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_supplies.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_supplies.yml
@@ -1,0 +1,12 @@
+models:
+  - name: stg_supplies
+    description: >
+      List of our supply expenses data with basic cleaning and transformation applied.
+
+      One row per supply cost, not per supply. As supply costs fluctuate they receive a new row with a new UUID. Thus there can be multiple rows per supply_id.
+    columns:
+      - name: supply_uuid
+        description: The unique key of our supplies per cost.
+        data_tests:
+          - not_null
+          - unique

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/__sources.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/__sources.yml
@@ -1,0 +1,35 @@
+version: 2
+
+sources:
+  - name: supply_chain
+    schema: "{{ target.schema }}_raw"
+    description: Supply chain and inventory data for the Jaffle Shop
+    tables:
+      - name: raw_suppliers
+        description: Supplier companies that provide ingredients and supplies
+      - name: raw_supplier_contracts
+        description: Contract terms with each supplier
+      - name: raw_purchase_orders
+        description: Purchase orders placed with suppliers
+        loaded_at_field: ordered_at
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
+      - name: raw_po_line_items
+        description: Individual items on each purchase order
+      - name: raw_po_receipts
+        description: Goods received against purchase orders
+      - name: raw_warehouses
+        description: Warehouse and distribution center locations
+      - name: raw_inventory_counts
+        description: Periodic physical inventory counts by location
+      - name: raw_inventory_movements
+        description: Inbound and outbound inventory transactions
+        loaded_at_field: moved_at
+        freshness:
+          warn_after: {count: 12, period: hour}
+          error_after: {count: 24, period: hour}
+      - name: raw_waste_logs
+        description: Records of spoiled or wasted inventory
+      - name: raw_delivery_shipments
+        description: Shipments from suppliers to stores and warehouses

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/_supply_chain__models.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/_supply_chain__models.yml
@@ -1,0 +1,240 @@
+models:
+  - name: stg_suppliers
+    description: Supplier companies that provide ingredients and supplies to Jaffle Shop, one row per supplier.
+    columns:
+      - name: supplier_id
+        description: The unique key for each supplier.
+        data_tests:
+          - not_null
+          - unique
+      - name: supplier_name
+        description: The name of the supplier company.
+      - name: contact_name
+        description: Primary contact person at the supplier.
+      - name: contact_email
+        description: Email address of the primary contact.
+      - name: is_active
+        description: Whether the supplier is currently active.
+      - name: created_at
+        description: The date the supplier record was created.
+
+  - name: stg_supplier_contracts
+    description: Contract terms negotiated with each supplier, one row per contract.
+    columns:
+      - name: contract_id
+        description: The unique key for each contract.
+        data_tests:
+          - not_null
+          - unique
+      - name: supplier_id
+        description: The foreign key to the supplier.
+        data_tests:
+          - not_null
+      - name: contract_type
+        description: The type of contract (e.g. fixed-price, volume-based).
+      - name: minimum_order_amount
+        description: The minimum order amount in USD required by the contract.
+      - name: lead_time_days
+        description: Contracted lead time in days from order to delivery.
+      - name: effective_date
+        description: The date the contract becomes effective.
+      - name: expiration_date
+        description: The date the contract expires.
+
+  - name: stg_purchase_orders
+    description: Purchase orders placed with suppliers, one row per purchase order.
+    columns:
+      - name: purchase_order_id
+        description: The unique key for each purchase order.
+        data_tests:
+          - not_null
+          - unique
+      - name: supplier_id
+        description: The foreign key to the supplier.
+        data_tests:
+          - not_null
+      - name: warehouse_id
+        description: The foreign key to the destination warehouse.
+      - name: po_status
+        description: Current status of the purchase order (e.g. draft, submitted, received, cancelled).
+      - name: total_amount
+        description: The total amount of the purchase order in USD.
+      - name: ordered_at
+        description: The date the purchase order was placed.
+      - name: expected_delivery_at
+        description: The expected delivery date.
+
+  - name: stg_po_line_items
+    description: Individual line items on each purchase order, one row per line item.
+    columns:
+      - name: po_line_item_id
+        description: The unique key for each purchase order line item.
+        data_tests:
+          - not_null
+          - unique
+      - name: purchase_order_id
+        description: The foreign key to the purchase order.
+        data_tests:
+          - not_null
+      - name: product_id
+        description: The foreign key to the product being ordered.
+        data_tests:
+          - not_null
+      - name: quantity_ordered
+        description: The quantity of the product ordered.
+      - name: unit_cost
+        description: The cost per unit in USD.
+      - name: line_total
+        description: The total cost for this line item in USD.
+
+  - name: stg_po_receipts
+    description: Goods received against purchase orders, one row per receipt.
+    columns:
+      - name: receipt_id
+        description: The unique key for each receipt.
+        data_tests:
+          - not_null
+          - unique
+      - name: purchase_order_id
+        description: The foreign key to the purchase order.
+        data_tests:
+          - not_null
+      - name: po_line_item_id
+        description: The foreign key to the purchase order line item.
+        data_tests:
+          - not_null
+      - name: quantity_received
+        description: The quantity of goods received.
+      - name: quality_status
+        description: Quality inspection result (e.g. accepted, rejected, partial).
+      - name: received_at
+        description: The date the goods were received.
+
+  - name: stg_warehouses
+    description: Warehouse and distribution center locations, one row per warehouse.
+    columns:
+      - name: warehouse_id
+        description: The unique key for each warehouse.
+        data_tests:
+          - not_null
+          - unique
+      - name: warehouse_name
+        description: The name of the warehouse.
+      - name: warehouse_type
+        description: The type of warehouse (e.g. distribution center, cold storage).
+      - name: capacity_units
+        description: The total storage capacity in standard units.
+      - name: is_active
+        description: Whether the warehouse is currently operational.
+      - name: opened_at
+        description: The date the warehouse opened.
+
+  - name: stg_inventory_counts
+    description: Periodic physical inventory counts by product and location, one row per count event.
+    columns:
+      - name: inventory_count_id
+        description: The unique key for each inventory count record.
+        data_tests:
+          - not_null
+          - unique
+      - name: product_id
+        description: The foreign key to the product.
+        data_tests:
+          - not_null
+      - name: location_id
+        description: The foreign key to the location (store or warehouse).
+        data_tests:
+          - not_null
+      - name: quantity_on_hand
+        description: Total quantity physically present.
+      - name: quantity_reserved
+        description: Quantity reserved for pending orders.
+      - name: quantity_available
+        description: Quantity available for new orders.
+      - name: counted_at
+        description: The date the physical count was performed.
+
+  - name: stg_inventory_movements
+    description: Inbound and outbound inventory transactions, one row per movement.
+    columns:
+      - name: movement_id
+        description: The unique key for each inventory movement.
+        data_tests:
+          - not_null
+          - unique
+      - name: product_id
+        description: The foreign key to the product.
+        data_tests:
+          - not_null
+      - name: location_id
+        description: The foreign key to the location (store or warehouse).
+        data_tests:
+          - not_null
+      - name: movement_type
+        description: The type of movement (e.g. inbound, outbound, transfer, adjustment).
+      - name: quantity
+        description: The quantity moved (positive for inbound, negative for outbound).
+      - name: reference_type
+        description: The type of source document (e.g. purchase_order, sale, transfer).
+      - name: reference_id
+        description: The ID of the source document.
+      - name: moved_at
+        description: The date the inventory movement occurred.
+
+  - name: stg_waste_logs
+    description: Records of spoiled or wasted inventory, one row per waste event.
+    columns:
+      - name: waste_log_id
+        description: The unique key for each waste log entry.
+        data_tests:
+          - not_null
+          - unique
+      - name: product_id
+        description: The foreign key to the product.
+        data_tests:
+          - not_null
+      - name: location_id
+        description: The foreign key to the location.
+        data_tests:
+          - not_null
+      - name: waste_reason
+        description: The reason for waste (e.g. expired, damaged, quality).
+      - name: quantity_wasted
+        description: The quantity of product wasted.
+      - name: cost_of_waste
+        description: The cost of the wasted inventory in USD.
+      - name: wasted_at
+        description: The date the waste was recorded.
+
+  - name: stg_delivery_shipments
+    description: Shipments from suppliers to stores and warehouses, one row per shipment.
+    columns:
+      - name: shipment_id
+        description: The unique key for each shipment.
+        data_tests:
+          - not_null
+          - unique
+      - name: purchase_order_id
+        description: The foreign key to the purchase order.
+        data_tests:
+          - not_null
+      - name: supplier_id
+        description: The foreign key to the supplier.
+        data_tests:
+          - not_null
+      - name: destination_id
+        description: The ID of the destination (store or warehouse).
+      - name: destination_type
+        description: The type of destination (e.g. store, warehouse).
+      - name: carrier
+        description: The shipping carrier.
+      - name: tracking_number
+        description: The shipment tracking number.
+      - name: shipment_status
+        description: Current status of the shipment (e.g. in_transit, delivered, delayed).
+      - name: shipped_at
+        description: The date the shipment was dispatched.
+      - name: estimated_arrival_at
+        description: The estimated arrival date.
+      - name: actual_arrival_at
+        description: The actual arrival date, null if not yet delivered.

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_delivery_shipments.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_delivery_shipments.sql
@@ -1,0 +1,34 @@
+with
+
+source as (
+
+    select * from {{ source('supply_chain', 'raw_delivery_shipments') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as shipment_id,
+        cast(purchase_order_id as varchar) as purchase_order_id,
+        cast(supplier_id as varchar) as supplier_id,
+        cast(destination_id as varchar) as destination_id,
+
+        ---------- text
+        destination_type,
+        carrier,
+        tracking_number,
+        shipment_status,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'shipped_at') }} as shipped_at,
+        {{ dbt.date_trunc('day', 'estimated_arrival_at') }} as estimated_arrival_at,
+        {{ dbt.date_trunc('day', 'actual_arrival_at') }} as actual_arrival_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_inventory_counts.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_inventory_counts.sql
@@ -1,0 +1,30 @@
+with
+
+source as (
+
+    select * from {{ source('supply_chain', 'raw_inventory_counts') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as inventory_count_id,
+        cast(product_id as varchar) as product_id,
+        cast(location_id as varchar) as location_id,
+
+        ---------- numerics
+        quantity_on_hand,
+        quantity_reserved,
+        quantity_available,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'counted_at') }} as counted_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_inventory_movements.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_inventory_movements.sql
@@ -1,0 +1,33 @@
+with
+
+source as (
+
+    select * from {{ source('supply_chain', 'raw_inventory_movements') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as movement_id,
+        cast(product_id as varchar) as product_id,
+        cast(location_id as varchar) as location_id,
+
+        ---------- text
+        movement_type,
+        reference_type,
+        cast(reference_id as varchar) as reference_id,
+
+        ---------- numerics
+        quantity,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'moved_at') }} as moved_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_po_line_items.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_po_line_items.sql
@@ -1,0 +1,27 @@
+with
+
+source as (
+
+    select * from {{ source('supply_chain', 'raw_po_line_items') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as po_line_item_id,
+        cast(purchase_order_id as varchar) as purchase_order_id,
+        cast(product_id as varchar) as product_id,
+
+        ---------- numerics
+        quantity_ordered,
+        {{ cents_to_dollars('unit_cost') }} as unit_cost,
+        {{ cents_to_dollars('line_total') }} as line_total
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_po_receipts.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_po_receipts.sql
@@ -1,0 +1,31 @@
+with
+
+source as (
+
+    select * from {{ source('supply_chain', 'raw_po_receipts') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as receipt_id,
+        cast(purchase_order_id as varchar) as purchase_order_id,
+        cast(po_line_item_id as varchar) as po_line_item_id,
+
+        ---------- numerics
+        quantity_received,
+
+        ---------- text
+        quality_status,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'received_at') }} as received_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_purchase_orders.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_purchase_orders.sql
@@ -1,0 +1,33 @@
+with
+
+source as (
+
+    select * from {{ source('supply_chain', 'raw_purchase_orders') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as purchase_order_id,
+        cast(supplier_id as varchar) as supplier_id,
+        cast(warehouse_id as varchar) as warehouse_id,
+
+        ---------- text
+        status as po_status,
+
+        ---------- numerics
+        {{ cents_to_dollars('total_amount') }} as total_amount,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'ordered_at') }} as ordered_at,
+        {{ dbt.date_trunc('day', 'expected_delivery_at') }} as expected_delivery_at,
+        {{ dbt.date_trunc('day', 'created_at') }} as created_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_supplier_contracts.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_supplier_contracts.sql
@@ -1,0 +1,34 @@
+with
+
+source as (
+
+    select * from {{ source('supply_chain', 'raw_supplier_contracts') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as contract_id,
+        cast(supplier_id as varchar) as supplier_id,
+
+        ---------- text
+        contract_type,
+        payment_terms,
+
+        ---------- numerics
+        {{ cents_to_dollars('minimum_order_amount') }} as minimum_order_amount,
+        lead_time_days,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'effective_date') }} as effective_date,
+        {{ dbt.date_trunc('day', 'expiration_date') }} as expiration_date,
+        {{ dbt.date_trunc('day', 'created_at') }} as created_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_suppliers.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_suppliers.sql
@@ -1,0 +1,36 @@
+with
+
+source as (
+
+    select * from {{ source('supply_chain', 'raw_suppliers') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as supplier_id,
+
+        ---------- text
+        name as supplier_name,
+        contact_name,
+        contact_email,
+        phone,
+        address,
+        city,
+        state,
+        country,
+
+        ---------- booleans
+        is_active,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'created_at') }} as created_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_warehouses.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_warehouses.sql
@@ -1,0 +1,36 @@
+with
+
+source as (
+
+    select * from {{ source('supply_chain', 'raw_warehouses') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as warehouse_id,
+
+        ---------- text
+        name as warehouse_name,
+        address,
+        city,
+        state,
+        warehouse_type,
+
+        ---------- numerics
+        capacity_units,
+
+        ---------- booleans
+        is_active,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'opened_at') }} as opened_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_waste_logs.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_waste_logs.sql
@@ -1,0 +1,32 @@
+with
+
+source as (
+
+    select * from {{ source('supply_chain', 'raw_waste_logs') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as waste_log_id,
+        cast(product_id as varchar) as product_id,
+        cast(location_id as varchar) as location_id,
+
+        ---------- text
+        waste_reason,
+
+        ---------- numerics
+        quantity_wasted,
+        {{ cents_to_dollars('cost_of_waste') }} as cost_of_waste,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'wasted_at') }} as wasted_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/utils/_utilities__models.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/utils/_utilities__models.yml
@@ -1,0 +1,81 @@
+models:
+  - name: util_date_spine
+    description: >
+      Date spine from ~2017 to ~2027 (3650 days from today, going backwards).
+      Provides calendar attributes for each day including day of week, week start,
+      month start, quarter start, and weekend flag.
+    columns:
+      - name: date_day
+        description: The calendar date.
+        data_tests:
+          - unique
+          - not_null
+      - name: day_of_week
+        description: "Day of week as integer (0=Sunday, 6=Saturday)."
+      - name: day_name
+        description: "Day name (e.g., Monday, Tuesday)."
+      - name: week_start
+        description: The start of the ISO week containing this date.
+      - name: month_start
+        description: The first day of the month.
+      - name: quarter_start
+        description: The first day of the calendar quarter.
+      - name: year
+        description: The calendar year.
+      - name: is_weekend
+        description: Whether the date falls on Saturday or Sunday.
+
+  - name: util_fiscal_periods
+    description: >
+      Fiscal calendar mapping. Maps each calendar date to a fiscal year,
+      fiscal quarter, and fiscal month assuming a February 1 fiscal year start.
+    columns:
+      - name: date_day
+        description: The calendar date.
+        data_tests:
+          - unique
+          - not_null
+      - name: fiscal_year
+        description: "Fiscal year (e.g., FY starting Feb 1 2024 = fiscal year 2024)."
+      - name: fiscal_quarter
+        description: "Fiscal quarter (1-4)."
+      - name: fiscal_month
+        description: "Fiscal month (1-12, where Feb=1, Jan=12)."
+
+  - name: util_store_calendar
+    description: >
+      Cross join of the date spine with locations. Provides one row per store
+      per day starting from each store's opening date, useful for gap-filling
+      sparse event data.
+    columns:
+      - name: date_day
+        description: The calendar date.
+      - name: location_id
+        description: The store/location identifier.
+      - name: location_name
+        description: The name of the store.
+      - name: days_since_opening
+        description: Number of days since the store opened.
+      - name: is_weekend
+        description: Whether the date is a weekend day.
+
+  - name: util_product_active_dates
+    description: >
+      Date range when each product was actively sold. Derived from first and
+      last order dates per product in stg_order_items.
+    columns:
+      - name: product_id
+        description: The product identifier.
+        data_tests:
+          - unique
+          - not_null
+      - name: product_name
+        description: The name of the product.
+      - name: active_from
+        description: Date of the first order containing this product.
+      - name: last_seen_at
+        description: Date of the most recent order containing this product.
+      - name: active_days
+        description: Number of days between first and last order.
+      - name: is_currently_active
+        description: Whether the product was ordered within the last 30 days.

--- a/groups/jaffle/projects/jaffle-shop/transform/models/utils/util_date_spine.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/utils/util_date_spine.sql
@@ -1,0 +1,36 @@
+with
+
+days as (
+
+    {{ dbt_date.get_base_dates(n_dateparts=3650, datepart="day") }}
+
+),
+
+date_spine as (
+
+    select
+        cast(date_day as date) as date_day,
+        {{ dbt.date_trunc('week', 'date_day') }} as week_start,
+        {{ dbt.date_trunc('month', 'date_day') }} as month_start,
+        {{ dbt.date_trunc('quarter', 'date_day') }} as quarter_start,
+        extract(year from date_day) as year,
+        {{ day_of_week_number('date_day') }} as day_of_week,
+        case {{ day_of_week_number('date_day') }}
+            when 0 then 'Sunday'
+            when 1 then 'Monday'
+            when 2 then 'Tuesday'
+            when 3 then 'Wednesday'
+            when 4 then 'Thursday'
+            when 5 then 'Friday'
+            when 6 then 'Saturday'
+        end as day_name,
+        case
+            when {{ day_of_week_number('date_day') }} in (0, 6) then true
+            else false
+        end as is_weekend
+
+    from days
+
+)
+
+select * from date_spine

--- a/groups/jaffle/projects/jaffle-shop/transform/models/utils/util_fiscal_periods.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/utils/util_fiscal_periods.sql
@@ -1,0 +1,49 @@
+with
+
+date_spine as (
+
+    select * from {{ ref('util_date_spine') }}
+
+),
+
+-- Fiscal year starts February 1
+fiscal_mapping as (
+
+    select
+        date_day,
+        week_start,
+        month_start,
+        quarter_start,
+        year,
+        day_of_week,
+        day_name,
+        is_weekend,
+
+        -- Fiscal year: if month >= Feb, fiscal year = calendar year
+        -- if month = Jan, fiscal year = calendar year - 1
+        case
+            when extract(month from date_day) >= 2
+                then extract(year from date_day)
+            else extract(year from date_day) - 1
+        end as fiscal_year,
+
+        -- Fiscal month: Feb=1, Mar=2, ..., Jan=12
+        case
+            when extract(month from date_day) >= 2
+                then extract(month from date_day) - 1
+            else 12
+        end as fiscal_month,
+
+        -- Fiscal quarter: FM 1-3 = FQ1, FM 4-6 = FQ2, FM 7-9 = FQ3, FM 10-12 = FQ4
+        case
+            when extract(month from date_day) between 2 and 4 then 1
+            when extract(month from date_day) between 5 and 7 then 2
+            when extract(month from date_day) between 8 and 10 then 3
+            else 4
+        end as fiscal_quarter
+
+    from date_spine
+
+)
+
+select * from fiscal_mapping

--- a/groups/jaffle/projects/jaffle-shop/transform/models/utils/util_product_active_dates.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/utils/util_product_active_dates.sql
@@ -1,0 +1,63 @@
+with
+
+order_items as (
+
+    select * from {{ ref('stg_order_items') }}
+
+),
+
+orders as (
+
+    select * from {{ ref('stg_orders') }}
+
+),
+
+products as (
+
+    select * from {{ ref('stg_products') }}
+
+),
+
+-- Find first and last order date per product
+product_order_range as (
+
+    select
+        oi.product_id,
+        min(o.ordered_at) as first_ordered_at,
+        max(o.ordered_at) as last_ordered_at,
+        count(distinct oi.order_id) as total_orders,
+        count(oi.order_item_id) as total_units_sold
+
+    from order_items as oi
+
+    inner join orders as o
+        on oi.order_id = o.order_id
+
+    group by 1
+
+),
+
+final as (
+
+    select
+        p.product_id,
+        p.product_name,
+        p.product_type,
+        por.first_ordered_at as active_from,
+        por.last_ordered_at as last_seen_at,
+        {{ sf_datediff('day', "por.first_ordered_at", "por.last_ordered_at") }} as active_days,
+        por.total_orders,
+        por.total_units_sold,
+        case
+            when {{ sf_datediff('day', "por.last_ordered_at", "current_date") }} <= 30 then true
+            else false
+        end as is_currently_active
+
+    from products as p
+
+    left join product_order_range as por
+        on p.product_id = por.product_id
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/utils/util_store_calendar.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/utils/util_store_calendar.sql
@@ -1,0 +1,37 @@
+with
+
+date_spine as (
+
+    select * from {{ ref('util_date_spine') }}
+
+),
+
+locations as (
+
+    select * from {{ ref('stg_locations') }}
+
+),
+
+-- One row per store per day, starting from each store's opening date
+store_calendar as (
+
+    select
+        ds.date_day,
+        ds.day_of_week,
+        ds.day_name,
+        ds.week_start,
+        ds.month_start,
+        ds.is_weekend,
+        l.location_id,
+        l.location_name,
+        {{ sf_datediff('day', "l.opened_date", "ds.date_day") }} as days_since_opening
+
+    from date_spine as ds
+
+    cross join locations as l
+
+    where ds.date_day >= l.opened_date
+
+)
+
+select * from store_calendar


### PR DESCRIPTION
----
## Summary by Gitar

- **Jaffle Staging & Seeds:**
    - Added 1:1 raw staging models and raw data seeds for `jaffle-shop` project under `transform/`
- **Project Onboarding Skill:**
    - Added onboarding framework and project alignment tools in `platform/toolkits/project-onboarding`
- **DBT Snowflake Toolkit:**
    - Added SQL portability scanner and cross-database macro adapters in `platform/toolkits/dbt-snowflake`

<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added guided project onboarding with staged validation, risk checks, and migration support.
  - Added Snowflake compatibility tooling for portable SQL across supported warehouses.
  - Added the Jaffle Shop project with standardized data models, governance, semantic annotations, and reporting dashboards.
  - Added reusable analytics for finance, HR, marketing, product, supply chain, cohorts, forecasts, and customer lifetime value.
- **Quality Improvements**
  - Added pull-request impact checks, data validation, freshness monitoring, and build comparison checks.
- **Documentation**
  - Added onboarding, Snowflake, reporting, governance, and toolkit guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->