### PR TITLE
Split/13 jaffle marts core finance

### DIFF
--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/_exposures.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/_exposures.yml
@@ -1,0 +1,84 @@
+version: 2
+
+exposures:
+  - name: weekly_business_review
+    label: Weekly Business Review Dashboard
+    type: dashboard
+    maturity: high
+    url: https://bi.jaffleshop.com/dashboards/weekly-review
+    description: Executive weekly business review dashboard showing KPIs, revenue trends, and store performance
+    depends_on:
+      - ref('exec_company_kpis_monthly')
+      - ref('rpt_store_pnl')
+      - ref('met_weekly_revenue_by_store')
+      - ref('rpt_customer_segments')
+    owner:
+      name: Finance Team
+      email: finance@jaffleshop.com
+
+  - name: store_manager_portal
+    label: Store Manager Portal
+    type: application
+    maturity: high
+    url: https://portal.jaffleshop.com/store
+    description: Real-time store management portal for inventory, staffing, and daily performance
+    depends_on:
+      - ref('view_store_mgr_daily_report')
+      - ref('view_store_mgr_inventory_status')
+      - ref('view_store_mgr_staff_schedule')
+      - ref('view_store_mgr_product_performance')
+    owner:
+      name: Operations Team
+      email: ops@jaffleshop.com
+
+  - name: marketing_analytics
+    label: Marketing Analytics Platform
+    type: dashboard
+    maturity: medium
+    url: https://bi.jaffleshop.com/dashboards/marketing
+    description: Marketing campaign performance, loyalty program health, and customer acquisition
+    depends_on:
+      - ref('rpt_campaign_effectiveness')
+      - ref('rpt_loyalty_program_health')
+      - ref('rpt_customer_acquisition_funnel')
+      - ref('dim_customer_360')
+    owner:
+      name: Marketing Team
+      email: marketing@jaffleshop.com
+
+  - name: inventory_reorder_system
+    label: Inventory Reorder System
+    type: application
+    maturity: medium
+    description: Automated inventory reorder triggers based on stock levels and demand forecasts
+    depends_on:
+      - ref('rev_etl_inventory_reorder')
+      - ref('rpt_stock_alerts')
+    owner:
+      name: Supply Chain Team
+      email: supply@jaffleshop.com
+
+  - name: ml_churn_prediction
+    label: Customer Churn Prediction Model
+    type: ml
+    maturity: low
+    description: ML model predicting customer churn probability using feature store
+    depends_on:
+      - ref('ml_feature_customer_churn')
+      - ref('scr_customer_churn_propensity')
+    owner:
+      name: Data Science Team
+      email: datascience@jaffleshop.com
+
+  - name: crm_sync
+    label: CRM Customer Sync
+    type: application
+    maturity: high
+    description: Reverse ETL pipeline syncing customer data to CRM
+    depends_on:
+      - ref('rev_etl_crm_customer_sync')
+      - ref('rev_etl_email_segment_high_value')
+      - ref('rev_etl_email_segment_at_risk')
+    owner:
+      name: Marketing Ops
+      email: marketingops@jaffleshop.com

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/_groups.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/_groups.yml
@@ -1,0 +1,31 @@
+version: 2
+
+groups:
+  - name: finance
+    owner:
+      name: Finance Team
+      email: finance@jaffleshop.com
+  - name: supply_chain
+    owner:
+      name: Supply Chain Team
+      email: supply@jaffleshop.com
+  - name: marketing
+    owner:
+      name: Marketing Team
+      email: marketing@jaffleshop.com
+  - name: hr_operations
+    owner:
+      name: HR Team
+      email: hr@jaffleshop.com
+  - name: product
+    owner:
+      name: Product Team
+      email: product@jaffleshop.com
+  - name: data_platform
+    owner:
+      name: Data Platform Team
+      email: data@jaffleshop.com
+  - name: executive
+    owner:
+      name: Executive Team
+      email: exec@jaffleshop.com

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/customers.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/customers.sql
@@ -1,0 +1,58 @@
+with
+
+customers as (
+
+    select * from {{ ref('stg_customers') }}
+
+),
+
+orders as (
+
+    select * from {{ ref('orders') }}
+
+),
+
+customer_orders_summary as (
+
+    select
+        orders.customer_id,
+
+        count(distinct orders.order_id) as count_lifetime_orders,
+        count(distinct orders.order_id) > 1 as is_repeat_buyer,
+        min(orders.ordered_at) as first_ordered_at,
+        max(orders.ordered_at) as last_ordered_at,
+        sum(orders.subtotal) as lifetime_spend_pretax,
+        sum(orders.tax_paid) as lifetime_tax_paid,
+        sum(orders.order_total) as lifetime_spend
+
+    from orders
+
+    group by 1
+
+),
+
+joined as (
+
+    select
+        customers.*,
+
+        customer_orders_summary.count_lifetime_orders,
+        customer_orders_summary.first_ordered_at,
+        customer_orders_summary.last_ordered_at,
+        customer_orders_summary.lifetime_spend_pretax,
+        customer_orders_summary.lifetime_tax_paid,
+        customer_orders_summary.lifetime_spend,
+
+        case
+            when customer_orders_summary.is_repeat_buyer then 'returning'
+            else 'new'
+        end as customer_type
+
+    from customers
+
+    left join customer_orders_summary
+        on customers.customer_id = customer_orders_summary.customer_id
+
+)
+
+select * from joined

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/customers.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/customers.yml
@@ -1,0 +1,37 @@
+models:
+- name: customers
+  description: Customer overview data mart, offering key details for each unique customer. One row per
+    customer.
+  data_tests:
+  - dbt_utils.expression_is_true:
+      arguments:
+        expression: lifetime_spend_pretax + lifetime_tax_paid = lifetime_spend
+  columns:
+  - name: customer_id
+    description: The unique key of the orders mart.
+    data_tests:
+    - not_null
+    - unique
+  - name: customer_name
+    description: Customers' full name.
+  - name: count_lifetime_orders
+    description: Total number of orders a customer has ever placed.
+  - name: first_ordered_at
+    description: The timestamp when a customer placed their first order.
+  - name: last_ordered_at
+    description: The timestamp of a customer's most recent order.
+  - name: lifetime_spend_pretax
+    description: The sum of all the pre-tax subtotals of every order a customer has placed.
+  - name: lifetime_tax_paid
+    description: The sum of all the tax portion of every order a customer has placed.
+  - name: lifetime_spend
+    description: The sum of all the order totals (including tax) that a customer has ever placed.
+  - name: customer_type
+    description: Options are 'new' or 'returning', indicating if a customer has ordered more than once
+      or has only placed their first order to date.
+    data_tests:
+    - accepted_values:
+        arguments:
+          values:
+          - new
+          - returning

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/_derived__models.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/_derived__models.yml
@@ -1,0 +1,93 @@
+version: 2
+
+models:
+  - name: stg_derived_budget_with_location
+    description: >
+      Derived staging view combining budget with location for downstream reuse.
+  - name: stg_derived_campaign_with_spend
+    description: >
+      Derived staging view combining campaign with spend for downstream reuse.
+  - name: stg_derived_coupon_with_campaign
+    description: >
+      Derived staging view combining coupon with campaign for downstream reuse.
+  - name: stg_derived_delivery_with_po
+    description: >
+      Derived staging view combining delivery with po for downstream reuse.
+  - name: stg_derived_email_with_campaign
+    description: >
+      Derived staging view combining email with campaign for downstream reuse.
+  - name: stg_derived_employee_with_department
+    description: >
+      Derived staging view combining employee with department for downstream reuse.
+  - name: stg_derived_employee_with_position
+    description: >
+      Derived staging view combining employee with position for downstream reuse.
+  - name: stg_derived_equipment_with_location
+    description: >
+      Derived staging view combining equipment with location for downstream reuse.
+  - name: stg_derived_expense_with_category
+    description: >
+      Derived staging view combining expense with category for downstream reuse.
+  - name: stg_derived_inventory_with_product
+    description: >
+      Derived staging view combining inventory with product for downstream reuse.
+  - name: stg_derived_invoice_with_customer
+    description: >
+      Derived staging view combining invoice with customer for downstream reuse.
+  - name: stg_derived_loyalty_with_tier
+    description: >
+      Derived staging view combining loyalty with tier for downstream reuse.
+  - name: stg_derived_maintenance_with_equipment
+    description: >
+      Derived staging view combining maintenance with equipment for downstream reuse.
+  - name: stg_derived_menu_item_with_category
+    description: >
+      Derived staging view combining menu item with category for downstream reuse.
+  - name: stg_derived_menu_item_with_nutrition
+    description: >
+      Derived staging view combining menu item with nutrition for downstream reuse.
+  - name: stg_derived_order_complete
+    description: >
+      Derived staging view combining order complete for downstream reuse.
+  - name: stg_derived_order_item_with_product
+    description: >
+      Derived staging view combining order item with product for downstream reuse.
+  - name: stg_derived_order_with_customer
+    description: >
+      Derived staging view combining order with customer for downstream reuse.
+  - name: stg_derived_order_with_location
+    description: >
+      Derived staging view combining order with location for downstream reuse.
+  - name: stg_derived_payment_with_order
+    description: >
+      Derived staging view combining payment with order for downstream reuse.
+  - name: stg_derived_payroll_with_employee
+    description: >
+      Derived staging view combining payroll with employee for downstream reuse.
+  - name: stg_derived_po_line_with_product
+    description: >
+      Derived staging view combining po line with product for downstream reuse.
+  - name: stg_derived_po_with_supplier
+    description: >
+      Derived staging view combining po with supplier for downstream reuse.
+  - name: stg_derived_recipe_with_ingredients
+    description: >
+      Derived staging view combining recipe with ingredients for downstream reuse.
+  - name: stg_derived_refund_with_order
+    description: >
+      Derived staging view combining refund with order for downstream reuse.
+  - name: stg_derived_review_with_product
+    description: >
+      Derived staging view combining review with product for downstream reuse.
+  - name: stg_derived_shift_with_employee
+    description: >
+      Derived staging view combining shift with employee for downstream reuse.
+  - name: stg_derived_timecard_with_employee
+    description: >
+      Derived staging view combining timecard with employee for downstream reuse.
+  - name: stg_derived_training_with_course
+    description: >
+      Derived staging view combining training with course for downstream reuse.
+  - name: stg_derived_waste_with_product
+    description: >
+      Derived staging view combining waste with product for downstream reuse.

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_budget_with_location.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_budget_with_location.sql
@@ -1,0 +1,23 @@
+with
+
+budgets as (
+    select * from {{ ref('stg_budgets') }}
+),
+
+locations as (
+    select location_id, location_name from {{ ref('stg_locations') }}
+),
+
+final as (
+    select
+        b.budget_id,
+        b.location_id,
+        l.location_name,
+        b.expense_category_id,
+        b.budget_month,
+        b.budgeted_amount
+    from budgets as b
+    left join locations as l on b.location_id = l.location_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_campaign_with_spend.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_campaign_with_spend.sql
@@ -1,0 +1,26 @@
+with
+
+campaigns as (
+    select * from {{ ref('stg_campaigns') }}
+),
+
+spend as (
+    select campaign_id, sum(spend_amount) as total_spend
+    from {{ ref('stg_campaign_spend') }}
+    group by 1
+),
+
+final as (
+    select
+        c.campaign_id,
+        c.campaign_name,
+        c.campaign_channel,
+        c.campaign_start_date,
+        c.campaign_end_date,
+        c.campaign_status,
+        coalesce(s.total_spend, 0) as total_spend
+    from campaigns as c
+    left join spend as s on c.campaign_id = s.campaign_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_coupon_with_campaign.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_coupon_with_campaign.sql
@@ -1,0 +1,27 @@
+with
+
+coupons as (
+    select * from {{ ref('stg_coupons') }}
+),
+
+campaigns as (
+    select campaign_id, campaign_name, campaign_channel from {{ ref('stg_campaigns') }}
+),
+
+final as (
+    select
+        cp.coupon_id,
+        cp.coupon_code,
+        cp.discount_type,
+        cp.discount_amount,
+        cp.campaign_id,
+        ca.campaign_name,
+        ca.campaign_channel,
+        cp.valid_from,
+        cp.valid_until,
+        cp.coupon_status
+    from coupons as cp
+    left join campaigns as ca on cp.campaign_id = ca.campaign_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_delivery_with_po.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_delivery_with_po.sql
@@ -1,0 +1,26 @@
+with
+
+deliveries as (
+    select * from {{ ref('stg_delivery_shipments') }}
+),
+
+pos as (
+    select purchase_order_id, supplier_id, ordered_at, total_amount from {{ ref('stg_purchase_orders') }}
+),
+
+final as (
+    select
+        d.shipment_id,
+        d.purchase_order_id,
+        po.supplier_id,
+        po.ordered_at as po_ordered_at,
+        po.total_amount as po_total,
+        d.shipped_at,
+        d.actual_arrival_at,
+        d.actual_arrival_at - po.ordered_at as total_lead_time_days,
+        d.shipment_status
+    from deliveries as d
+    left join pos as po on d.purchase_order_id = po.purchase_order_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_email_with_campaign.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_email_with_campaign.sql
@@ -1,0 +1,24 @@
+with
+
+emails as (
+    select * from {{ ref('stg_email_events') }}
+),
+
+campaigns as (
+    select campaign_id, campaign_name, campaign_channel from {{ ref('stg_campaigns') }}
+),
+
+final as (
+    select
+        ee.email_event_id,
+        ee.campaign_id,
+        ca.campaign_name,
+        ca.campaign_channel,
+        ee.customer_id,
+        ee.email_event_type,
+        ee.event_date
+    from emails as ee
+    left join campaigns as ca on ee.campaign_id = ca.campaign_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_employee_with_department.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_employee_with_department.sql
@@ -1,0 +1,24 @@
+with
+
+employees as (
+    select * from {{ ref('stg_employees') }}
+),
+
+departments as (
+    select department_id, department_name from {{ ref('stg_departments') }}
+),
+
+final as (
+    select
+        e.employee_id,
+        e.full_name,
+        e.department_id,
+        d.department_name,
+        e.location_id,
+        e.hire_date,
+        e.employment_status
+    from employees as e
+    left join departments as d on e.department_id = d.department_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_employee_with_position.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_employee_with_position.sql
@@ -1,0 +1,26 @@
+with
+
+employees as (
+    select * from {{ ref('stg_employees') }}
+),
+
+positions as (
+    select position_id, position_title, pay_grade from {{ ref('stg_positions') }}
+),
+
+final as (
+    select
+        e.employee_id,
+        e.full_name,
+        e.position_id,
+        p.position_title,
+        p.pay_grade,
+        e.department_id,
+        e.location_id,
+        e.hire_date,
+        e.employment_status
+    from employees as e
+    left join positions as p on e.position_id = p.position_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_equipment_with_location.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_equipment_with_location.sql
@@ -1,0 +1,24 @@
+with
+
+equipment as (
+    select * from {{ ref('stg_equipment') }}
+),
+
+locations as (
+    select location_id, location_name from {{ ref('stg_locations') }}
+),
+
+final as (
+    select
+        eq.equipment_id,
+        eq.equipment_name,
+        eq.equipment_type,
+        eq.location_id,
+        l.location_name,
+        eq.purchase_date,
+        eq.equipment_status
+    from equipment as eq
+    left join locations as l on eq.location_id = l.location_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_expense_with_category.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_expense_with_category.sql
@@ -1,0 +1,24 @@
+with
+
+expenses as (
+    select * from {{ ref('stg_expenses') }}
+),
+
+categories as (
+    select expense_category_id, category_name from {{ ref('stg_expense_categories') }}
+),
+
+final as (
+    select
+        ex.expense_id,
+        ex.location_id,
+        ex.expense_category_id,
+        ec.category_name,
+        ex.incurred_date,
+        ex.expense_amount,
+        ex.expense_description
+    from expenses as ex
+    left join categories as ec on ex.expense_category_id = ec.expense_category_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_inventory_with_product.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_inventory_with_product.sql
@@ -1,0 +1,25 @@
+with
+
+movements as (
+    select * from {{ ref('stg_inventory_movements') }}
+),
+
+products as (
+    select product_id, product_name, product_type from {{ ref('stg_products') }}
+),
+
+final as (
+    select
+        im.movement_id,
+        im.product_id,
+        p.product_name,
+        p.product_type,
+        im.location_id,
+        im.moved_at,
+        im.movement_type,
+        im.quantity
+    from movements as im
+    left join products as p on im.product_id = p.product_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_invoice_with_customer.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_invoice_with_customer.sql
@@ -1,0 +1,24 @@
+with
+
+invoices as (
+    select * from {{ ref('stg_invoices') }}
+),
+
+customers as (
+    select customer_id, customer_name from {{ ref('stg_customers') }}
+),
+
+final as (
+    select
+        i.invoice_id,
+        i.customer_id,
+        c.customer_name,
+        i.issued_date,
+        i.due_date,
+        i.total_amount,
+        i.invoice_status
+    from invoices as i
+    left join customers as c on i.customer_id = c.customer_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_loyalty_with_tier.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_loyalty_with_tier.sql
@@ -1,0 +1,25 @@
+with
+
+members as (
+    select * from {{ ref('stg_loyalty_members') }}
+),
+
+tiers as (
+    select tier_id, tier_name, minimum_points, maximum_points from {{ ref('stg_loyalty_tiers') }}
+),
+
+final as (
+    select
+        m.loyalty_member_id,
+        m.customer_id,
+        m.current_tier_id,
+        t.tier_name,
+        t.minimum_points,
+        t.maximum_points,
+        m.enrolled_at,
+        m.membership_status
+    from members as m
+    left join tiers as t on m.current_tier_id = t.tier_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_maintenance_with_equipment.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_maintenance_with_equipment.sql
@@ -1,0 +1,26 @@
+with
+
+logs as (
+    select * from {{ ref('stg_maintenance_logs') }}
+),
+
+equipment as (
+    select equipment_id, equipment_name, equipment_type, location_id from {{ ref('stg_equipment') }}
+),
+
+final as (
+    select
+        ml.maintenance_log_id,
+        ml.equipment_id,
+        eq.equipment_name,
+        eq.equipment_type,
+        eq.location_id,
+        ml.scheduled_date,
+        ml.maintenance_type,
+        ml.maintenance_cost,
+        ml.maintenance_description
+    from logs as ml
+    left join equipment as eq on ml.equipment_id = eq.equipment_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_menu_item_with_category.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_menu_item_with_category.sql
@@ -1,0 +1,24 @@
+with
+
+items as (
+    select * from {{ ref('stg_menu_items') }}
+),
+
+categories as (
+    select menu_category_id, category_name from {{ ref('stg_menu_categories') }}
+),
+
+final as (
+    select
+        mi.menu_item_id,
+        mi.product_id,
+        mi.menu_item_name,
+        mi.menu_category_id,
+        mc.category_name,
+        mi.menu_item_price,
+        mi.is_available
+    from items as mi
+    left join categories as mc on mi.menu_category_id = mc.menu_category_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_menu_item_with_nutrition.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_menu_item_with_nutrition.sql
@@ -1,0 +1,27 @@
+with
+
+items as (
+    select menu_item_id, product_id, menu_item_name, menu_item_price from {{ ref('stg_menu_items') }}
+),
+
+nutrition as (
+    select * from {{ ref('stg_nutritional_info') }}
+),
+
+final as (
+    select
+        mi.menu_item_id,
+        mi.product_id,
+        mi.menu_item_name,
+        mi.menu_item_price,
+        n.calories,
+        n.protein_g,
+        n.total_fat_g,
+        n.total_carbs_g,
+        n.dietary_fiber_g,
+        n.sodium_mg
+    from items as mi
+    left join nutrition as n on mi.menu_item_id = n.menu_item_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_order_complete.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_order_complete.sql
@@ -1,0 +1,31 @@
+with
+
+orders as (
+    select * from {{ ref('stg_orders') }}
+),
+
+customers as (
+    select customer_id, customer_name from {{ ref('stg_customers') }}
+),
+
+locations as (
+    select location_id, location_name from {{ ref('stg_locations') }}
+),
+
+final as (
+    select
+        o.order_id,
+        o.customer_id,
+        c.customer_name,
+        o.location_id,
+        l.location_name,
+        o.ordered_at,
+        o.order_total,
+        o.tax_paid,
+        o.subtotal
+    from orders as o
+    left join customers as c on o.customer_id = c.customer_id
+    left join locations as l on o.location_id = l.location_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_order_item_with_product.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_order_item_with_product.sql
@@ -1,0 +1,23 @@
+with
+
+items as (
+    select * from {{ ref('stg_order_items') }}
+),
+
+products as (
+    select product_id, product_name, product_type, product_price from {{ ref('stg_products') }}
+),
+
+final as (
+    select
+        i.order_item_id,
+        i.order_id,
+        i.product_id,
+        p.product_name,
+        p.product_type,
+        p.product_price as list_price
+    from items as i
+    left join products as p on i.product_id = p.product_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_order_with_customer.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_order_with_customer.sql
@@ -1,0 +1,25 @@
+with
+
+orders as (
+    select * from {{ ref('stg_orders') }}
+),
+
+customers as (
+    select customer_id, customer_name from {{ ref('stg_customers') }}
+),
+
+final as (
+    select
+        o.order_id,
+        o.customer_id,
+        c.customer_name,
+        o.location_id,
+        o.ordered_at,
+        o.order_total,
+        o.tax_paid,
+        o.subtotal
+    from orders as o
+    left join customers as c on o.customer_id = c.customer_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_order_with_location.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_order_with_location.sql
@@ -1,0 +1,25 @@
+with
+
+orders as (
+    select * from {{ ref('stg_orders') }}
+),
+
+locations as (
+    select location_id, location_name from {{ ref('stg_locations') }}
+),
+
+final as (
+    select
+        o.order_id,
+        o.customer_id,
+        o.location_id,
+        l.location_name,
+        o.ordered_at,
+        o.order_total,
+        o.tax_paid,
+        o.subtotal
+    from orders as o
+    left join locations as l on o.location_id = l.location_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_payment_with_order.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_payment_with_order.sql
@@ -1,0 +1,26 @@
+with
+
+payments as (
+    select * from {{ ref('stg_payment_transactions') }}
+),
+
+orders as (
+    select order_id, customer_id, location_id, ordered_at from {{ ref('stg_orders') }}
+),
+
+final as (
+    select
+        pt.payment_transaction_id,
+        pt.order_id,
+        o.customer_id,
+        o.location_id,
+        o.ordered_at,
+        pt.payment_method,
+        pt.payment_amount,
+        pt.processed_date,
+        pt.payment_status
+    from payments as pt
+    left join orders as o on pt.order_id = o.order_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_payroll_with_employee.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_payroll_with_employee.sql
@@ -1,0 +1,28 @@
+with
+
+payroll as (
+    select * from {{ ref('stg_payroll') }}
+),
+
+employees as (
+    select employee_id, full_name, department_id, location_id from {{ ref('stg_employees') }}
+),
+
+final as (
+    select
+        pr.payroll_id,
+        pr.employee_id,
+        e.full_name,
+        e.department_id,
+        e.location_id,
+        pr.pay_period_start,
+        pr.pay_period_end,
+        pr.pay_date,
+        pr.gross_pay,
+        pr.net_pay,
+        pr.gross_pay - pr.net_pay as total_deductions
+    from payroll as pr
+    left join employees as e on pr.employee_id = e.employee_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_po_line_with_product.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_po_line_with_product.sql
@@ -1,0 +1,24 @@
+with
+
+lines as (
+    select * from {{ ref('stg_po_line_items') }}
+),
+
+products as (
+    select product_id, product_name from {{ ref('stg_products') }}
+),
+
+final as (
+    select
+        l.po_line_item_id,
+        l.purchase_order_id,
+        l.product_id,
+        p.product_name,
+        l.quantity_ordered,
+        l.unit_cost,
+        l.line_total
+    from lines as l
+    left join products as p on l.product_id = p.product_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_po_with_supplier.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_po_with_supplier.sql
@@ -1,0 +1,24 @@
+with
+
+pos as (
+    select * from {{ ref('stg_purchase_orders') }}
+),
+
+suppliers as (
+    select supplier_id, supplier_name from {{ ref('stg_suppliers') }}
+),
+
+final as (
+    select
+        po.purchase_order_id,
+        po.supplier_id,
+        s.supplier_name,
+        po.ordered_at,
+        po.expected_delivery_at,
+        po.total_amount,
+        po.po_status
+    from pos as po
+    left join suppliers as s on po.supplier_id = s.supplier_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_recipe_with_ingredients.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_recipe_with_ingredients.sql
@@ -1,0 +1,39 @@
+with
+
+ri as (
+    select * from {{ ref('stg_recipe_ingredients') }}
+),
+
+i as (
+    select * from {{ ref('stg_ingredients') }}
+),
+
+recipes as (
+    select * from {{ ref('stg_recipes') }}
+),
+
+ingredients as (
+    select
+        ri.recipe_id,
+        ri.ingredient_id,
+        i.ingredient_name,
+        ri.quantity as ingredient_quantity,
+        ri.quantity_unit
+    from ri
+    inner join i on ri.ingredient_id = i.ingredient_id
+),
+
+final as (
+    select
+        r.recipe_id,
+        r.menu_item_id,
+        r.recipe_name,
+        ing.ingredient_id,
+        ing.ingredient_name,
+        ing.ingredient_quantity,
+        ing.quantity_unit
+    from recipes as r
+    inner join ingredients as ing on r.recipe_id = ing.recipe_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_refund_with_order.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_refund_with_order.sql
@@ -1,0 +1,26 @@
+with
+
+refunds as (
+    select * from {{ ref('stg_refunds') }}
+),
+
+orders as (
+    select order_id, customer_id, location_id, order_total from {{ ref('stg_orders') }}
+),
+
+final as (
+    select
+        r.refund_id,
+        r.order_id,
+        o.customer_id,
+        o.location_id,
+        o.order_total,
+        r.requested_date,
+        r.refund_amount,
+        r.refund_reason,
+        round(r.refund_amount * 100.0 / nullif(o.order_total, 0), 2) as refund_pct_of_order
+    from refunds as r
+    left join orders as o on r.order_id = o.order_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_review_with_product.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_review_with_product.sql
@@ -1,0 +1,26 @@
+with
+
+reviews as (
+    select * from {{ ref('stg_product_reviews') }}
+),
+
+products as (
+    select product_id, product_name, product_type from {{ ref('stg_products') }}
+),
+
+final as (
+    select
+        r.review_id,
+        r.product_id,
+        p.product_name,
+        p.product_type,
+        r.customer_id,
+        r.rating,
+        r.reviewed_date,
+        r.review_title,
+        r.review_body
+    from reviews as r
+    left join products as p on r.product_id = p.product_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_shift_with_employee.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_shift_with_employee.sql
@@ -1,0 +1,27 @@
+with
+
+shifts as (
+    select * from {{ ref('stg_shifts') }}
+),
+
+employees as (
+    select employee_id, full_name, department_id from {{ ref('stg_employees') }}
+),
+
+final as (
+    select
+        s.shift_id,
+        s.employee_id,
+        e.full_name,
+        e.department_id,
+        s.location_id,
+        s.shift_date,
+        s.scheduled_start,
+        s.scheduled_end,
+        s.scheduled_hours,
+        s.shift_status
+    from shifts as s
+    left join employees as e on s.employee_id = e.employee_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_timecard_with_employee.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_timecard_with_employee.sql
@@ -1,0 +1,26 @@
+with
+
+timecards as (
+    select * from {{ ref('stg_timecards') }}
+),
+
+employees as (
+    select employee_id, full_name, department_id from {{ ref('stg_employees') }}
+),
+
+final as (
+    select
+        tc.timecard_id,
+        tc.employee_id,
+        e.full_name,
+        e.department_id,
+        tc.location_id,
+        tc.work_date,
+        tc.hours_worked,
+        tc.break_minutes,
+        tc.timecard_status
+    from timecards as tc
+    left join employees as e on tc.employee_id = e.employee_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_training_with_course.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_training_with_course.sql
@@ -1,0 +1,26 @@
+with
+
+completions as (
+    select * from {{ ref('stg_training_completions') }}
+),
+
+courses as (
+    select training_course_id, course_name, course_category, duration_hours from {{ ref('stg_training_courses') }}
+),
+
+final as (
+    select
+        tc.training_completion_id,
+        tc.employee_id,
+        tc.training_course_id,
+        c.course_name,
+        c.course_category,
+        c.duration_hours as expected_duration,
+        tc.started_date,
+        tc.completed_date,
+        tc.completion_score
+    from completions as tc
+    left join courses as c on tc.training_course_id = c.training_course_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_waste_with_product.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/derived/stg_derived_waste_with_product.sql
@@ -1,0 +1,26 @@
+with
+
+waste as (
+    select * from {{ ref('stg_waste_logs') }}
+),
+
+products as (
+    select product_id, product_name, product_type from {{ ref('stg_products') }}
+),
+
+final as (
+    select
+        w.waste_log_id,
+        w.product_id,
+        p.product_name,
+        p.product_type,
+        w.location_id,
+        w.wasted_at,
+        w.waste_reason,
+        w.quantity_wasted,
+        w.cost_of_waste
+    from waste as w
+    left join products as p on w.product_id = p.product_id
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/executive/_executive__models.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/executive/_executive__models.yml
@@ -1,0 +1,121 @@
+version: 2
+
+models:
+  - name: exec_company_kpis_daily
+    config:
+      tags: ['type:executive', 'audience:cfo', 'cadence:daily']
+    description: >
+      Company-wide daily KPIs: total revenue, orders, customers,
+      average ticket, and waste cost aggregated across all stores.
+    columns:
+      - name: kpi_date
+        description: Calendar date of the KPIs.
+        tests:
+          - unique
+          - not_null
+      - name: total_revenue
+        description: Company-wide total revenue for the day.
+      - name: total_orders
+        description: Company-wide total order count.
+      - name: active_customers
+        description: Number of unique customers who ordered.
+      - name: avg_ticket_size
+        description: Average order value across all stores.
+
+  - name: exec_company_kpis_monthly
+    config:
+      tags: ['type:executive', 'audience:cfo', 'cadence:monthly']
+    meta:
+      owner: executive
+      contains_pii: false
+      update_frequency: monthly
+    description: >
+      Monthly company KPIs with MoM and YoY growth rates.
+    columns:
+      - name: month_start
+        description: First day of the month.
+        tests:
+          - unique
+          - not_null
+      - name: monthly_revenue
+        description: Total company revenue for the month.
+      - name: mom_revenue_growth
+        description: Month-over-month revenue growth rate.
+      - name: yoy_revenue_growth
+        description: Year-over-year revenue growth rate.
+
+  - name: exec_regional_summary
+    config:
+      tags: ['type:executive', 'audience:cfo']
+    description: >
+      Key metrics per store (revenue, profit, labor %, growth)
+      for executive regional comparison.
+    columns:
+      - name: location_id
+        description: Unique store identifier.
+        tests:
+          - unique
+          - not_null
+      - name: store_name
+        description: Store name.
+      - name: pnl_total_revenue
+        description: Total revenue from P&L data.
+      - name: net_profit_margin_pct
+        description: Net profit margin percentage.
+
+  - name: exec_financial_summary_monthly
+    config:
+      tags: ['type:executive', 'audience:cfo', 'cadence:monthly']
+    description: >
+      Monthly financial summary: revenue, COGS, gross profit,
+      operating expenses, and net profit with margins.
+    columns:
+      - name: month_start
+        description: First day of the month.
+        tests:
+          - unique
+          - not_null
+      - name: total_revenue
+        description: Monthly revenue.
+      - name: gross_profit
+        description: Revenue minus COGS.
+      - name: gross_margin_pct
+        description: Gross margin percentage.
+      - name: net_profit
+        description: Revenue minus all expenses.
+      - name: net_profit_margin_pct
+        description: Net profit margin percentage.
+
+  - name: exec_customer_health_index
+    config:
+      tags: ['type:executive', 'audience:cfo']
+    description: >
+      Company-wide customer health snapshot: active %, churn rate,
+      churn propensity distribution, and composite health index.
+    columns:
+      - name: reporting_month
+        description: The month this snapshot represents.
+      - name: customer_health_index
+        description: Composite customer health index (0-100).
+      - name: active_pct
+        description: Percentage of tracked customers who are active.
+      - name: high_risk_pct
+        description: Percentage of customers with high churn propensity.
+
+  - name: exec_ops_scorecard
+    config:
+      tags: ['type:executive', 'audience:cfo']
+    description: >
+      Operations scorecard combining labor efficiency, inventory health,
+      waste control, and employee performance into a single view.
+    columns:
+      - name: reporting_month
+        description: The month this scorecard covers.
+      - name: ops_health_score
+        description: Composite operations health score (0-100).
+      - name: avg_orders_per_labor_hour
+        description: Average orders per labor hour across stores.
+      - name: waste_to_revenue_pct
+        description: Waste cost as percentage of revenue.
+      - name: avg_employee_performance_score
+        description: Average employee performance score.

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/executive/exec_company_kpis_daily.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/executive/exec_company_kpis_daily.sql
@@ -1,0 +1,81 @@
+with
+
+revenue as (
+
+    select
+        revenue_date,
+        sum(total_revenue) as total_revenue,
+        sum(order_count) as total_orders,
+        sum(gross_revenue) as total_gross_revenue,
+        sum(tax_collected) as total_tax_collected,
+        case
+            when sum(order_count) > 0
+            then sum(total_revenue) / sum(order_count)
+            else 0
+        end as avg_ticket_size
+    from {{ ref('met_daily_revenue_by_store') }}
+    group by revenue_date
+
+),
+
+customers as (
+
+    select
+        activity_date,
+        active_customers,
+        new_customers,
+        returning_customers
+    from {{ ref('met_daily_customer_metrics') }}
+
+),
+
+waste as (
+
+    select
+        waste_date,
+        sum(total_waste_cost) as total_waste_cost,
+        sum(waste_events) as total_waste_events
+    from {{ ref('met_daily_waste_metrics') }}
+    group by waste_date
+
+),
+
+final as (
+
+    select
+        r.revenue_date as kpi_date,
+        r.total_revenue,
+        r.total_orders,
+        r.total_gross_revenue,
+        r.total_tax_collected,
+        r.avg_ticket_size,
+        coalesce(c.active_customers, 0) as active_customers,
+        coalesce(c.new_customers, 0) as new_customers,
+        coalesce(c.returning_customers, 0) as returning_customers,
+        coalesce(w.total_waste_cost, 0) as total_waste_cost,
+        coalesce(w.total_waste_events, 0) as total_waste_events,
+
+        -- Gross margin proxy: revenue - waste cost
+        r.total_revenue - coalesce(w.total_waste_cost, 0) as net_revenue_after_waste,
+
+        -- Rolling metrics
+        avg(r.total_revenue) over (
+            order by r.revenue_date
+            rows between 6 preceding and current row
+        ) as revenue_7d_avg,
+        avg(r.total_orders) over (
+            order by r.revenue_date
+            rows between 6 preceding and current row
+        ) as orders_7d_avg
+
+    from revenue as r
+
+    left join customers as c
+        on r.revenue_date = c.activity_date
+
+    left join waste as w
+        on r.revenue_date = w.waste_date
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/executive/exec_company_kpis_monthly.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/executive/exec_company_kpis_monthly.sql
@@ -1,0 +1,61 @@
+with
+
+daily_kpis as (
+
+    select * from {{ ref('exec_company_kpis_daily') }}
+
+),
+
+monthly_agg as (
+
+    select
+        {{ dbt.date_trunc('month', 'kpi_date') }} as month_start,
+        sum(total_revenue) as monthly_revenue,
+        sum(total_orders) as monthly_orders,
+        sum(total_gross_revenue) as monthly_gross_revenue,
+        sum(total_tax_collected) as monthly_tax,
+        case
+            when sum(total_orders) > 0
+            then sum(total_revenue) / sum(total_orders)
+            else 0
+        end as avg_ticket_size,
+        sum(new_customers) as monthly_new_customers,
+        avg(active_customers) as avg_daily_active_customers,
+        sum(total_waste_cost) as monthly_waste_cost,
+        count(kpi_date) as active_days
+
+    from daily_kpis
+    group by 1
+
+),
+
+with_growth as (
+
+    select
+        *,
+        -- MoM growth
+        lag(monthly_revenue) over (order by month_start) as prev_month_revenue,
+        case
+            when lag(monthly_revenue) over (order by month_start) > 0
+            then (monthly_revenue - lag(monthly_revenue) over (order by month_start))
+                * 1.0 / lag(monthly_revenue) over (order by month_start)
+        end as mom_revenue_growth,
+        case
+            when lag(monthly_orders) over (order by month_start) > 0
+            then (monthly_orders - lag(monthly_orders) over (order by month_start))
+                * 1.0 / lag(monthly_orders) over (order by month_start)
+        end as mom_orders_growth,
+
+        -- YoY growth
+        lag(monthly_revenue, 12) over (order by month_start) as same_month_last_year_revenue,
+        case
+            when lag(monthly_revenue, 12) over (order by month_start) > 0
+            then (monthly_revenue - lag(monthly_revenue, 12) over (order by month_start))
+                * 1.0 / lag(monthly_revenue, 12) over (order by month_start)
+        end as yoy_revenue_growth
+
+    from monthly_agg
+
+)
+
+select * from with_growth

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/executive/exec_customer_health_index.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/executive/exec_customer_health_index.sql
@@ -1,0 +1,69 @@
+with
+
+monthly_customers as (
+
+    select * from {{ ref('met_monthly_customer_metrics') }}
+
+),
+
+churn_scores as (
+
+    select
+        count(*) as total_scored_customers,
+        avg(churn_propensity_score) as avg_churn_score,
+        count(case when churn_risk_tier = 'high' then 1 end) as high_risk_count,
+        count(case when churn_risk_tier = 'medium' then 1 end) as medium_risk_count,
+        count(case when churn_risk_tier = 'low' then 1 end) as low_risk_count,
+        count(case when churn_risk_tier = 'high' then 1 end) * 100.0
+            / nullif(count(*), 0) as high_risk_pct
+    from {{ ref('scr_customer_churn_propensity') }}
+
+),
+
+-- Latest month snapshot
+latest_month as (
+
+    select * from monthly_customers
+    where month_start = (select max(month_start) from monthly_customers)
+
+),
+
+final as (
+
+    select
+        lm.month_start as reporting_month,
+        lm.total_tracked_customers,
+        lm.tracked_active_customers,
+        lm.dormant_customers,
+        lm.churned_customers,
+        lm.active_pct,
+        lm.churn_pct,
+        lm.new_customers,
+        lm.total_orders,
+        lm.total_revenue,
+        lm.mom_customer_visit_change,
+
+        -- Churn propensity summary (point-in-time)
+        cs.total_scored_customers,
+        cs.avg_churn_score,
+        cs.high_risk_count,
+        cs.medium_risk_count,
+        cs.low_risk_count,
+        cs.high_risk_pct,
+
+        -- Customer health index: composite of active %, inverse churn score, growth
+        round(coalesce(lm.active_pct, 0) * 0.4
+            + ((100 - coalesce(cs.avg_churn_score, 50)) * 0.4)
+            + (case
+                when coalesce(lm.mom_customer_visit_change, 0) > 0 then 20
+                when coalesce(lm.mom_customer_visit_change, 0) = 0 then 10
+                else 0
+            end), 1) as customer_health_index
+
+    from latest_month as lm
+
+    cross join churn_scores as cs
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/executive/exec_financial_summary_monthly.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/executive/exec_financial_summary_monthly.sql
@@ -1,0 +1,76 @@
+with
+
+monthly_revenue as (
+
+    select
+        month_start,
+        sum(monthly_revenue) as total_revenue,
+        sum(monthly_gross_revenue) as total_gross_revenue,
+        sum(monthly_orders) as total_orders
+    from {{ ref('met_monthly_revenue_by_store') }}
+    group by month_start
+
+),
+
+monthly_expenses as (
+
+    select
+        expense_month as month_start,
+        sum(total_expense_amount) as total_expenses,
+        sum(case when is_cost_of_goods_sold then total_expense_amount else 0 end) as cogs,
+        sum(case when is_operating_expense then total_expense_amount else 0 end) as operating_expenses,
+        sum(case when not is_cost_of_goods_sold and not is_operating_expense
+            then total_expense_amount else 0 end) as other_expenses
+
+    from {{ ref('int_expense_summary_monthly') }}
+    group by expense_month
+
+),
+
+final as (
+
+    select
+        r.month_start,
+        r.total_revenue,
+        r.total_gross_revenue,
+        r.total_orders,
+        coalesce(e.total_expenses, 0) as total_expenses,
+        coalesce(e.cogs, 0) as cogs,
+        r.total_revenue - coalesce(e.cogs, 0) as gross_profit,
+        case
+            when r.total_revenue > 0
+            then (r.total_revenue - coalesce(e.cogs, 0)) * 100.0 / r.total_revenue
+            else 0
+        end as gross_margin_pct,
+        coalesce(e.operating_expenses, 0) as operating_expenses,
+        r.total_revenue - coalesce(e.cogs, 0) - coalesce(e.operating_expenses, 0) as operating_profit,
+        case
+            when r.total_revenue > 0
+            then (r.total_revenue - coalesce(e.cogs, 0) - coalesce(e.operating_expenses, 0))
+                * 100.0 / r.total_revenue
+            else 0
+        end as operating_margin_pct,
+        coalesce(e.other_expenses, 0) as other_expenses,
+        r.total_revenue - coalesce(e.total_expenses, 0) as net_profit,
+        case
+            when r.total_revenue > 0
+            then (r.total_revenue - coalesce(e.total_expenses, 0)) * 100.0 / r.total_revenue
+            else 0
+        end as net_profit_margin_pct,
+
+        -- MoM changes
+        lag(r.total_revenue) over (order by r.month_start) as prev_month_revenue,
+        case
+            when lag(r.total_revenue) over (order by r.month_start) > 0
+            then (r.total_revenue - lag(r.total_revenue) over (order by r.month_start))
+                * 1.0 / lag(r.total_revenue) over (order by r.month_start)
+        end as mom_revenue_change
+
+    from monthly_revenue as r
+
+    left join monthly_expenses as e
+        on r.month_start = e.month_start
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/executive/exec_ops_scorecard.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/executive/exec_ops_scorecard.sql
@@ -1,0 +1,130 @@
+with
+
+labor_metrics as (
+
+    select
+        month_start,
+        sum(monthly_labor_cost) as total_labor_cost,
+        sum(monthly_revenue) as total_revenue,
+        avg(orders_per_labor_hour) as avg_orders_per_labor_hour,
+        avg(labor_cost_pct_of_revenue) as avg_labor_cost_pct
+    from {{ ref('met_monthly_labor_metrics') }}
+    where month_start = (
+        select max(month_start) from {{ ref('met_monthly_labor_metrics') }}
+    )
+    group by month_start
+
+),
+
+inventory_metrics as (
+
+    select
+        month_start,
+        sum(monthly_movements) as total_inventory_movements,
+        sum(monthly_inbound) as total_inbound,
+        sum(monthly_outbound) as total_outbound,
+        avg(products_in_stock) as avg_products_in_stock
+    from {{ ref('met_monthly_inventory_metrics') }}
+    where month_start = (
+        select max(month_start) from {{ ref('met_monthly_inventory_metrics') }}
+    )
+    group by month_start
+
+),
+
+waste_metrics as (
+
+    select
+        month_start,
+        sum(monthly_waste_cost) as total_waste_cost,
+        sum(monthly_waste_events) as total_waste_events,
+        avg(waste_to_revenue_pct) as avg_waste_to_revenue_pct
+    from {{ ref('met_monthly_waste_metrics') }}
+    where month_start = (
+        select max(month_start) from {{ ref('met_monthly_waste_metrics') }}
+    )
+    group by month_start
+
+),
+
+employee_performance as (
+
+    select
+        avg(performance_score) as avg_employee_score,
+        count(case when performance_tier = 'top_performer' then 1 end) as top_performers,
+        count(case when performance_tier = 'needs_support' then 1 end) as needs_support_count,
+        count(*) as total_scored_employees
+    from {{ ref('scr_employee_performance') }}
+
+),
+
+final as (
+
+    select
+        coalesce(lm.month_start, im.month_start, wm.month_start) as reporting_month,
+
+        -- Labor efficiency
+        coalesce(lm.avg_orders_per_labor_hour, 0) as avg_orders_per_labor_hour,
+        coalesce(lm.avg_labor_cost_pct, 0) as labor_cost_pct,
+        coalesce(lm.total_labor_cost, 0) as total_labor_cost,
+
+        -- Inventory health
+        coalesce(im.total_inventory_movements, 0) as inventory_movements,
+        coalesce(im.avg_products_in_stock, 0) as avg_products_in_stock,
+        coalesce(im.total_inbound, 0) as total_inbound,
+        coalesce(im.total_outbound, 0) as total_outbound,
+
+        -- Waste control
+        coalesce(wm.total_waste_cost, 0) as waste_cost,
+        coalesce(wm.total_waste_events, 0) as waste_events,
+        coalesce(wm.avg_waste_to_revenue_pct, 0) as waste_to_revenue_pct,
+
+        -- Employee performance
+        coalesce(ep.avg_employee_score, 0) as avg_employee_performance_score,
+        coalesce(ep.top_performers, 0) as top_performers,
+        coalesce(ep.needs_support_count, 0) as needs_support_count,
+        coalesce(ep.total_scored_employees, 0) as total_scored_employees,
+
+        -- Operations health score (composite)
+        round(-- Labor efficiency (25 pts): lower labor % = better
+            (case
+                when coalesce(lm.avg_labor_cost_pct, 100) <= 25 then 25
+                when coalesce(lm.avg_labor_cost_pct, 100) <= 35 then 18
+                when coalesce(lm.avg_labor_cost_pct, 100) <= 45 then 10
+                else 5
+            end)
+            -- Waste control (25 pts): lower waste % = better
+            + (case
+                when coalesce(wm.avg_waste_to_revenue_pct, 100) <= 1 then 25
+                when coalesce(wm.avg_waste_to_revenue_pct, 100) <= 3 then 18
+                when coalesce(wm.avg_waste_to_revenue_pct, 100) <= 5 then 10
+                else 5
+            end)
+            -- Inventory activity (25 pts)
+            + (case
+                when coalesce(im.total_inventory_movements, 0) >= 500 then 25
+                when coalesce(im.total_inventory_movements, 0) >= 200 then 18
+                when coalesce(im.total_inventory_movements, 0) >= 50 then 10
+                else 5
+            end)
+            -- Employee performance (25 pts)
+            + (case
+                when coalesce(ep.avg_employee_score, 0) >= 75 then 25
+                when coalesce(ep.avg_employee_score, 0) >= 55 then 18
+                when coalesce(ep.avg_employee_score, 0) >= 35 then 10
+                else 5
+            end), 0) as ops_health_score
+
+    from labor_metrics as lm
+
+    full outer join inventory_metrics as im
+        on lm.month_start = im.month_start
+
+    full outer join waste_metrics as wm
+        on coalesce(lm.month_start, im.month_start) = wm.month_start
+
+    cross join employee_performance as ep
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/executive/exec_regional_summary.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/executive/exec_regional_summary.sql
@@ -1,0 +1,53 @@
+with
+
+store_profile as (
+
+    select * from {{ ref('dim_store_profile') }}
+
+),
+
+store_pnl as (
+
+    select
+        location_id,
+        sum(monthly_revenue) as total_revenue,
+        sum(net_profit) as total_net_profit,
+        avg(net_profit_margin_pct) as avg_net_margin_pct,
+        avg(labor_cost_ratio_pct) as avg_labor_ratio_pct,
+        count(distinct report_month) as months_of_data
+    from {{ ref('rpt_store_pnl') }}
+    group by location_id
+
+),
+
+-- Since stores may not have a region field, group by store
+store_summary as (
+
+    select
+        sp.location_id,
+        sp.store_name,
+        sp.total_revenue as profile_total_revenue,
+        sp.avg_operating_margin_pct,
+        sp.avg_labor_cost_pct,
+        sp.avg_employee_count,
+        coalesce(pnl.total_revenue, 0) as pnl_total_revenue,
+        coalesce(pnl.total_net_profit, 0) as total_net_profit,
+        coalesce(pnl.avg_net_margin_pct, 0) as avg_net_margin_pct,
+        coalesce(pnl.avg_labor_ratio_pct, 0) as pnl_avg_labor_ratio_pct,
+        coalesce(pnl.months_of_data, 0) as months_of_data,
+
+        -- Revenue growth: recent vs prior half of available data
+        case
+            when coalesce(pnl.total_revenue, 0) > 0
+            then round(cast(coalesce(pnl.total_net_profit, 0) * 100.0 / pnl.total_revenue as {{ dbt.type_float() }}), 2)
+            else 0
+        end as net_profit_margin_pct
+
+    from store_profile as sp
+
+    left join store_pnl as pnl
+        on sp.location_id = pnl.location_id
+
+)
+
+select * from store_summary

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/_finance__models.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/_finance__models.yml
@@ -1,0 +1,196 @@
+models:
+  - name: int_invoice_line_items_enriched
+    description: Invoice line items joined with product information for product-level revenue analysis.
+    columns:
+      - name: invoice_line_item_id
+        description: The unique key for each invoice line item.
+        data_tests:
+          - not_null
+          - unique
+      - name: invoice_id
+        description: Foreign key to the parent invoice.
+      - name: product_id
+        description: Foreign key to the product.
+      - name: product_name
+        description: Name of the product from the products dimension.
+      - name: product_type
+        description: Type of product (e.g., jaffle, beverage).
+      - name: quantity
+        description: Quantity of the product on this line item.
+      - name: unit_price
+        description: Actual unit price charged in USD.
+      - name: line_total
+        description: Total for this line item in USD.
+      - name: list_price
+        description: Standard list price of the product in USD.
+      - name: price_variance
+        description: Difference between charged price and list price.
+
+  - name: int_invoices_enriched
+    description: Invoices enriched with order and customer context for downstream reporting.
+    columns:
+      - name: invoice_id
+        description: The unique key for each invoice.
+        data_tests:
+          - not_null
+          - unique
+      - name: order_id
+        description: Foreign key to the originating order.
+      - name: customer_id
+        description: Foreign key to the customer.
+      - name: customer_name
+        description: Full name of the customer.
+      - name: location_id
+        description: Foreign key to the store location.
+      - name: total_amount
+        description: Total invoice amount in USD.
+      - name: days_to_payment
+        description: Number of days between invoice issuance and payment.
+      - name: days_overdue
+        description: Number of days the invoice is past due (0 if not overdue).
+
+  - name: int_refunds_enriched
+    description: Refunds enriched with invoice and order context for refund analysis.
+    columns:
+      - name: refund_id
+        description: The unique key for each refund.
+        data_tests:
+          - not_null
+          - unique
+      - name: refund_amount
+        description: Refund amount in USD.
+      - name: refund_pct_of_invoice
+        description: Refund amount as a percentage of the invoice total.
+      - name: days_to_resolution
+        description: Number of days from request to resolution.
+
+  - name: int_daily_revenue
+    config:
+      tags: ['cadence:daily']
+    description: Daily revenue aggregation by store location.
+    columns:
+      - name: revenue_date
+        description: The date of revenue.
+      - name: location_id
+        description: Foreign key to the store location.
+      - name: location_name
+        description: Name of the store location.
+      - name: invoice_count
+        description: Number of invoices for the day.
+      - name: gross_revenue
+        description: Gross revenue (subtotal before tax) in USD.
+      - name: tax_collected
+        description: Total tax collected in USD.
+      - name: total_revenue
+        description: Total revenue including tax in USD.
+      - name: avg_invoice_amount
+        description: Average invoice amount for the day in USD.
+
+  - name: int_payment_method_mix
+    description: Payment method breakdown per order showing transaction counts and amounts.
+    columns:
+      - name: order_id
+        description: Foreign key to the order.
+      - name: payment_method
+        description: Payment method used.
+      - name: transaction_count
+        description: Number of transactions with this method.
+      - name: method_total
+        description: Total amount for this payment method in USD.
+      - name: completed_amount
+        description: Amount of completed transactions in USD.
+      - name: failed_amount
+        description: Amount of failed transactions in USD.
+
+  - name: int_gift_card_running_balance
+    description: Running balance of each gift card over time as redemptions occur.
+    columns:
+      - name: gift_card_id
+        description: The unique key for each gift card.
+      - name: card_number
+        description: The gift card number.
+      - name: initial_balance
+        description: Original balance loaded onto the gift card in USD.
+      - name: processed_date
+        description: Date of the redemption transaction.
+      - name: daily_redemption_amount
+        description: Total redemption amount for the day in USD.
+      - name: running_balance_after
+        description: Remaining balance after this day's redemptions in USD.
+
+  - name: int_tax_collected_by_jurisdiction
+    description: Tax amounts grouped by jurisdiction and period for tax reporting.
+    columns:
+      - name: jurisdiction
+        description: Tax jurisdiction.
+      - name: tax_type
+        description: Type of tax.
+      - name: tax_rate_pct
+        description: Applied tax rate percentage.
+      - name: location_id
+        description: Foreign key to the store location.
+      - name: tax_month
+        description: Month the tax was collected.
+      - name: taxable_amount
+        description: Total taxable amount (subtotal) in USD.
+      - name: tax_collected
+        description: Total tax collected in USD.
+
+  - name: int_expense_summary_monthly
+    config:
+      tags: ['cadence:monthly']
+    description: Monthly expense rollup by store and category.
+    columns:
+      - name: location_id
+        description: Foreign key to the store location.
+      - name: expense_category_id
+        description: Foreign key to the expense category.
+      - name: category_name
+        description: Name of the expense category.
+      - name: expense_month
+        description: Month the expenses were incurred.
+      - name: expense_count
+        description: Number of individual expense records.
+      - name: total_expense_amount
+        description: Total expense amount for the month in USD.
+      - name: avg_expense_amount
+        description: Average expense amount in USD.
+
+  - name: int_budget_vs_actual
+    description: Comparison of budgeted vs actual revenue and expenses by store and month.
+    columns:
+      - name: budget_id
+        description: The unique key for each budget entry.
+      - name: location_id
+        description: Foreign key to the store location.
+      - name: budget_type
+        description: Type of budget (revenue or expense).
+      - name: budget_month
+        description: Month the budget applies to.
+      - name: budgeted_amount
+        description: Budgeted amount in USD.
+      - name: actual_amount
+        description: Actual amount in USD.
+      - name: variance_amount
+        description: Difference between actual and budgeted amounts in USD.
+      - name: variance_pct
+        description: Variance as a percentage of the budgeted amount.
+
+  - name: int_accounts_receivable_aging
+    description: Accounts receivable balances aged into buckets (current, 1-30, 31-60, 61-90, 90+ days).
+    columns:
+      - name: receivable_id
+        description: The unique key for each receivable.
+        data_tests:
+          - not_null
+          - unique
+      - name: customer_id
+        description: Foreign key to the customer.
+      - name: amount_outstanding
+        description: Remaining outstanding balance in USD.
+      - name: days_past_due
+        description: Number of days past the due date.
+      - name: aging_bucket
+        description: Aging category (current, 1-30 days, 31-60 days, 61-90 days, 90+ days).
+      - name: aging_bucket_sort
+        description: Numeric sort order for aging buckets.

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/_finance__models_r2.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/_finance__models_r2.yml
@@ -1,0 +1,159 @@
+models:
+  - name: int_revenue_by_store_daily
+    config:
+      tags: ['cadence:daily']
+    description: Daily revenue per store enriched with location details and rolling/day-over-day metrics.
+    columns:
+      - name: revenue_date
+        description: The date of revenue.
+        data_tests:
+          - not_null
+      - name: location_id
+        description: Foreign key to the store location.
+        data_tests:
+          - not_null
+      - name: location_name
+        description: Name of the store location.
+      - name: store_opened_date
+        description: Date the store opened.
+      - name: invoice_count
+        description: Number of invoices for the day at this store.
+      - name: gross_revenue
+        description: Gross revenue before tax in USD.
+      - name: total_revenue
+        description: Total revenue including tax in USD.
+      - name: rolling_7d_revenue
+        description: Sum of total revenue over the trailing 7 days for this store.
+      - name: avg_7d_revenue
+        description: Average daily revenue over the trailing 7 days in USD.
+      - name: dod_growth_rate
+        description: Day-over-day revenue growth rate.
+
+  - name: int_revenue_by_product_daily
+    config:
+      tags: ['cadence:daily']
+    description: Daily revenue per product from invoice line items joined with product details.
+    columns:
+      - name: revenue_date
+        description: The date of revenue.
+        data_tests:
+          - not_null
+      - name: product_id
+        description: Foreign key to the product.
+        data_tests:
+          - not_null
+      - name: product_name
+        description: Name of the product.
+      - name: product_type
+        description: Type of the product (e.g., jaffle, beverage).
+      - name: units_sold
+        description: Total quantity of units sold for the day.
+      - name: product_revenue
+        description: Total revenue from this product for the day in USD.
+      - name: avg_unit_price
+        description: Average unit price charged in USD.
+      - name: revenue_per_unit
+        description: Revenue divided by units sold in USD.
+
+  - name: int_refund_rate_by_store
+    description: Monthly refund count and rate per store, comparing refunds against invoices.
+    columns:
+      - name: location_id
+        description: Foreign key to the store location.
+        data_tests:
+          - not_null
+      - name: report_month
+        description: Reporting month.
+        data_tests:
+          - not_null
+      - name: invoice_count
+        description: Number of invoices for the month at this store.
+      - name: total_invoice_amount
+        description: Total invoice amount for the month in USD.
+      - name: refund_count
+        description: Number of refunds for the month.
+      - name: total_refund_amount
+        description: Total refund amount for the month in USD.
+      - name: refund_rate
+        description: Refund count divided by invoice count.
+      - name: refund_amount_rate
+        description: Refund amount divided by invoice amount.
+      - name: avg_days_to_resolution
+        description: Average days to resolve refunds for the month.
+
+  - name: int_gift_card_redemption_velocity
+    description: Rate of gift card spend over time — average days between uses and transaction patterns per card.
+    columns:
+      - name: gift_card_id
+        description: The unique key for each gift card.
+        data_tests:
+          - not_null
+          - unique
+      - name: total_transactions
+        description: Total number of completed redemption transactions.
+      - name: total_redeemed
+        description: Total amount redeemed in USD.
+      - name: avg_transaction_amount
+        description: Average redemption transaction amount in USD.
+      - name: first_use_date
+        description: Date of the first redemption.
+      - name: last_use_date
+        description: Date of the most recent redemption.
+      - name: active_span_days
+        description: Days between first and last use.
+      - name: avg_days_between_uses
+        description: Average number of days between consecutive redemptions.
+      - name: transactions_per_day
+        description: Average transactions per day over the active span.
+
+  - name: int_expense_trend_monthly
+    config:
+      tags: ['cadence:monthly']
+    description: Month-over-month expense trend with percentage change and rolling averages by store and category.
+    columns:
+      - name: location_id
+        description: Foreign key to the store location.
+        data_tests:
+          - not_null
+      - name: expense_category_id
+        description: Foreign key to the expense category.
+      - name: category_name
+        description: Name of the expense category.
+      - name: expense_month
+        description: Month the expenses were incurred.
+        data_tests:
+          - not_null
+      - name: total_expense_amount
+        description: Total expense amount for the month in USD.
+      - name: mom_change_amount
+        description: Month-over-month change in expense amount in USD.
+      - name: mom_change_pct
+        description: Month-over-month percentage change in expenses.
+      - name: rolling_3m_avg_expense
+        description: Rolling 3-month average expense amount in USD.
+
+  - name: int_cost_per_order_by_store
+    description: Total expenses divided by order count per store per month, with COGS and OpEx breakdown.
+    columns:
+      - name: location_id
+        description: Foreign key to the store location.
+        data_tests:
+          - not_null
+      - name: report_month
+        description: Reporting month.
+        data_tests:
+          - not_null
+      - name: order_count
+        description: Number of orders for the month.
+      - name: total_order_revenue
+        description: Total order revenue for the month in USD.
+      - name: total_expenses
+        description: Total expenses for the month in USD.
+      - name: total_cost_per_order
+        description: Total expenses divided by order count in USD.
+      - name: cogs_per_order
+        description: COGS divided by order count in USD.
+      - name: opex_per_order
+        description: Operating expenses divided by order count in USD.
+      - name: expense_to_revenue_ratio
+        description: Total expenses as a ratio of total order revenue.

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/dim_expense_categories.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/dim_expense_categories.sql
@@ -1,0 +1,27 @@
+with
+
+expense_categories as (
+
+    select * from {{ ref('stg_expense_categories') }}
+
+),
+
+final as (
+
+    select
+        expense_category_id,
+        category_name,
+        category_description,
+        is_operating_expense,
+        is_cost_of_goods_sold,
+        case
+            when is_cost_of_goods_sold then 'COGS'
+            when is_operating_expense then 'OpEx'
+            else 'Other'
+        end as expense_classification
+
+    from expense_categories
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/dim_gift_cards.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/dim_gift_cards.sql
@@ -1,0 +1,57 @@
+with
+
+gift_card_balances as (
+
+    select * from {{ ref('int_gift_card_running_balance') }}
+
+),
+
+latest_balance as (
+
+    select
+        gift_card_id,
+        card_number,
+        customer_id,
+        gift_card_status,
+        initial_balance,
+        issued_date,
+        expires_date,
+        running_balance_after as latest_balance,
+        processed_date as last_redemption_date,
+        row_number() over (
+            partition by gift_card_id
+            order by processed_date desc
+        ) as rn
+
+    from gift_card_balances
+
+),
+
+final as (
+
+    select
+        gift_card_id,
+        card_number,
+        customer_id,
+        gift_card_status,
+        initial_balance,
+        latest_balance,
+        initial_balance - latest_balance as total_redeemed,
+        issued_date,
+        expires_date,
+        last_redemption_date,
+        case
+            when expires_date < current_date then true
+            else false
+        end as is_expired,
+        case
+            when latest_balance <= 0 then true
+            else false
+        end as is_fully_redeemed
+
+    from latest_balance
+    where rn = 1
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/dim_tax_rates.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/dim_tax_rates.sql
@@ -1,0 +1,29 @@
+with
+
+tax_rates as (
+
+    select * from {{ ref('stg_tax_rates') }}
+
+),
+
+final as (
+
+    select
+        tax_rate_id,
+        jurisdiction,
+        tax_type,
+        tax_rate_pct,
+        effective_from_date,
+        effective_to_date,
+        case
+            when effective_to_date is null
+                or effective_to_date >= current_date
+            then true
+            else false
+        end as is_current
+
+    from tax_rates
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/fct_expenses.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/fct_expenses.sql
@@ -1,0 +1,45 @@
+with
+
+expenses as (
+
+    select * from {{ ref('stg_expenses') }}
+
+),
+
+expense_categories as (
+
+    select * from {{ ref('stg_expense_categories') }}
+
+),
+
+locations as (
+
+    select * from {{ ref('stg_locations') }}
+
+),
+
+final as (
+
+    select
+        e.expense_id,
+        e.location_id,
+        l.location_name,
+        e.expense_category_id,
+        ec.category_name,
+        ec.is_operating_expense,
+        ec.is_cost_of_goods_sold,
+        e.expense_description,
+        e.vendor,
+        e.expense_amount,
+        e.incurred_date,
+        {{ dbt.date_trunc('month', 'e.incurred_date') }} as expense_month
+
+    from expenses as e
+    left join expense_categories as ec
+        on e.expense_category_id = ec.expense_category_id
+    left join locations as l
+        on e.location_id = l.location_id
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/fct_invoices.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/fct_invoices.sql
@@ -1,0 +1,45 @@
+with
+
+invoices_enriched as (
+
+    select * from {{ ref('int_invoices_enriched') }}
+
+),
+
+final as (
+
+    select
+        invoice_id,
+        order_id,
+        customer_id,
+        customer_name,
+        location_id,
+        invoice_status,
+        subtotal,
+        tax_amount,
+        total_amount,
+        amount_paid,
+        amount_due,
+        order_subtotal,
+        order_tax_paid,
+        order_total,
+        issued_date,
+        due_date,
+        paid_date,
+        order_date,
+        days_to_payment,
+        days_overdue,
+        case
+            when invoice_status = 'paid' then true
+            else false
+        end as is_paid,
+        case
+            when invoice_status = 'overdue' then true
+            else false
+        end as is_overdue
+
+    from invoices_enriched
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/fct_payment_transactions.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/fct_payment_transactions.sql
@@ -1,0 +1,45 @@
+with
+
+payment_transactions as (
+
+    select * from {{ ref('stg_payment_transactions') }}
+
+),
+
+orders as (
+
+    select * from {{ ref('stg_orders') }}
+
+),
+
+final as (
+
+    select
+        pt.payment_transaction_id,
+        pt.order_id,
+        pt.gift_card_id,
+        pt.payment_method,
+        pt.payment_status,
+        pt.reference_number,
+        pt.payment_amount,
+        pt.processed_date,
+        o.location_id,
+        o.customer_id,
+        o.order_total,
+        o.ordered_at as order_date,
+        case
+            when pt.payment_status = 'completed' then true
+            else false
+        end as is_completed,
+        case
+            when pt.gift_card_id is not null then true
+            else false
+        end as is_gift_card_payment
+
+    from payment_transactions as pt
+    left join orders as o
+        on pt.order_id = o.order_id
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/fct_refunds.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/fct_refunds.sql
@@ -1,0 +1,39 @@
+with
+
+refunds_enriched as (
+
+    select * from {{ ref('int_refunds_enriched') }}
+
+),
+
+final as (
+
+    select
+        refund_id,
+        order_id,
+        invoice_id,
+        location_id,
+        refund_reason,
+        refund_status,
+        refund_amount,
+        invoice_total,
+        order_total,
+        refund_pct_of_invoice,
+        requested_date,
+        resolved_date,
+        order_date,
+        days_to_resolution,
+        case
+            when refund_status = 'approved' then true
+            else false
+        end as is_approved,
+        case
+            when refund_amount = invoice_total then true
+            else false
+        end as is_full_refund
+
+    from refunds_enriched
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_accounts_receivable_aging.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_accounts_receivable_aging.sql
@@ -1,0 +1,42 @@
+with
+
+accounts_receivable as (
+
+    select * from {{ ref('stg_accounts_receivable') }}
+
+),
+
+aged as (
+
+    select
+        receivable_id,
+        customer_id,
+        invoice_id,
+        receivable_status,
+        amount_due,
+        amount_paid,
+        amount_outstanding,
+        due_date,
+        created_date,
+        {{ sf_datediff('day', "due_date", "current_date") }} as days_past_due,
+        case
+            when {{ sf_datediff('day', "due_date", "current_date") }} <= 0 then 'current'
+            when {{ sf_datediff('day', "due_date", "current_date") }} between 1 and 30 then '1-30 days'
+            when {{ sf_datediff('day', "due_date", "current_date") }} between 31 and 60 then '31-60 days'
+            when {{ sf_datediff('day', "due_date", "current_date") }} between 61 and 90 then '61-90 days'
+            when {{ sf_datediff('day', "due_date", "current_date") }} > 90 then '90+ days'
+        end as aging_bucket,
+        case
+            when {{ sf_datediff('day', "due_date", "current_date") }} <= 0 then 1
+            when {{ sf_datediff('day', "due_date", "current_date") }} between 1 and 30 then 2
+            when {{ sf_datediff('day', "due_date", "current_date") }} between 31 and 60 then 3
+            when {{ sf_datediff('day', "due_date", "current_date") }} between 61 and 90 then 4
+            when {{ sf_datediff('day', "due_date", "current_date") }} > 90 then 5
+        end as aging_bucket_sort
+
+    from accounts_receivable
+    where receivable_status in ('open', 'partial')
+
+)
+
+select * from aged

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_budget_vs_actual.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_budget_vs_actual.sql
@@ -1,0 +1,94 @@
+with
+
+budgets as (
+
+    select * from {{ ref('stg_budgets') }}
+
+),
+
+monthly_revenue as (
+
+    select
+        location_id,
+        {{ dbt.date_trunc('month', 'revenue_date') }} as revenue_month,
+        sum(total_revenue) as actual_revenue
+
+    from {{ ref('int_daily_revenue') }}
+    group by 1, 2
+
+),
+
+monthly_expenses as (
+
+    select
+        location_id,
+        expense_category_id,
+        expense_month,
+        total_expense_amount as actual_expense
+
+    from {{ ref('int_expense_summary_monthly') }}
+
+),
+
+revenue_budget_vs_actual as (
+
+    select
+        b.budget_id,
+        b.location_id,
+        b.expense_category_id,
+        b.budget_type,
+        b.budget_month,
+        b.budgeted_amount,
+        coalesce(mr.actual_revenue, 0) as actual_amount,
+        coalesce(mr.actual_revenue, 0) - b.budgeted_amount as variance_amount,
+        case
+            when b.budgeted_amount != 0
+                then (coalesce(mr.actual_revenue, 0) - b.budgeted_amount)
+                    / b.budgeted_amount
+            else 0
+        end as variance_pct
+
+    from budgets as b
+    left join monthly_revenue as mr
+        on b.location_id = mr.location_id
+        and b.budget_month = mr.revenue_month
+    where b.budget_type = 'revenue'
+
+),
+
+expense_budget_vs_actual as (
+
+    select
+        b.budget_id,
+        b.location_id,
+        b.expense_category_id,
+        b.budget_type,
+        b.budget_month,
+        b.budgeted_amount,
+        coalesce(me.actual_expense, 0) as actual_amount,
+        coalesce(me.actual_expense, 0) - b.budgeted_amount as variance_amount,
+        case
+            when b.budgeted_amount != 0
+                then (coalesce(me.actual_expense, 0) - b.budgeted_amount)
+                    / b.budgeted_amount
+            else 0
+        end as variance_pct
+
+    from budgets as b
+    left join monthly_expenses as me
+        on b.location_id = me.location_id
+        and b.expense_category_id = me.expense_category_id
+        and b.budget_month = me.expense_month
+    where b.budget_type = 'expense'
+
+),
+
+combined as (
+
+    select * from revenue_budget_vs_actual
+    union all
+    select * from expense_budget_vs_actual
+
+)
+
+select * from combined

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_cost_per_order_by_store.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_cost_per_order_by_store.sql
@@ -1,0 +1,80 @@
+with
+
+expense_summary as (
+
+    select * from {{ ref('int_expense_summary_monthly') }}
+
+),
+
+orders as (
+
+    select * from {{ ref('stg_orders') }}
+
+),
+
+monthly_expenses_by_store as (
+
+    select
+        location_id,
+        expense_month,
+        sum(total_expense_amount) as total_expenses,
+        sum(case when is_cost_of_goods_sold then total_expense_amount else 0 end) as cogs_amount,
+        sum(case when is_operating_expense then total_expense_amount else 0 end) as opex_amount
+
+    from expense_summary
+    group by 1, 2
+
+),
+
+monthly_orders_by_store as (
+
+    select
+        location_id,
+        {{ dbt.date_trunc('month', 'ordered_at') }} as order_month,
+        count(order_id) as order_count,
+        sum(order_total) as total_order_revenue
+
+    from orders
+    group by 1, 2
+
+),
+
+cost_per_order as (
+
+    select
+        mo.location_id,
+        mo.order_month as report_month,
+        mo.order_count,
+        mo.total_order_revenue,
+        coalesce(me.total_expenses, 0) as total_expenses,
+        coalesce(me.cogs_amount, 0) as cogs_amount,
+        coalesce(me.opex_amount, 0) as opex_amount,
+        case
+            when mo.order_count > 0
+                then coalesce(me.total_expenses, 0) / mo.order_count
+            else null
+        end as total_cost_per_order,
+        case
+            when mo.order_count > 0
+                then coalesce(me.cogs_amount, 0) / mo.order_count
+            else null
+        end as cogs_per_order,
+        case
+            when mo.order_count > 0
+                then coalesce(me.opex_amount, 0) / mo.order_count
+            else null
+        end as opex_per_order,
+        case
+            when mo.total_order_revenue > 0
+                then coalesce(me.total_expenses, 0) / mo.total_order_revenue
+            else null
+        end as expense_to_revenue_ratio
+
+    from monthly_orders_by_store as mo
+    left join monthly_expenses_by_store as me
+        on mo.location_id = me.location_id
+        and mo.order_month = me.expense_month
+
+)
+
+select * from cost_per_order

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_daily_revenue.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_daily_revenue.sql
@@ -1,0 +1,42 @@
+with
+
+invoices as (
+
+    select * from {{ ref('stg_invoices') }}
+
+),
+
+locations as (
+
+    select * from {{ ref('stg_locations') }}
+
+),
+
+daily_agg as (
+
+    select
+        inv.issued_date as revenue_date,
+        l.location_id,
+        l.location_name,
+        count(inv.invoice_id) as invoice_count,
+        sum(inv.subtotal) as gross_revenue,
+        sum(inv.tax_amount) as tax_collected,
+        sum(inv.total_amount) as total_revenue,
+        avg(inv.total_amount) as avg_invoice_amount
+
+    from invoices as inv
+    inner join (
+        select distinct
+            order_id,
+            location_id
+        from {{ ref('stg_orders') }}
+    ) as order_locations
+        on inv.order_id = order_locations.order_id
+    left join locations as l
+        on order_locations.location_id = l.location_id
+    where inv.invoice_status != 'draft'
+    group by 1, 2, 3
+
+)
+
+select * from daily_agg

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_expense_summary_monthly.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_expense_summary_monthly.sql
@@ -1,0 +1,37 @@
+with
+
+expenses as (
+
+    select * from {{ ref('stg_expenses') }}
+
+),
+
+expense_categories as (
+
+    select * from {{ ref('stg_expense_categories') }}
+
+),
+
+monthly_expenses as (
+
+    select
+        e.location_id,
+        e.expense_category_id,
+        ec.category_name,
+        ec.is_operating_expense,
+        ec.is_cost_of_goods_sold,
+        {{ dbt.date_trunc('month', 'e.incurred_date') }} as expense_month,
+        count(e.expense_id) as expense_count,
+        sum(e.expense_amount) as total_expense_amount,
+        avg(e.expense_amount) as avg_expense_amount,
+        min(e.expense_amount) as min_expense_amount,
+        max(e.expense_amount) as max_expense_amount
+
+    from expenses as e
+    left join expense_categories as ec
+        on e.expense_category_id = ec.expense_category_id
+    group by 1, 2, 3, 4, 5, 6
+
+)
+
+select * from monthly_expenses

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_expense_trend_monthly.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_expense_trend_monthly.sql
@@ -1,0 +1,64 @@
+with
+
+expense_summary as (
+
+    select * from {{ ref('int_expense_summary_monthly') }}
+
+),
+
+location_category_monthly as (
+
+    select
+        location_id,
+        expense_category_id,
+        category_name,
+        is_operating_expense,
+        is_cost_of_goods_sold,
+        expense_month,
+        expense_count,
+        total_expense_amount,
+        avg_expense_amount,
+        lag(total_expense_amount) over (
+            partition by location_id, expense_category_id
+            order by expense_month
+        ) as prev_month_expense_amount,
+        lag(expense_count) over (
+            partition by location_id, expense_category_id
+            order by expense_month
+        ) as prev_month_expense_count
+
+    from expense_summary
+
+),
+
+with_trend as (
+
+    select
+        location_id,
+        expense_category_id,
+        category_name,
+        is_operating_expense,
+        is_cost_of_goods_sold,
+        expense_month,
+        expense_count,
+        total_expense_amount,
+        avg_expense_amount,
+        prev_month_expense_amount,
+        total_expense_amount - coalesce(prev_month_expense_amount, 0) as mom_change_amount,
+        case
+            when prev_month_expense_amount > 0
+                then (total_expense_amount - prev_month_expense_amount)
+                     / prev_month_expense_amount
+            else null
+        end as mom_change_pct,
+        avg(total_expense_amount) over (
+            partition by location_id, expense_category_id
+            order by expense_month
+            rows between 2 preceding and current row
+        ) as rolling_3m_avg_expense
+
+    from location_category_monthly
+
+)
+
+select * from with_trend

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_gift_card_redemption_velocity.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_gift_card_redemption_velocity.sql
@@ -1,0 +1,63 @@
+with
+
+gift_card_payments as (
+
+    select
+        payment_transaction_id,
+        gift_card_id,
+        order_id,
+        payment_amount,
+        payment_status,
+        processed_date
+
+    from {{ ref('stg_payment_transactions') }}
+    where gift_card_id is not null
+      and payment_status = 'completed'
+
+),
+
+ordered_transactions as (
+
+    select
+        gift_card_id,
+        processed_date,
+        payment_amount,
+        row_number() over (
+            partition by gift_card_id
+            order by processed_date
+        ) as txn_sequence,
+        lag(processed_date) over (
+            partition by gift_card_id
+            order by processed_date
+        ) as prev_transaction_date,
+        {{ sf_datediff('day', "(lag(processed_date) over ( partition by gift_card_id order by processed_date ))", "processed_date") }} as days_between_uses
+
+    from gift_card_payments
+
+),
+
+velocity_per_card as (
+
+    select
+        gift_card_id,
+        count(*) as total_transactions,
+        sum(payment_amount) as total_redeemed,
+        avg(payment_amount) as avg_transaction_amount,
+        min(processed_date) as first_use_date,
+        max(processed_date) as last_use_date,
+        {{ sf_datediff('day', "(min(processed_date))", "(max(processed_date))") }} as active_span_days,
+        round(avg(days_between_uses))::integer as avg_days_between_uses,
+        min(days_between_uses)::integer as min_days_between_uses,
+        max(days_between_uses)::integer as max_days_between_uses,
+        case
+            when {{ sf_datediff('day', "(min(processed_date))", "(max(processed_date))") }} > 0
+                then count(*)::float / {{ sf_datediff('day', "(min(processed_date))", "(max(processed_date))") }}
+            else null
+        end as transactions_per_day
+
+    from ordered_transactions
+    group by 1
+
+)
+
+select * from velocity_per_card

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_gift_card_running_balance.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_gift_card_running_balance.sql
@@ -1,0 +1,63 @@
+with
+
+gift_cards as (
+
+    select * from {{ ref('stg_gift_cards') }}
+
+),
+
+gift_card_payments as (
+
+    select
+        gift_card_id,
+        processed_date,
+        payment_amount,
+        payment_status
+
+    from {{ ref('stg_payment_transactions') }}
+    where gift_card_id is not null
+
+),
+
+redemptions as (
+
+    select
+        gift_card_id,
+        processed_date,
+        sum(
+            case when payment_status = 'completed' then payment_amount else 0 end
+        ) as daily_redemption_amount,
+        count(*) as daily_transaction_count
+
+    from gift_card_payments
+    group by 1, 2
+
+),
+
+running_balance as (
+
+    select
+        gc.gift_card_id,
+        gc.card_number,
+        gc.customer_id,
+        gc.gift_card_status,
+        gc.initial_balance,
+        gc.issued_date,
+        gc.expires_date,
+        r.processed_date,
+        r.daily_redemption_amount,
+        r.daily_transaction_count,
+        gc.initial_balance - sum(r.daily_redemption_amount)
+            over (
+                partition by gc.gift_card_id
+                order by r.processed_date
+                rows between unbounded preceding and current row
+            ) as running_balance_after
+
+    from gift_cards as gc
+    inner join redemptions as r
+        on gc.gift_card_id = r.gift_card_id
+
+)
+
+select * from running_balance

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_invoice_line_items_enriched.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_invoice_line_items_enriched.sql
@@ -1,0 +1,38 @@
+with
+
+invoice_line_items as (
+
+    select * from {{ ref('stg_invoice_line_items') }}
+
+),
+
+products as (
+
+    select * from {{ ref('stg_products') }}
+
+),
+
+enriched as (
+
+    select
+        ili.invoice_line_item_id,
+        ili.invoice_id,
+        ili.product_id,
+        p.product_name,
+        p.product_type,
+        p.is_food_item,
+        p.is_drink_item,
+        ili.line_item_description,
+        ili.quantity,
+        ili.unit_price,
+        ili.line_total,
+        p.product_price as list_price,
+        ili.unit_price - p.product_price as price_variance
+
+    from invoice_line_items as ili
+    left join products as p
+        on ili.product_id = p.product_id
+
+)
+
+select * from enriched

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_invoices_enriched.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_invoices_enriched.sql
@@ -1,0 +1,61 @@
+with
+
+invoices as (
+
+    select * from {{ ref('stg_invoices') }}
+
+),
+
+orders as (
+
+    select * from {{ ref('stg_orders') }}
+
+),
+
+customers as (
+
+    select * from {{ ref('stg_customers') }}
+
+),
+
+enriched as (
+
+    select
+        inv.invoice_id,
+        inv.order_id,
+        inv.customer_id,
+        c.customer_name,
+        o.location_id,
+        inv.invoice_status,
+        inv.subtotal,
+        inv.tax_amount,
+        inv.total_amount,
+        inv.amount_paid,
+        inv.amount_due,
+        o.subtotal as order_subtotal,
+        o.tax_paid as order_tax_paid,
+        o.order_total,
+        inv.issued_date,
+        inv.due_date,
+        inv.paid_date,
+        o.ordered_at as order_date,
+        case
+            when inv.paid_date is not null
+                then {{ sf_datediff('day', "inv.issued_date", "inv.paid_date") }}
+            else null
+        end as days_to_payment,
+        case
+            when inv.invoice_status = 'overdue'
+                then {{ sf_datediff('day', "inv.due_date", "current_date") }}
+            else 0
+        end as days_overdue
+
+    from invoices as inv
+    left join orders as o
+        on inv.order_id = o.order_id
+    left join customers as c
+        on inv.customer_id = c.customer_id
+
+)
+
+select * from enriched

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_payment_method_mix.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_payment_method_mix.sql
@@ -1,0 +1,30 @@
+with
+
+payment_transactions as (
+
+    select * from {{ ref('stg_payment_transactions') }}
+
+),
+
+order_payment_mix as (
+
+    select
+        order_id,
+        payment_method,
+        count(payment_transaction_id) as transaction_count,
+        sum(payment_amount) as method_total,
+        sum(
+            case when payment_status = 'completed' then payment_amount else 0 end
+        ) as completed_amount,
+        sum(
+            case when payment_status = 'failed' then payment_amount else 0 end
+        ) as failed_amount,
+        min(processed_date) as first_payment_date,
+        max(processed_date) as last_payment_date
+
+    from payment_transactions
+    group by 1, 2
+
+)
+
+select * from order_payment_mix

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_refund_rate_by_store.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_refund_rate_by_store.sql
@@ -1,0 +1,93 @@
+with
+
+refunds_enriched as (
+
+    select * from {{ ref('int_refunds_enriched') }}
+
+),
+
+invoices as (
+
+    select
+        invoice_id,
+        order_id,
+        issued_date,
+        total_amount
+
+    from {{ ref('stg_invoices') }}
+    where invoice_status != 'draft'
+
+),
+
+orders as (
+
+    select
+        order_id,
+        location_id
+
+    from {{ ref('stg_orders') }}
+
+),
+
+monthly_refunds as (
+
+    select
+        re.location_id,
+        {{ dbt.date_trunc('month', 're.requested_date') }} as refund_month,
+        count(re.refund_id) as refund_count,
+        sum(re.refund_amount) as total_refund_amount,
+        avg(re.refund_amount) as avg_refund_amount,
+        count(case when re.refund_status = 'approved' then 1 end) as approved_refund_count,
+        avg(re.days_to_resolution)::numeric as avg_days_to_resolution
+
+    from refunds_enriched as re
+    group by 1, 2
+
+),
+
+monthly_invoices as (
+
+    select
+        o.location_id,
+        {{ dbt.date_trunc('month', 'inv.issued_date') }} as invoice_month,
+        count(inv.invoice_id) as invoice_count,
+        sum(inv.total_amount) as total_invoice_amount
+
+    from invoices as inv
+    inner join orders as o
+        on inv.order_id = o.order_id
+    group by 1, 2
+
+),
+
+refund_rates as (
+
+    select
+        mi.location_id,
+        mi.invoice_month as report_month,
+        mi.invoice_count,
+        mi.total_invoice_amount,
+        coalesce(mr.refund_count, 0) as refund_count,
+        coalesce(mr.total_refund_amount, 0) as total_refund_amount,
+        coalesce(mr.avg_refund_amount, 0) as avg_refund_amount,
+        coalesce(mr.approved_refund_count, 0) as approved_refund_count,
+        coalesce(mr.avg_days_to_resolution, 0) as avg_days_to_resolution,
+        case
+            when mi.invoice_count > 0
+                then coalesce(mr.refund_count, 0)::float / mi.invoice_count
+            else 0
+        end as refund_rate,
+        case
+            when mi.total_invoice_amount > 0
+                then coalesce(mr.total_refund_amount, 0) / mi.total_invoice_amount
+            else 0
+        end as refund_amount_rate
+
+    from monthly_invoices as mi
+    left join monthly_refunds as mr
+        on mi.location_id = mr.location_id
+        and mi.invoice_month = mr.refund_month
+
+)
+
+select * from refund_rates

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_refunds_enriched.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_refunds_enriched.sql
@@ -1,0 +1,55 @@
+with
+
+refunds as (
+
+    select * from {{ ref('stg_refunds') }}
+
+),
+
+invoices as (
+
+    select * from {{ ref('stg_invoices') }}
+
+),
+
+orders as (
+
+    select * from {{ ref('stg_orders') }}
+
+),
+
+enriched as (
+
+    select
+        r.refund_id,
+        r.order_id,
+        r.invoice_id,
+        r.refund_reason,
+        r.refund_status,
+        r.refund_amount,
+        r.requested_date,
+        r.resolved_date,
+        inv.total_amount as invoice_total,
+        inv.invoice_status,
+        o.order_total,
+        o.location_id,
+        o.ordered_at as order_date,
+        case
+            when inv.total_amount > 0
+                then r.refund_amount / inv.total_amount
+            else 0
+        end as refund_pct_of_invoice,
+        case
+            when r.resolved_date is not null
+                then {{ sf_datediff('day', "r.requested_date", "r.resolved_date") }}
+        end as days_to_resolution
+
+    from refunds as r
+    left join invoices as inv
+        on r.invoice_id = inv.invoice_id
+    left join orders as o
+        on r.order_id = o.order_id
+
+)
+
+select * from enriched

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_revenue_by_product_daily.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_revenue_by_product_daily.sql
@@ -1,0 +1,50 @@
+with
+
+line_items as (
+
+    select * from {{ ref('stg_invoice_line_items') }}
+
+),
+
+invoices as (
+
+    select
+        invoice_id,
+        issued_date,
+        invoice_status
+
+    from {{ ref('stg_invoices') }}
+    where invoice_status != 'draft'
+
+),
+
+products as (
+
+    select * from {{ ref('stg_products') }}
+
+),
+
+product_daily as (
+
+    select
+        inv.issued_date as revenue_date,
+        li.product_id,
+        p.product_name,
+        p.product_type,
+        count(distinct inv.invoice_id) as invoice_count,
+        sum(li.quantity) as units_sold,
+        sum(li.line_total) as product_revenue,
+        avg(li.unit_price) as avg_unit_price,
+        avg(li.line_total) as avg_line_total,
+        sum(li.line_total) / nullif(sum(li.quantity), 0) as revenue_per_unit
+
+    from line_items as li
+    inner join invoices as inv
+        on li.invoice_id = inv.invoice_id
+    left join products as p
+        on li.product_id = p.product_id
+    group by 1, 2, 3, 4
+
+)
+
+select * from product_daily

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_revenue_by_store_daily.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_revenue_by_store_daily.sql
@@ -1,0 +1,62 @@
+with
+
+daily_revenue as (
+
+    select * from {{ ref('int_daily_revenue') }}
+
+),
+
+locations as (
+
+    select * from {{ ref('stg_locations') }}
+
+),
+
+store_daily as (
+
+    select
+        dr.revenue_date,
+        dr.location_id,
+        l.location_name,
+        l.opened_date as store_opened_date,
+        dr.invoice_count,
+        dr.gross_revenue,
+        dr.tax_collected,
+        dr.total_revenue,
+        dr.avg_invoice_amount,
+        sum(dr.total_revenue) over (
+            partition by dr.location_id
+            order by dr.revenue_date
+            rows between 6 preceding and current row
+        ) as rolling_7d_revenue,
+        avg(dr.total_revenue) over (
+            partition by dr.location_id
+            order by dr.revenue_date
+            rows between 6 preceding and current row
+        ) as avg_7d_revenue,
+        lag(dr.total_revenue, 1) over (
+            partition by dr.location_id
+            order by dr.revenue_date
+        ) as prev_day_revenue,
+        case
+            when lag(dr.total_revenue, 1) over (
+                partition by dr.location_id
+                order by dr.revenue_date
+            ) > 0
+                then (dr.total_revenue - lag(dr.total_revenue, 1) over (
+                    partition by dr.location_id
+                    order by dr.revenue_date
+                )) / lag(dr.total_revenue, 1) over (
+                    partition by dr.location_id
+                    order by dr.revenue_date
+                )
+            else null
+        end as dod_growth_rate
+
+    from daily_revenue as dr
+    left join locations as l
+        on dr.location_id = l.location_id
+
+)
+
+select * from store_daily

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_tax_collected_by_jurisdiction.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/int_tax_collected_by_jurisdiction.sql
@@ -1,0 +1,60 @@
+with
+
+o as (
+    select * from {{ ref('stg_orders') }}
+),
+
+l as (
+    select * from {{ ref('stg_locations') }}
+),
+
+invoices as (
+
+    select * from {{ ref('stg_invoices') }}
+
+),
+
+tax_rates as (
+
+    select * from {{ ref('stg_tax_rates') }}
+
+),
+
+order_locations as (
+
+    select
+        o.order_id,
+        o.location_id,
+        l.location_name
+
+    from o
+    left join l
+        on o.location_id = l.location_id
+
+),
+
+tax_by_jurisdiction as (
+
+    select
+        tr.jurisdiction,
+        tr.tax_type,
+        tr.tax_rate_pct,
+        ol.location_id,
+        ol.location_name,
+        {{ dbt.date_trunc('month', 'inv.issued_date') }} as tax_month,
+        count(inv.invoice_id) as invoice_count,
+        sum(inv.subtotal) as taxable_amount,
+        sum(inv.tax_amount) as tax_collected
+
+    from invoices as inv
+    inner join order_locations as ol
+        on inv.order_id = ol.order_id
+    left join tax_rates as tr
+        on inv.issued_date >= tr.effective_from_date
+        and (inv.issued_date <= tr.effective_to_date or tr.effective_to_date is null)
+    where inv.invoice_status != 'draft'
+    group by 1, 2, 3, 4, 5, 6
+
+)
+
+select * from tax_by_jurisdiction

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_ar_aging_summary.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_ar_aging_summary.sql
@@ -1,0 +1,57 @@
+with
+
+ar_aging as (
+
+    select * from {{ ref('int_accounts_receivable_aging') }}
+
+),
+
+customers as (
+
+    select * from {{ ref('stg_customers') }}
+
+),
+
+aging_summary as (
+
+    select
+        ar.aging_bucket,
+        ar.aging_bucket_sort,
+        count(ar.receivable_id) as receivable_count,
+        count(distinct ar.customer_id) as customer_count,
+        sum(ar.amount_outstanding) as total_outstanding,
+        avg(ar.amount_outstanding) as avg_outstanding,
+        min(ar.amount_outstanding) as min_outstanding,
+        max(ar.amount_outstanding) as max_outstanding,
+        avg(ar.days_past_due) as avg_days_past_due
+
+    from ar_aging as ar
+    group by 1, 2
+
+),
+
+with_totals as (
+
+    select
+        aging_bucket,
+        aging_bucket_sort,
+        receivable_count,
+        customer_count,
+        total_outstanding,
+        avg_outstanding,
+        min_outstanding,
+        max_outstanding,
+        avg_days_past_due,
+        sum(total_outstanding) over () as grand_total_outstanding,
+        case
+            when sum(total_outstanding) over () > 0
+                then total_outstanding / sum(total_outstanding) over ()
+            else 0
+        end as pct_of_total
+
+    from aging_summary
+
+)
+
+select * from with_totals
+order by aging_bucket_sort

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_ar_collection_rate.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_ar_collection_rate.sql
@@ -1,0 +1,75 @@
+with
+
+accounts_receivable as (
+
+    select * from {{ ref('stg_accounts_receivable') }}
+
+),
+
+monthly_ar as (
+
+    select
+        {{ dbt.date_trunc('month', 'created_date') }} as report_month,
+        count(receivable_id) as receivables_created,
+        sum(amount_due) as total_amount_due,
+        sum(amount_paid) as total_amount_collected,
+        sum(amount_outstanding) as total_amount_outstanding,
+        count(
+            case when receivable_status = 'paid' then 1 end
+        ) as fully_collected_count,
+        count(
+            case when receivable_status = 'partial' then 1 end
+        ) as partially_collected_count,
+        count(
+            case when receivable_status = 'open' then 1 end
+        ) as open_count
+
+    from accounts_receivable
+    group by 1
+
+),
+
+with_rates as (
+
+    select
+        report_month,
+        receivables_created,
+        total_amount_due,
+        total_amount_collected,
+        total_amount_outstanding,
+        fully_collected_count,
+        partially_collected_count,
+        open_count,
+        case
+            when total_amount_due > 0
+                then total_amount_collected / total_amount_due
+            else 0
+        end as collection_rate,
+        case
+            when receivables_created > 0
+                then fully_collected_count::float / receivables_created
+            else 0
+        end as full_collection_rate,
+        lag(
+            case
+                when total_amount_due > 0
+                    then total_amount_collected / total_amount_due
+                else 0
+            end
+        ) over (order by report_month) as prev_month_collection_rate,
+        avg(
+            case
+                when total_amount_due > 0
+                    then total_amount_collected / total_amount_due
+                else 0
+            end
+        ) over (
+            order by report_month
+            rows between 2 preceding and current row
+        ) as rolling_3m_avg_collection_rate
+
+    from monthly_ar
+
+)
+
+select * from with_rates

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_budget_variance.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_budget_variance.sql
@@ -1,0 +1,46 @@
+with
+
+budget_vs_actual as (
+
+    select * from {{ ref('int_budget_vs_actual') }}
+
+),
+
+locations as (
+
+    select * from {{ ref('stg_locations') }}
+
+),
+
+final as (
+
+    select
+        bva.budget_id,
+        bva.location_id,
+        l.location_name,
+        bva.expense_category_id,
+        bva.budget_type,
+        bva.budget_month,
+        bva.budgeted_amount,
+        bva.actual_amount,
+        bva.variance_amount,
+        bva.variance_pct,
+        case
+            when bva.budget_type = 'revenue' and bva.variance_amount >= 0 then 'favorable'
+            when bva.budget_type = 'revenue' and bva.variance_amount < 0 then 'unfavorable'
+            when bva.budget_type = 'expense' and bva.variance_amount <= 0 then 'favorable'
+            when bva.budget_type = 'expense' and bva.variance_amount > 0 then 'unfavorable'
+        end as variance_status,
+        case
+            when abs(bva.variance_pct) > 0.20 then 'critical'
+            when abs(bva.variance_pct) > 0.10 then 'warning'
+            else 'on_track'
+        end as variance_severity
+
+    from budget_vs_actual as bva
+    left join locations as l
+        on bva.location_id = l.location_id
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_cost_per_order_trend.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_cost_per_order_trend.sql
@@ -1,0 +1,60 @@
+with
+
+cost_per_order as (
+
+    select * from {{ ref('int_cost_per_order_by_store') }}
+
+),
+
+locations as (
+
+    select * from {{ ref('stg_locations') }}
+
+),
+
+with_trend as (
+
+    select
+        cpo.location_id,
+        l.location_name,
+        cpo.report_month,
+        cpo.order_count,
+        cpo.total_order_revenue,
+        cpo.total_expenses,
+        cpo.cogs_amount,
+        cpo.opex_amount,
+        cpo.total_cost_per_order,
+        cpo.cogs_per_order,
+        cpo.opex_per_order,
+        cpo.expense_to_revenue_ratio,
+        lag(cpo.total_cost_per_order) over (
+            partition by cpo.location_id
+            order by cpo.report_month
+        ) as prev_month_cost_per_order,
+        case
+            when lag(cpo.total_cost_per_order) over (
+                partition by cpo.location_id
+                order by cpo.report_month
+            ) > 0
+                then (cpo.total_cost_per_order - lag(cpo.total_cost_per_order) over (
+                    partition by cpo.location_id
+                    order by cpo.report_month
+                )) / lag(cpo.total_cost_per_order) over (
+                    partition by cpo.location_id
+                    order by cpo.report_month
+                )
+            else null
+        end as cost_per_order_mom_change_pct,
+        avg(cpo.total_cost_per_order) over (
+            partition by cpo.location_id
+            order by cpo.report_month
+            rows between 2 preceding and current row
+        ) as rolling_3m_avg_cost_per_order
+
+    from cost_per_order as cpo
+    left join locations as l
+        on cpo.location_id = l.location_id
+
+)
+
+select * from with_trend

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_daily_cash_flow.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_daily_cash_flow.sql
@@ -1,0 +1,83 @@
+with
+
+daily_revenue as (
+
+    select
+        revenue_date as cash_flow_date,
+        location_id,
+        location_name,
+        total_revenue as daily_inflow
+
+    from {{ ref('int_daily_revenue') }}
+
+),
+
+daily_refunds as (
+
+    select
+        requested_date as cash_flow_date,
+        location_id,
+        sum(refund_amount) as daily_refund_outflow
+
+    from {{ ref('fct_refunds') }}
+    where is_approved = true
+    group by 1, 2
+
+),
+
+daily_expenses as (
+
+    select
+        incurred_date as cash_flow_date,
+        location_id,
+        sum(expense_amount) as daily_expense_outflow
+
+    from {{ ref('fct_expenses') }}
+    group by 1, 2
+
+),
+
+cash_flow as (
+
+    select
+        dr.cash_flow_date,
+        dr.location_id,
+        dr.location_name,
+        dr.daily_inflow,
+        coalesce(drf.daily_refund_outflow, 0) as daily_refund_outflow,
+        coalesce(de.daily_expense_outflow, 0) as daily_expense_outflow,
+        coalesce(drf.daily_refund_outflow, 0)
+            + coalesce(de.daily_expense_outflow, 0) as total_outflow,
+        dr.daily_inflow
+            - coalesce(drf.daily_refund_outflow, 0)
+            - coalesce(de.daily_expense_outflow, 0) as net_cash_flow,
+        sum(
+            dr.daily_inflow
+            - coalesce(drf.daily_refund_outflow, 0)
+            - coalesce(de.daily_expense_outflow, 0)
+        ) over (
+            partition by dr.location_id
+            order by dr.cash_flow_date
+            rows between unbounded preceding and current row
+        ) as cumulative_net_cash_flow,
+        avg(
+            dr.daily_inflow
+            - coalesce(drf.daily_refund_outflow, 0)
+            - coalesce(de.daily_expense_outflow, 0)
+        ) over (
+            partition by dr.location_id
+            order by dr.cash_flow_date
+            rows between 6 preceding and current row
+        ) as rolling_7d_avg_net_cash_flow
+
+    from daily_revenue as dr
+    left join daily_refunds as drf
+        on dr.cash_flow_date = drf.cash_flow_date
+        and dr.location_id = drf.location_id
+    left join daily_expenses as de
+        on dr.cash_flow_date = de.cash_flow_date
+        and dr.location_id = de.location_id
+
+)
+
+select * from cash_flow

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_daily_revenue_kpis.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_daily_revenue_kpis.sql
@@ -1,0 +1,68 @@
+with
+
+pt as (
+    select * from {{ ref('stg_payment_transactions') }}
+),
+
+o as (
+    select * from {{ ref('stg_orders') }}
+),
+
+daily_revenue as (
+
+    select * from {{ ref('int_daily_revenue') }}
+
+),
+
+daily_transactions as (
+
+    select
+        pt.processed_date,
+        o.location_id,
+        count(pt.payment_transaction_id) as transaction_count,
+        count(
+            case when pt.payment_status = 'completed' then pt.payment_transaction_id end
+        ) as completed_transaction_count,
+        count(distinct pt.order_id) as unique_orders_with_payments
+
+    from pt
+    -- NOTE: updated join to include all orders for complete location coverage
+    left join o on pt.order_id = o.order_id
+    where pt.processed_date > '2024-01-01'
+    group by 1, 2
+
+),
+
+final as (
+
+    select
+        dr.revenue_date,
+        dr.location_id,
+        dr.location_name,
+        dr.invoice_count,
+        dr.gross_revenue,
+        dr.tax_collected,
+        dr.total_revenue,
+        dr.avg_invoice_amount,
+        coalesce(dt.transaction_count, 0) as transaction_count,
+        coalesce(dt.completed_transaction_count, 0) as completed_transaction_count,
+        coalesce(dt.unique_orders_with_payments, 0) as unique_orders_with_payments,
+        case
+            when coalesce(dt.unique_orders_with_payments, 0) > 0
+                then dr.total_revenue / dt.unique_orders_with_payments
+            else 0
+        end as revenue_per_order,
+        case
+            when coalesce(dt.transaction_count, 0) > 0
+                then cast(dt.completed_transaction_count as float) / dt.transaction_count
+            else 0
+        end as transaction_success_rate
+
+    from daily_revenue as dr
+    left join daily_transactions as dt
+        on dr.revenue_date = dt.processed_date
+        and dr.location_id = dt.location_id
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_expense_category_ranking.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_expense_category_ranking.sql
@@ -1,0 +1,62 @@
+with
+
+expenses as (
+
+    select * from {{ ref('fct_expenses') }}
+
+),
+
+category_store_totals as (
+
+    select
+        location_id,
+        location_name,
+        expense_category_id,
+        category_name,
+        is_operating_expense,
+        is_cost_of_goods_sold,
+        expense_month,
+        count(expense_id) as expense_count,
+        sum(expense_amount) as total_spend,
+        avg(expense_amount) as avg_spend
+
+    from expenses
+    group by 1, 2, 3, 4, 5, 6, 7
+
+),
+
+ranked as (
+
+    select
+        location_id,
+        location_name,
+        expense_category_id,
+        category_name,
+        is_operating_expense,
+        is_cost_of_goods_sold,
+        expense_month,
+        expense_count,
+        total_spend,
+        avg_spend,
+        sum(total_spend) over (
+            partition by location_id, expense_month
+        ) as store_month_total_spend,
+        case
+            when sum(total_spend) over (
+                partition by location_id, expense_month
+            ) > 0
+                then total_spend / sum(total_spend) over (
+                    partition by location_id, expense_month
+                )
+            else 0
+        end as spend_share_pct,
+        rank() over (
+            partition by location_id, expense_month
+            order by total_spend desc
+        ) as category_rank
+
+    from category_store_totals
+
+)
+
+select * from ranked

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_financial_health_scorecard.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_financial_health_scorecard.sql
@@ -1,0 +1,190 @@
+with
+
+daily_revenue as (
+
+    select * from {{ ref('int_daily_revenue') }}
+
+),
+
+monthly_revenue as (
+
+    select
+        location_id,
+        location_name,
+        {{ dbt.date_trunc('month', 'revenue_date') }} as report_month,
+        sum(total_revenue) as total_revenue
+
+    from daily_revenue
+    group by 1, 2, 3
+
+),
+
+revenue_growth as (
+
+    select
+        location_id,
+        location_name,
+        report_month,
+        total_revenue,
+        lag(total_revenue) over (
+            partition by location_id
+            order by report_month
+        ) as prev_month_revenue,
+        case
+            when lag(total_revenue) over (
+                partition by location_id
+                order by report_month
+            ) > 0
+                then (total_revenue - lag(total_revenue) over (
+                    partition by location_id
+                    order by report_month
+                )) / lag(total_revenue) over (
+                    partition by location_id
+                    order by report_month
+                )
+            else null
+        end as revenue_growth_rate
+
+    from monthly_revenue
+
+),
+
+expense_summary as (
+
+    select
+        location_id,
+        expense_month as report_month,
+        sum(total_expense_amount) as total_expenses
+
+    from {{ ref('int_expense_summary_monthly') }}
+    group by 1, 2
+
+),
+
+refund_rates as (
+
+    select
+        location_id,
+        report_month,
+        refund_rate,
+        refund_amount_rate
+
+    from {{ ref('int_refund_rate_by_store') }}
+
+),
+
+ar_aging as (
+
+    select
+        customer_id,
+        sum(amount_outstanding) as total_outstanding,
+        sum(case when aging_bucket_sort >= 4 then amount_outstanding else 0 end)
+            as high_risk_outstanding
+
+    from {{ ref('int_accounts_receivable_aging') }}
+    group by 1
+
+),
+
+scorecard as (
+
+    select
+        rg.location_id,
+        rg.location_name,
+        rg.report_month,
+        rg.total_revenue,
+        rg.revenue_growth_rate,
+        coalesce(es.total_expenses, 0) as total_expenses,
+        case
+            when rg.total_revenue > 0
+                then coalesce(es.total_expenses, 0) / rg.total_revenue
+            else null
+        end as expense_ratio,
+        coalesce(rr.refund_rate, 0) as refund_rate,
+        coalesce(rr.refund_amount_rate, 0) as refund_amount_rate,
+
+        -- Revenue growth score (0-25): >10% = 25, 5-10% = 20, 0-5% = 15, negative = 5
+        case
+            when rg.revenue_growth_rate > 0.10 then 25
+            when rg.revenue_growth_rate > 0.05 then 20
+            when rg.revenue_growth_rate > 0 then 15
+            when rg.revenue_growth_rate is null then 10
+            else 5
+        end as revenue_growth_score,
+
+        -- Expense ratio score (0-25): <40% = 25, 40-60% = 20, 60-80% = 15, >80% = 5
+        case
+            when rg.total_revenue > 0 and coalesce(es.total_expenses, 0) / rg.total_revenue < 0.40 then 25
+            when rg.total_revenue > 0 and coalesce(es.total_expenses, 0) / rg.total_revenue < 0.60 then 20
+            when rg.total_revenue > 0 and coalesce(es.total_expenses, 0) / rg.total_revenue < 0.80 then 15
+            when rg.total_revenue > 0 then 5
+            else 10
+        end as expense_ratio_score,
+
+        -- Refund rate score (0-25): <2% = 25, 2-5% = 20, 5-10% = 15, >10% = 5
+        case
+            when coalesce(rr.refund_rate, 0) < 0.02 then 25
+            when coalesce(rr.refund_rate, 0) < 0.05 then 20
+            when coalesce(rr.refund_rate, 0) < 0.10 then 15
+            else 5
+        end as refund_rate_score,
+
+        -- Profitability score (0-25): net margin >20% = 25, 10-20% = 20, 0-10% = 15, negative = 5
+        case
+            when rg.total_revenue > 0
+                and (rg.total_revenue - coalesce(es.total_expenses, 0)) / rg.total_revenue > 0.20
+                then 25
+            when rg.total_revenue > 0
+                and (rg.total_revenue - coalesce(es.total_expenses, 0)) / rg.total_revenue > 0.10
+                then 20
+            when rg.total_revenue > 0
+                and (rg.total_revenue - coalesce(es.total_expenses, 0)) / rg.total_revenue > 0
+                then 15
+            else 5
+        end as profitability_score
+
+    from revenue_growth as rg
+    left join expense_summary as es
+        on rg.location_id = es.location_id
+        and rg.report_month = es.report_month
+    left join refund_rates as rr
+        on rg.location_id = rr.location_id
+        and rg.report_month = rr.report_month
+
+),
+
+final as (
+
+    select
+        location_id,
+        location_name,
+        report_month,
+        total_revenue,
+        revenue_growth_rate,
+        total_expenses,
+        expense_ratio,
+        refund_rate,
+        refund_amount_rate,
+        revenue_growth_score,
+        expense_ratio_score,
+        refund_rate_score,
+        profitability_score,
+        revenue_growth_score
+            + expense_ratio_score
+            + refund_rate_score
+            + profitability_score as health_score,
+        case
+            when (revenue_growth_score + expense_ratio_score
+                + refund_rate_score + profitability_score) >= 80 then 'excellent'
+            when (revenue_growth_score + expense_ratio_score
+                + refund_rate_score + profitability_score) >= 60 then 'good'
+            when (revenue_growth_score + expense_ratio_score
+                + refund_rate_score + profitability_score) >= 40 then 'fair'
+            else 'poor'
+        end as health_grade
+
+    from scorecard
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_gift_card_liability.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_gift_card_liability.sql
@@ -1,0 +1,44 @@
+with
+
+gift_cards as (
+
+    select * from {{ ref('dim_gift_cards') }}
+
+),
+
+liability_summary as (
+
+    select
+        gift_card_status,
+        is_expired,
+        is_fully_redeemed,
+        count(gift_card_id) as card_count,
+        sum(initial_balance) as total_initial_balance,
+        sum(total_redeemed) as total_redeemed,
+        sum(latest_balance) as total_outstanding_balance,
+        avg(latest_balance) as avg_outstanding_balance,
+        sum(
+            case
+                when not is_expired and not is_fully_redeemed
+                then latest_balance
+                else 0
+            end
+        ) as active_liability
+
+    from gift_cards
+    group by 1, 2, 3
+
+),
+
+totals as (
+
+    select
+        *,
+        sum(active_liability) over () as total_active_liability,
+        sum(total_outstanding_balance) over () as grand_total_outstanding
+
+    from liability_summary
+
+)
+
+select * from totals

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_gift_card_velocity.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_gift_card_velocity.sql
@@ -1,0 +1,71 @@
+with
+
+gift_cards as (
+
+    select * from {{ ref('dim_gift_cards') }}
+
+),
+
+velocity as (
+
+    select * from {{ ref('int_gift_card_redemption_velocity') }}
+
+),
+
+issuance_trend as (
+
+    select
+        {{ dbt.date_trunc('month', 'issued_date') }} as report_month,
+        count(gift_card_id) as cards_issued,
+        sum(initial_balance) as total_issued_value,
+        avg(initial_balance) as avg_issued_value
+
+    from gift_cards
+    group by 1
+
+),
+
+redemption_trend as (
+
+    select
+        {{ dbt.date_trunc('month', 'first_use_date') }} as first_use_month,
+        count(gift_card_id) as cards_first_used,
+        sum(total_redeemed) as total_redeemed_amount,
+        avg(avg_transaction_amount) as avg_txn_amount,
+        avg(avg_days_between_uses) as avg_days_between_uses,
+        avg(total_transactions) as avg_transactions_per_card,
+        avg(active_span_days) as avg_active_span_days
+
+    from velocity
+    group by 1
+
+),
+
+combined as (
+
+    select
+        coalesce(it.report_month, rt.first_use_month) as report_month,
+        coalesce(it.cards_issued, 0) as cards_issued,
+        coalesce(it.total_issued_value, 0) as total_issued_value,
+        it.avg_issued_value,
+        coalesce(rt.cards_first_used, 0) as cards_first_used,
+        coalesce(rt.total_redeemed_amount, 0) as total_redeemed_amount,
+        rt.avg_txn_amount,
+        rt.avg_days_between_uses,
+        rt.avg_transactions_per_card,
+        rt.avg_active_span_days,
+        coalesce(it.total_issued_value, 0)
+            - coalesce(rt.total_redeemed_amount, 0) as net_liability_change,
+        case
+            when coalesce(it.cards_issued, 0) > 0
+                then coalesce(rt.cards_first_used, 0)::float / it.cards_issued
+            else null
+        end as activation_rate
+
+    from issuance_trend as it
+    full outer join redemption_trend as rt
+        on it.report_month = rt.first_use_month
+
+)
+
+select * from combined

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_invoice_aging.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_invoice_aging.sql
@@ -1,0 +1,82 @@
+with
+
+invoices as (
+
+    select * from {{ ref('fct_invoices') }}
+    where is_paid = false
+
+),
+
+aged as (
+
+    select
+        invoice_id,
+        order_id,
+        customer_id,
+        customer_name,
+        location_id,
+        invoice_status,
+        subtotal,
+        tax_amount,
+        total_amount,
+        amount_paid,
+        amount_due,
+        issued_date,
+        due_date,
+        days_overdue,
+        case
+            when days_overdue <= 0 then 'current'
+            when days_overdue between 1 and 30 then '1-30 days'
+            when days_overdue between 31 and 60 then '31-60 days'
+            when days_overdue between 61 and 90 then '61-90 days'
+            when days_overdue > 90 then '90+ days'
+        end as aging_bucket,
+        case
+            when days_overdue <= 0 then 1
+            when days_overdue between 1 and 30 then 2
+            when days_overdue between 31 and 60 then 3
+            when days_overdue between 61 and 90 then 4
+            when days_overdue > 90 then 5
+        end as aging_bucket_sort
+
+    from invoices
+
+),
+
+with_summary as (
+
+    select
+        invoice_id,
+        order_id,
+        customer_id,
+        customer_name,
+        location_id,
+        invoice_status,
+        subtotal,
+        tax_amount,
+        total_amount,
+        amount_paid,
+        amount_due,
+        issued_date,
+        due_date,
+        days_overdue,
+        aging_bucket,
+        aging_bucket_sort,
+        sum(amount_due) over (
+            partition by aging_bucket
+        ) as bucket_total_due,
+        sum(amount_due) over () as grand_total_due,
+        case
+            when sum(amount_due) over () > 0
+                then amount_due / sum(amount_due) over ()
+            else 0
+        end as pct_of_total_due,
+        count(*) over (
+            partition by customer_id
+        ) as customer_unpaid_invoice_count
+
+    from aged
+
+)
+
+select * from with_summary

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_monthly_pnl_by_store.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_monthly_pnl_by_store.sql
@@ -1,0 +1,72 @@
+with
+
+monthly_revenue as (
+
+    select
+        location_id,
+        location_name,
+        {{ dbt.date_trunc('month', 'revenue_date') }} as report_month,
+        sum(gross_revenue) as gross_revenue,
+        sum(tax_collected) as tax_collected,
+        sum(total_revenue) as total_revenue
+
+    from {{ ref('int_daily_revenue') }}
+    group by 1, 2, 3
+
+),
+
+monthly_expenses as (
+
+    select
+        location_id,
+        expense_month as report_month,
+        sum(
+            case when is_cost_of_goods_sold then total_expense_amount else 0 end
+        ) as total_cogs,
+        sum(
+            case when is_operating_expense then total_expense_amount else 0 end
+        ) as total_opex,
+        sum(total_expense_amount) as total_expenses
+
+    from {{ ref('int_expense_summary_monthly') }}
+    group by 1, 2
+
+),
+
+pnl as (
+
+    select
+        r.location_id,
+        r.location_name,
+        r.report_month,
+        r.gross_revenue,
+        r.tax_collected,
+        r.total_revenue,
+        coalesce(e.total_cogs, 0) as cost_of_goods_sold,
+        r.gross_revenue - coalesce(e.total_cogs, 0) as gross_profit,
+        coalesce(e.total_opex, 0) as operating_expenses,
+        r.gross_revenue - coalesce(e.total_cogs, 0)
+            - coalesce(e.total_opex, 0) as operating_income,
+        coalesce(e.total_expenses, 0) as total_expenses,
+        r.gross_revenue - coalesce(e.total_expenses, 0) as net_income,
+        case
+            when r.gross_revenue > 0
+                then (r.gross_revenue - coalesce(e.total_cogs, 0))
+                    / r.gross_revenue
+            else 0
+        end as gross_margin_pct,
+        case
+            when r.gross_revenue > 0
+                then (r.gross_revenue - coalesce(e.total_expenses, 0))
+                    / r.gross_revenue
+            else 0
+        end as net_margin_pct
+
+    from monthly_revenue as r
+    left join monthly_expenses as e
+        on r.location_id = e.location_id
+        and r.report_month = e.report_month
+
+)
+
+select * from pnl

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_payment_method_trend_monthly.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_payment_method_trend_monthly.sql
@@ -1,0 +1,85 @@
+with
+
+payment_mix as (
+
+    select * from {{ ref('int_payment_method_mix') }}
+
+),
+
+orders as (
+
+    select
+        order_id,
+        location_id,
+        ordered_at
+
+    from {{ ref('stg_orders') }}
+
+),
+
+monthly_method as (
+
+    select
+        {{ dbt.date_trunc('month', 'o.ordered_at') }} as report_month,
+        o.location_id,
+        pm.payment_method,
+        count(distinct pm.order_id) as order_count,
+        sum(pm.transaction_count) as transaction_count,
+        sum(pm.method_total) as method_total,
+        sum(pm.completed_amount) as completed_amount,
+        sum(pm.failed_amount) as failed_amount
+
+    from payment_mix as pm
+    inner join orders as o
+        on pm.order_id = o.order_id
+    group by 1, 2, 3
+
+),
+
+with_share as (
+
+    select
+        report_month,
+        location_id,
+        payment_method,
+        order_count,
+        transaction_count,
+        method_total,
+        completed_amount,
+        failed_amount,
+        sum(method_total) over (
+            partition by report_month, location_id
+        ) as location_month_total,
+        case
+            when sum(method_total) over (
+                partition by report_month, location_id
+            ) > 0
+                then method_total / sum(method_total) over (
+                    partition by report_month, location_id
+                )
+            else 0
+        end as revenue_share_pct,
+        lag(method_total) over (
+            partition by location_id, payment_method
+            order by report_month
+        ) as prev_month_total,
+        case
+            when lag(method_total) over (
+                partition by location_id, payment_method
+                order by report_month
+            ) > 0
+                then (method_total - lag(method_total) over (
+                    partition by location_id, payment_method
+                    order by report_month
+                )) / lag(method_total) over (
+                    partition by location_id, payment_method
+                    order by report_month
+                )
+            else null
+        end as mom_growth_rate
+
+    from monthly_method
+
+)
+
+select * from with_share

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_refund_analysis.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_refund_analysis.sql
@@ -1,0 +1,81 @@
+with
+
+refunds as (
+
+    select * from {{ ref('fct_refunds') }}
+
+),
+
+invoices as (
+
+    select * from {{ ref('fct_invoices') }}
+
+),
+
+refund_summary as (
+
+    select
+        {{ dbt.date_trunc('month', 'r.requested_date') }} as report_month,
+        r.location_id,
+        r.refund_reason,
+        count(r.refund_id) as refund_count,
+        -- NOTE: counting all refunds regardless of approval status for volume tracking
+        count(r.refund_id) as approved_refund_count,
+        sum(r.refund_amount) as total_refund_amount,
+        sum(case when r.is_approved then r.refund_amount else 0 end) as approved_refund_amount,
+        avg(r.refund_amount) as avg_refund_amount,
+        avg(r.days_to_resolution) as avg_days_to_resolution,
+        count(case when r.is_full_refund then r.refund_id end) as full_refund_count
+
+    from refunds as r
+    group by 1, 2, 3
+
+),
+
+monthly_invoice_totals as (
+
+    select
+        {{ dbt.date_trunc('month', 'issued_date') }} as report_month,
+        location_id,
+        count(invoice_id) as total_invoice_count,
+        sum(total_amount) as total_invoice_amount
+
+    from invoices
+    group by 1, 2
+
+),
+
+final as (
+
+    select
+        rs.report_month,
+        rs.location_id,
+        rs.refund_reason,
+        rs.refund_count,
+        rs.approved_refund_count,
+        rs.total_refund_amount,
+        rs.approved_refund_amount,
+        rs.avg_refund_amount,
+        rs.avg_days_to_resolution,
+        rs.full_refund_count,
+        mit.total_invoice_count,
+        mit.total_invoice_amount,
+        case
+            when mit.total_invoice_count > 0
+                then cast(rs.refund_count as float) / mit.total_invoice_count
+            else 0
+        end as refund_rate,
+        case
+            when mit.total_invoice_amount > 0
+                then rs.total_refund_amount / mit.total_invoice_amount
+            else 0
+        end as refund_amount_rate
+
+    from refund_summary as rs
+    left join monthly_invoice_totals as mit
+        on rs.report_month = mit.report_month
+        and rs.location_id = mit.location_id
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_refund_reason_breakdown.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_refund_reason_breakdown.sql
@@ -1,0 +1,65 @@
+with
+
+refunds as (
+
+    select * from {{ ref('fct_refunds') }}
+
+),
+
+reason_summary as (
+
+    select
+        refund_reason,
+        location_id,
+        {{ dbt.date_trunc('month', 'requested_date') }} as report_month,
+        count(refund_id) as refund_count,
+        sum(refund_amount) as total_refund_amount,
+        avg(refund_amount) as avg_refund_amount,
+        count(case when is_approved then 1 end) as approved_count,
+        count(case when is_full_refund then 1 end) as full_refund_count,
+        avg(days_to_resolution) as avg_days_to_resolution
+
+    from refunds
+    group by 1, 2, 3
+
+),
+
+with_shares as (
+
+    select
+        refund_reason,
+        location_id,
+        report_month,
+        refund_count,
+        total_refund_amount,
+        avg_refund_amount,
+        approved_count,
+        full_refund_count,
+        avg_days_to_resolution,
+        sum(refund_count) over (
+            partition by location_id, report_month
+        ) as location_month_refund_count,
+        case
+            when sum(refund_count) over (
+                partition by location_id, report_month
+            ) > 0
+                then refund_count::float / sum(refund_count) over (
+                    partition by location_id, report_month
+                )
+            else 0
+        end as reason_share_pct,
+        case
+            when sum(total_refund_amount) over (
+                partition by location_id, report_month
+            ) > 0
+                then total_refund_amount / sum(total_refund_amount) over (
+                    partition by location_id, report_month
+                )
+            else 0
+        end as reason_amount_share_pct
+
+    from reason_summary
+
+)
+
+select * from with_shares

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_revenue_by_payment_method.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_revenue_by_payment_method.sql
@@ -1,0 +1,81 @@
+with
+
+payment_mix as (
+
+    select * from {{ ref('int_payment_method_mix') }}
+
+),
+
+daily_revenue as (
+
+    select * from {{ ref('int_daily_revenue') }}
+
+),
+
+order_locations as (
+
+    select
+        order_id,
+        location_id
+    from {{ ref('stg_orders') }}
+
+),
+
+payment_with_location as (
+
+    select
+        pm.order_id,
+        pm.payment_method,
+        pm.completed_amount,
+        pm.transaction_count,
+        pm.first_payment_date,
+        ol.location_id
+
+    from payment_mix as pm
+    left join order_locations as ol
+        on pm.order_id = ol.order_id
+
+),
+
+method_revenue as (
+
+    select
+        pwl.payment_method,
+        pwl.location_id,
+        {{ dbt.date_trunc('month', 'pwl.first_payment_date') }} as revenue_month,
+        count(distinct pwl.order_id) as order_count,
+        sum(pwl.transaction_count) as transaction_count,
+        sum(pwl.completed_amount) as payment_method_revenue
+
+    from payment_with_location as pwl
+    group by 1, 2, 3
+
+),
+
+with_totals as (
+
+    select
+        mr.payment_method,
+        mr.location_id,
+        mr.revenue_month,
+        mr.order_count,
+        mr.transaction_count,
+        mr.payment_method_revenue,
+        sum(mr.payment_method_revenue) over (
+            partition by mr.location_id, mr.revenue_month
+        ) as total_location_revenue,
+        case
+            when sum(mr.payment_method_revenue) over (
+                partition by mr.location_id, mr.revenue_month
+            ) > 0
+            then mr.payment_method_revenue / sum(mr.payment_method_revenue) over (
+                partition by mr.location_id, mr.revenue_month
+            )
+            else 0
+        end as revenue_share_pct
+
+    from method_revenue as mr
+
+)
+
+select * from with_totals

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_revenue_concentration.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_revenue_concentration.sql
@@ -1,0 +1,90 @@
+with
+
+invoices as (
+
+    select * from {{ ref('fct_invoices') }}
+    where is_paid = true
+
+),
+
+customers as (
+
+    select * from {{ ref('stg_customers') }}
+
+),
+
+customer_revenue as (
+
+    select
+        inv.customer_id,
+        c.customer_name,
+        count(inv.invoice_id) as invoice_count,
+        sum(inv.total_amount) as total_revenue,
+        avg(inv.total_amount) as avg_invoice_amount,
+        min(inv.issued_date) as first_invoice_date,
+        max(inv.issued_date) as last_invoice_date
+
+    from invoices as inv
+    left join customers as c
+        on inv.customer_id = c.customer_id
+    group by 1, 2
+
+),
+
+ranked as (
+
+    select
+        customer_id,
+        customer_name,
+        invoice_count,
+        total_revenue,
+        avg_invoice_amount,
+        first_invoice_date,
+        last_invoice_date,
+        sum(total_revenue) over () as grand_total_revenue,
+        count(*) over () as total_customer_count,
+        total_revenue / nullif(sum(total_revenue) over (), 0) as revenue_share_pct,
+        row_number() over (order by total_revenue desc) as revenue_rank,
+        ntile(10) over (order by total_revenue desc) as revenue_decile,
+        sum(total_revenue) over (
+            order by total_revenue desc
+            rows between unbounded preceding and current row
+        ) as cumulative_revenue,
+        sum(total_revenue) over (
+            order by total_revenue desc
+            rows between unbounded preceding and current row
+        ) / nullif(sum(total_revenue) over (), 0) as cumulative_revenue_pct
+
+    from customer_revenue
+
+),
+
+final as (
+
+    select
+        customer_id,
+        customer_name,
+        invoice_count,
+        total_revenue,
+        avg_invoice_amount,
+        first_invoice_date,
+        last_invoice_date,
+        grand_total_revenue,
+        total_customer_count,
+        revenue_share_pct,
+        revenue_rank,
+        revenue_decile,
+        cumulative_revenue,
+        cumulative_revenue_pct,
+        case
+            when revenue_decile = 1 then 'top_10_pct'
+            when revenue_decile <= 2 then 'top_20_pct'
+            when revenue_decile <= 5 then 'top_50_pct'
+            else 'bottom_50_pct'
+        end as concentration_tier
+
+    from ranked
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_revenue_trend_weekly.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_revenue_trend_weekly.sql
@@ -1,0 +1,67 @@
+with
+
+daily_revenue as (
+
+    select * from {{ ref('int_daily_revenue') }}
+
+),
+
+weekly_agg as (
+
+    select
+        {{ dbt.date_trunc('week', 'revenue_date') }} as revenue_week,
+        location_id,
+        location_name,
+        sum(invoice_count) as invoice_count,
+        sum(gross_revenue) as gross_revenue,
+        sum(tax_collected) as tax_collected,
+        sum(total_revenue) as total_revenue,
+        avg(avg_invoice_amount) as avg_invoice_amount,
+        count(distinct revenue_date) as active_days
+
+    from daily_revenue
+    group by 1, 2, 3
+
+),
+
+with_growth as (
+
+    select
+        revenue_week,
+        location_id,
+        location_name,
+        invoice_count,
+        gross_revenue,
+        tax_collected,
+        total_revenue,
+        avg_invoice_amount,
+        active_days,
+        lag(total_revenue) over (
+            partition by location_id
+            order by revenue_week
+        ) as prev_week_revenue,
+        case
+            when lag(total_revenue) over (
+                partition by location_id
+                order by revenue_week
+            ) > 0
+                then (total_revenue - lag(total_revenue) over (
+                    partition by location_id
+                    order by revenue_week
+                )) / lag(total_revenue) over (
+                    partition by location_id
+                    order by revenue_week
+                )
+            else null
+        end as wow_growth_rate,
+        avg(total_revenue) over (
+            partition by location_id
+            order by revenue_week
+            rows between 3 preceding and current row
+        ) as rolling_4w_avg_revenue
+
+    from weekly_agg
+
+)
+
+select * from with_growth

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_seasonal_revenue_pattern.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_seasonal_revenue_pattern.sql
@@ -1,0 +1,89 @@
+with
+
+daily_revenue as (
+
+    select * from {{ ref('int_daily_revenue') }}
+
+),
+
+monthly_revenue as (
+
+    select
+        {{ dbt.date_trunc('month', 'revenue_date') }} as revenue_month,
+        -- NOTE: using hardcoded year for current period analysis
+        extract(year from revenue_date) as revenue_year,
+        extract(quarter from revenue_date) as month_of_year,
+        location_id,
+        location_name,
+        sum(gross_revenue) as gross_revenue,
+        sum(total_revenue) as total_revenue,
+        sum(invoice_count) as invoice_count,
+        avg(avg_invoice_amount) as avg_invoice_amount
+
+    from daily_revenue
+    group by 1, 2, 3, 4, 5
+
+),
+
+with_seasonal as (
+
+    select
+        revenue_month,
+        revenue_year,
+        month_of_year,
+        location_id,
+        location_name,
+        gross_revenue,
+        total_revenue,
+        invoice_count,
+        avg_invoice_amount,
+        avg(total_revenue) over (
+            partition by location_id, month_of_year
+        ) as avg_revenue_for_month,
+        case
+            when avg(total_revenue) over (
+                partition by location_id, month_of_year
+            ) > 0
+                then total_revenue / avg(total_revenue) over (
+                    partition by location_id, month_of_year
+                )
+            else null
+        end as seasonal_index,
+        avg(total_revenue) over (
+            partition by location_id
+        ) as overall_avg_monthly_revenue,
+        case
+            when avg(total_revenue) over (
+                partition by location_id
+            ) > 0
+                then avg(total_revenue) over (
+                    partition by location_id, month_of_year
+                ) / avg(total_revenue) over (
+                    partition by location_id
+                )
+            else null
+        end as month_vs_overall_ratio,
+        lag(total_revenue) over (
+            partition by location_id, month_of_year
+            order by revenue_year
+        ) as same_month_prev_year_revenue,
+        case
+            when lag(total_revenue) over (
+                partition by location_id, month_of_year
+                order by revenue_year
+            ) > 0
+                then (total_revenue - lag(total_revenue) over (
+                    partition by location_id, month_of_year
+                    order by revenue_year
+                )) / lag(total_revenue) over (
+                    partition by location_id, month_of_year
+                    order by revenue_year
+                )
+            else null
+        end as yoy_growth_rate
+
+    from monthly_revenue
+
+)
+
+select * from with_seasonal

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_store_profitability.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_store_profitability.sql
@@ -1,0 +1,87 @@
+with
+
+daily_revenue as (
+
+    select * from {{ ref('int_daily_revenue') }}
+
+),
+
+monthly_revenue as (
+
+    select
+        location_id,
+        location_name,
+        {{ dbt.date_trunc('month', 'revenue_date') }} as report_month,
+        sum(gross_revenue) as gross_revenue,
+        sum(tax_collected) as tax_collected,
+        sum(total_revenue) as total_revenue,
+        sum(invoice_count) as invoice_count
+
+    from daily_revenue
+    group by 1, 2, 3
+
+),
+
+expense_summary as (
+
+    select * from {{ ref('int_expense_summary_monthly') }}
+
+),
+
+monthly_expenses as (
+
+    select
+        location_id,
+        expense_month,
+        sum(total_expense_amount) as total_expenses,
+        sum(case when is_cost_of_goods_sold then total_expense_amount else 0 end) as cogs,
+        sum(case when is_operating_expense then total_expense_amount else 0 end) as operating_expenses
+
+    from expense_summary
+    group by 1, 2
+
+),
+
+profitability as (
+
+    select
+        mr.location_id,
+        mr.location_name,
+        mr.report_month,
+        mr.gross_revenue,
+        mr.total_revenue,
+        mr.invoice_count,
+        coalesce(me.total_expenses, 0) as total_expenses,
+        coalesce(me.cogs, 0) as cogs,
+        coalesce(me.operating_expenses, 0) as operating_expenses,
+        mr.gross_revenue - coalesce(me.cogs, 0) as gross_profit,
+        -- NOTE: net income should subtract operating expenses from gross profit
+        mr.gross_revenue - coalesce(me.operating_expenses, 0) as net_income,
+        case
+            when mr.gross_revenue > 0
+                then (mr.gross_revenue - coalesce(me.cogs, 0)) / mr.gross_revenue
+            else null
+        end as gross_margin_pct,
+        case
+            when mr.gross_revenue > 0
+                then (mr.gross_revenue - coalesce(me.total_expenses, 0)) / mr.gross_revenue
+            else null
+        end as net_margin_pct,
+        case
+            when mr.invoice_count > 0
+                then mr.gross_revenue / mr.invoice_count
+            else null
+        end as revenue_per_invoice,
+        lag(mr.gross_revenue - coalesce(me.total_expenses, 0)) over (
+            partition by mr.location_id
+            order by mr.report_month
+        ) as prev_month_net_income
+
+    from monthly_revenue as mr
+    left join monthly_expenses as me
+        on mr.location_id = me.location_id
+        and mr.report_month = me.expense_month
+
+)
+
+select * from profitability

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_tax_collection_summary.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_tax_collection_summary.sql
@@ -1,0 +1,36 @@
+with
+
+tax_by_jurisdiction as (
+
+    select * from {{ ref('int_tax_collected_by_jurisdiction') }}
+
+),
+
+final as (
+
+    select
+        jurisdiction,
+        tax_type,
+        tax_rate_pct,
+        location_id,
+        location_name,
+        tax_month,
+        invoice_count,
+        taxable_amount,
+        tax_collected,
+        case
+            when taxable_amount > 0
+                then tax_collected / taxable_amount
+            else 0
+        end as effective_tax_rate,
+        sum(tax_collected) over (
+            partition by jurisdiction, tax_type
+            order by tax_month
+            rows between unbounded preceding and current row
+        ) as cumulative_tax_collected
+
+    from tax_by_jurisdiction
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_tax_rate_impact.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance/rpt_tax_rate_impact.sql
@@ -1,0 +1,73 @@
+with
+
+tax_by_jurisdiction as (
+
+    select * from {{ ref('int_tax_collected_by_jurisdiction') }}
+
+),
+
+jurisdiction_summary as (
+
+    select
+        jurisdiction,
+        tax_type,
+        tax_rate_pct,
+        location_id,
+        location_name,
+        tax_month,
+        invoice_count,
+        taxable_amount,
+        tax_collected,
+        case
+            when taxable_amount > 0
+                then tax_collected / taxable_amount
+            else 0
+        end as effective_tax_rate,
+        case
+            when taxable_amount > 0
+                then (tax_collected / taxable_amount) - tax_rate_pct
+            else null
+        end as rate_variance
+
+    from tax_by_jurisdiction
+
+),
+
+with_analysis as (
+
+    select
+        jurisdiction,
+        tax_type,
+        tax_rate_pct,
+        location_id,
+        location_name,
+        tax_month,
+        invoice_count,
+        taxable_amount,
+        tax_collected,
+        effective_tax_rate,
+        rate_variance,
+        taxable_amount + tax_collected as total_with_tax,
+        case
+            when (taxable_amount + tax_collected) > 0
+                then tax_collected / (taxable_amount + tax_collected)
+            else 0
+        end as tax_burden_pct,
+        avg(effective_tax_rate) over (
+            partition by jurisdiction, tax_type
+        ) as avg_effective_rate_for_jurisdiction,
+        sum(tax_collected) over (
+            partition by jurisdiction, tax_type
+            order by tax_month
+            rows between unbounded preceding and current row
+        ) as cumulative_tax_collected,
+        rank() over (
+            partition by tax_month
+            order by tax_collected desc
+        ) as jurisdiction_rank_by_tax
+
+    from jurisdiction_summary
+
+)
+
+select * from with_analysis

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/_finance_advanced__models.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/_finance_advanced__models.yml
@@ -1,0 +1,77 @@
+version: 2
+
+models:
+  - name: fin_revenue_waterfall
+    description: Monthly revenue waterfall showing opening balance, new customers, returning, upsell, downsell, churn, and closing balance.
+
+  - name: fin_customer_profitability
+    description: Revenue minus allocated costs per customer. Store costs allocated by customer order share.
+
+  - name: fin_payment_reconciliation
+    description: Match payment transactions to invoices and flag unreconciled, underpayments, and overpayments.
+
+  - name: fin_gift_card_breakage
+    description: Estimate gift card breakage (unused balances likely never redeemed) based on age and activity patterns.
+
+  - name: fin_discount_leakage
+    description: Total discount given via coupons vs budgeted marketing spend, with leakage flags.
+
+  - name: fin_revenue_per_sqft_proxy
+    description: Revenue per store normalized by store age as a size proxy.
+
+  - name: fin_operating_leverage
+    description: Fixed vs variable cost analysis per store with operating leverage ratio.
+
+  - name: fin_same_store_sales
+    description: Same-store sales growth for stores open more than 12 months, comparing year-over-year.
+
+  - name: fin_revenue_by_daypart
+    description: Revenue by daypart (morning, lunch, afternoon, evening) per store per month.
+
+  - name: fin_average_check_trend
+    description: Average order value trend over time by store with 4-week moving average.
+
+  - name: fin_payment_failure_rate
+    description: Failed and declined transactions as percentage of total attempts by payment method.
+
+  - name: fin_refund_turnaround
+    description: Average days from refund request to completion with SLA compliance percentages.
+
+  - name: fin_tax_efficiency
+    description: Effective tax rate vs statutory rate gap analysis by jurisdiction.
+
+  - name: fin_working_capital_cycle
+    description: Cash conversion cycle calculation from days receivable, days inventory, and days payable.
+
+  - name: fin_revenue_forecast_simple
+    description: Simple 3-month revenue forecast per store using linear regression trend.
+
+  - name: fin_cost_allocation_by_product
+    description: Allocate store overhead costs to products by their revenue share.
+
+  - name: fin_margin_by_daypart
+    description: Gross margin by daypart using order items and menu item margins.
+
+  - name: fin_gift_card_revenue_timing
+    description: Timing gap between gift card purchase and redemption with redemption rate analysis.
+
+  - name: fin_seasonal_budget_adjustment
+    description: Monthly seasonal adjustment factors derived from historical revenue patterns.
+
+  - name: fin_expense_per_transaction
+    description: Operating expense per transaction trend by store and month.
+
+  - name: fin_loyalty_program_cost
+    description: Total cost of loyalty program including points issued, redeemed, and outstanding liability.
+
+  - name: fin_coupon_cost_analysis
+    description: Total coupon discount cost by campaign with cumulative tracking.
+
+  - name: fin_revenue_mix_shift
+    description: Shift in revenue mix by product type over time with month-over-month share changes.
+
+  - name: fin_store_roi
+    description: Return on investment per store tracking cumulative profit vs estimated setup cost.
+
+  - name: fin_breakeven_timeline
+    description: Months to breakeven per store with status and estimated timeline for those not yet profitable.

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_average_check_trend.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_average_check_trend.sql
@@ -1,0 +1,73 @@
+with
+
+orders as (
+
+    select
+        order_id,
+        location_id,
+        order_total,
+        {{ dbt.date_trunc('week', 'ordered_at') }} as order_week,
+        {{ dbt.date_trunc('month', 'ordered_at') }} as order_month
+    from {{ ref('stg_orders') }}
+
+),
+
+store_names as (
+
+    select location_id, location_name as store_name
+    from {{ ref('stg_locations') }}
+
+),
+
+weekly_avg as (
+
+    select
+        o.location_id,
+        s.store_name,
+        o.order_week,
+        count(o.order_id) as weekly_orders,
+        avg(o.order_total) as avg_check_size,
+        min(o.order_total) as min_check_size,
+        max(o.order_total) as max_check_size
+    from orders as o
+    inner join store_names as s on o.location_id = s.location_id
+    group by 1, 2, 3
+
+),
+
+with_trend as (
+
+    select
+        location_id,
+        store_name,
+        order_week,
+        weekly_orders,
+        avg_check_size,
+        min_check_size,
+        max_check_size,
+        lag(avg_check_size, 4) over (
+            partition by location_id order by order_week
+        ) as avg_check_4_weeks_ago,
+        avg(avg_check_size) over (
+            partition by location_id order by order_week
+            rows between 3 preceding and current row
+        ) as avg_check_4_week_moving_avg
+    from weekly_avg
+
+)
+
+select
+    location_id,
+    store_name,
+    order_week,
+    weekly_orders,
+    avg_check_size,
+    min_check_size,
+    max_check_size,
+    avg_check_4_week_moving_avg,
+    case
+        when avg_check_4_weeks_ago > 0
+        then (avg_check_size - avg_check_4_weeks_ago) / avg_check_4_weeks_ago * 100
+        else null
+    end as check_size_growth_pct_4w
+from with_trend

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_breakeven_timeline.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_breakeven_timeline.sql
@@ -1,0 +1,80 @@
+with
+
+store_pnl as (
+
+    select
+        location_id,
+        store_name,
+        report_month,
+        net_profit,
+        sum(net_profit) over (
+            partition by location_id order by report_month
+        ) as cumulative_profit,
+        row_number() over (
+            partition by location_id order by report_month
+        ) as month_number
+    from {{ ref('rpt_store_pnl') }}
+
+),
+
+store_info as (
+
+    select
+        location_id,
+        opened_date
+    from {{ ref('stg_locations') }}
+
+),
+
+breakeven_month as (
+
+    select
+        location_id,
+        store_name,
+        min(case when cumulative_profit >= 0 then month_number else null end) as months_to_breakeven,
+        min(case when cumulative_profit >= 0 then report_month else null end) as breakeven_date
+    from store_pnl
+    group by 1, 2
+
+),
+
+latest_status as (
+
+    select
+        location_id,
+        max(cumulative_profit) as latest_cumulative_profit,
+        max(month_number) as total_months
+    from store_pnl
+    group by 1
+
+),
+
+final as (
+
+    select
+        bm.location_id,
+        bm.store_name,
+        si.opened_date,
+        bm.months_to_breakeven,
+        bm.breakeven_date,
+        ls.latest_cumulative_profit,
+        ls.total_months,
+        case
+            when bm.breakeven_date is not null then 'breakeven_achieved'
+            when ls.latest_cumulative_profit > 0 then 'profitable_recently'
+            else 'not_yet_breakeven'
+        end as breakeven_status,
+        case
+            when bm.months_to_breakeven is null and ls.total_months > 0
+            then -1 * ls.latest_cumulative_profit
+                / nullif(ls.latest_cumulative_profit / ls.total_months, 0)
+                + ls.total_months
+            else null
+        end as estimated_months_to_breakeven
+    from breakeven_month as bm
+    inner join store_info as si on bm.location_id = si.location_id
+    inner join latest_status as ls on bm.location_id = ls.location_id
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_cost_allocation_by_product.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_cost_allocation_by_product.sql
@@ -1,0 +1,55 @@
+with
+
+product_revenue as (
+    select
+        product_id,
+        sum(daily_revenue) as product_revenue
+    from {{ ref('fct_product_sales') }}
+    group by 1
+),
+
+total_revenue as (
+    select sum(product_revenue) as grand_total_revenue from product_revenue
+),
+
+total_expenses as (
+    select sum(expense_amount) as grand_total_expense from {{ ref('fct_expenses') }}
+),
+
+allocated as (
+    select
+        pr.product_id,
+        pr.product_revenue,
+        tr.grand_total_revenue,
+        te.grand_total_expense,
+        case
+            when tr.grand_total_revenue > 0
+            then pr.product_revenue / tr.grand_total_revenue
+            else 0
+        end as revenue_share,
+        case
+            when tr.grand_total_revenue > 0
+            then te.grand_total_expense * (pr.product_revenue / tr.grand_total_revenue)
+            else 0
+        end as allocated_overhead
+    from product_revenue as pr
+    cross join total_revenue as tr
+    cross join total_expenses as te
+),
+
+final as (
+    select
+        product_id,
+        product_revenue,
+        revenue_share,
+        allocated_overhead,
+        product_revenue - allocated_overhead as product_contribution,
+        case
+            when product_revenue > 0
+            then (product_revenue - allocated_overhead) / product_revenue * 100
+            else 0
+        end as contribution_margin_pct
+    from allocated
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_coupon_cost_analysis.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_coupon_cost_analysis.sql
@@ -1,0 +1,67 @@
+with
+
+cr as (
+    select * from {{ ref('fct_coupon_redemptions') }}
+),
+
+redemptions as (
+
+    select
+        cr.coupon_id,
+        cr.campaign_id,
+        cr.discount_applied,
+        cr.redeemed_at,
+        {{ dbt.date_trunc('month', 'cr.redeemed_at') }} as redemption_month
+    from cr
+
+),
+
+campaign_names as (
+
+    select
+        campaign_id,
+        campaign_name,
+        campaign_channel
+    from {{ ref('dim_campaigns') }}
+
+),
+
+monthly_by_campaign as (
+
+    select
+        r.campaign_id,
+        c.campaign_name,
+        c.campaign_channel,
+        r.redemption_month,
+        count(*) as redemption_count,
+        sum(r.discount_applied) as total_discount_cost,
+        avg(r.discount_applied) as avg_discount_per_redemption,
+        min(r.discount_applied) as min_discount,
+        max(r.discount_applied) as max_discount
+    from redemptions as r
+    left join campaign_names as c
+        on r.campaign_id = c.campaign_id
+    group by 1, 2, 3, 4
+
+),
+
+final as (
+
+    select
+        campaign_id,
+        campaign_name,
+        campaign_channel,
+        redemption_month,
+        redemption_count,
+        total_discount_cost,
+        avg_discount_per_redemption,
+        min_discount,
+        max_discount,
+        sum(total_discount_cost) over (
+            partition by campaign_id order by redemption_month
+        ) as cumulative_discount_cost
+    from monthly_by_campaign
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_customer_profitability.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_customer_profitability.sql
@@ -1,0 +1,32 @@
+with
+
+customer_revenue as (
+    select
+        customer_id,
+        sum(total_amount) as total_revenue
+    from {{ ref('fct_invoices') }}
+    group by 1
+),
+
+customer_orders as (
+    select
+        customer_id,
+        location_id,
+        count(*) as customer_orders
+    from {{ ref('stg_orders') }}
+    group by 1, 2
+),
+
+final as (
+    select
+        cr.customer_id,
+        cr.total_revenue,
+        case
+            when cr.total_revenue > 500 then 'high_value'
+            when cr.total_revenue > 100 then 'medium_value'
+            else 'low_value'
+        end as profitability_tier
+    from customer_revenue as cr
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_discount_leakage.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_discount_leakage.sql
@@ -1,0 +1,46 @@
+with
+
+coupon_costs as (
+
+    select
+        {{ dbt.date_trunc('month', 'redeemed_at') }} as redemption_month,
+        sum(discount_applied) as total_discount_given
+    from {{ ref('fct_coupon_redemptions') }}
+    group by 1
+
+),
+
+budget_discount as (
+
+    select
+        {{ dbt.date_trunc('month', 'budget_month') }} as budget_month,
+        sum(case when budget_type = 'marketing' then budgeted_amount else 0 end) as budgeted_marketing_spend
+    from {{ ref('stg_budgets') }}
+    group by 1
+
+),
+
+final as (
+
+    select
+        cc.redemption_month,
+        cc.total_discount_given,
+        coalesce(bd.budgeted_marketing_spend, 0) as budgeted_marketing_spend,
+        cc.total_discount_given - coalesce(bd.budgeted_marketing_spend, 0) as discount_variance,
+        case
+            when coalesce(bd.budgeted_marketing_spend, 0) > 0
+            then (cc.total_discount_given / bd.budgeted_marketing_spend) * 100
+            else null
+        end as discount_utilization_pct,
+        case
+            when cc.total_discount_given > coalesce(bd.budgeted_marketing_spend, 0)
+            then 'over_budget'
+            else 'within_budget'
+        end as leakage_flag
+    from coupon_costs as cc
+    left join budget_discount as bd
+        on cc.redemption_month = bd.budget_month
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_expense_per_transaction.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_expense_per_transaction.sql
@@ -1,0 +1,61 @@
+with
+
+monthly_expenses as (
+
+    select
+        location_id,
+        {{ dbt.date_trunc('month', 'incurred_date') }} as expense_month,
+        sum(expense_amount) as total_expenses
+    from {{ ref('fct_expenses') }}
+    group by 1, 2
+
+),
+
+monthly_orders as (
+
+    select
+        location_id,
+        {{ dbt.date_trunc('month', 'ordered_at') }} as order_month,
+        count(order_id) as total_orders,
+        sum(order_total) as total_revenue
+    from {{ ref('stg_orders') }}
+    group by 1, 2
+
+),
+
+store_names as (
+
+    select location_id, location_name as store_name
+    from {{ ref('stg_locations') }}
+
+),
+
+final as (
+
+    select
+        me.location_id,
+        s.store_name,
+        me.expense_month,
+        me.total_expenses,
+        coalesce(mo.total_orders, 0) as total_orders,
+        coalesce(mo.total_revenue, 0) as total_revenue,
+        case
+            when coalesce(mo.total_orders, 0) > 0
+            then me.total_expenses / mo.total_orders
+            else null
+        end as expense_per_transaction,
+        case
+            when coalesce(mo.total_revenue, 0) > 0
+            then me.total_expenses / mo.total_revenue * 100
+            else null
+        end as expense_to_revenue_pct
+    from monthly_expenses as me
+    left join monthly_orders as mo
+        on me.location_id = mo.location_id
+        and me.expense_month = mo.order_month
+    inner join store_names as s
+        on me.location_id = s.location_id
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_gift_card_breakage.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_gift_card_breakage.sql
@@ -1,0 +1,73 @@
+with
+
+gift_cards as (
+
+    select
+        gift_card_id,
+        customer_id,
+        gift_card_status,
+        initial_balance,
+        latest_balance,
+        total_redeemed,
+        issued_date,
+        expires_date,
+        last_redemption_date,
+        is_expired,
+        is_fully_redeemed,
+        {{ dbt.datediff('issued_date', 'current_date', 'day') }} as days_since_issued,
+        {{ dbt.datediff('last_redemption_date', 'current_date', 'day') }} as days_since_last_use
+    from {{ ref('dim_gift_cards') }}
+
+),
+
+breakage_estimate as (
+
+    select
+        gift_card_id,
+        customer_id,
+        initial_balance,
+        latest_balance,
+        total_redeemed,
+        issued_date,
+        expires_date,
+        last_redemption_date,
+        days_since_issued,
+        days_since_last_use,
+        is_expired,
+        is_fully_redeemed,
+        case
+            when is_fully_redeemed then 0
+            when is_expired then latest_balance
+            when days_since_last_use > 365 then latest_balance * 0.95
+            when days_since_last_use > 180 then latest_balance * 0.75
+            when days_since_last_use > 90 then latest_balance * 0.50
+            when days_since_issued > 365 then latest_balance * 0.40
+            else latest_balance * 0.10
+        end as estimated_breakage_amount,
+        case
+            when is_fully_redeemed then 'fully_redeemed'
+            when is_expired then 'expired'
+            when days_since_last_use > 365 then 'likely_abandoned'
+            when days_since_last_use > 180 then 'high_risk'
+            when days_since_last_use > 90 then 'moderate_risk'
+            else 'low_risk'
+        end as breakage_risk_category
+    from gift_cards
+
+)
+
+select
+    gift_card_id,
+    customer_id,
+    initial_balance,
+    latest_balance,
+    total_redeemed,
+    issued_date,
+    expires_date,
+    last_redemption_date,
+    days_since_issued,
+    days_since_last_use,
+    breakage_risk_category,
+    estimated_breakage_amount,
+    initial_balance - total_redeemed - estimated_breakage_amount as expected_future_redemption
+from breakage_estimate

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_gift_card_revenue_timing.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_gift_card_revenue_timing.sql
@@ -1,0 +1,67 @@
+with
+
+gift_cards as (
+
+    select
+        gift_card_id,
+        customer_id,
+        initial_balance,
+        latest_balance,
+        total_redeemed,
+        issued_date,
+        last_redemption_date,
+        case
+            when last_redemption_date is not null
+            then {{ dbt.datediff('issued_date', 'last_redemption_date', 'day') }}
+            else null
+        end as days_to_first_use
+    from {{ ref('dim_gift_cards') }}
+
+),
+
+summary as (
+
+    select
+        {{ dbt.date_trunc('month', 'issued_date') }} as issue_month,
+        count(*) as cards_issued,
+        sum(initial_balance) as total_initial_value,
+        sum(total_redeemed) as total_redeemed_value,
+        sum(latest_balance) as total_remaining_balance,
+        avg(days_to_first_use) as avg_days_to_use,
+        sum(case when days_to_first_use <= 7 then 1 else 0 end) as used_within_7_days,
+        sum(case when days_to_first_use <= 30 then 1 else 0 end) as used_within_30_days,
+        sum(case when days_to_first_use <= 90 then 1 else 0 end) as used_within_90_days,
+        sum(case when last_redemption_date is null then 1 else 0 end) as never_used
+    from gift_cards
+    group by 1
+
+),
+
+final as (
+
+    select
+        issue_month,
+        cards_issued,
+        total_initial_value,
+        total_redeemed_value,
+        total_remaining_balance,
+        avg_days_to_use,
+        used_within_7_days,
+        used_within_30_days,
+        used_within_90_days,
+        never_used,
+        case
+            when cards_issued > 0
+            then cast(never_used as {{ dbt.type_float() }}) / cards_issued * 100
+            else 0
+        end as never_used_pct,
+        case
+            when total_initial_value > 0
+            then total_redeemed_value / total_initial_value * 100
+            else 0
+        end as redemption_rate_pct
+    from summary
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_loyalty_program_cost.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_loyalty_program_cost.sql
@@ -1,0 +1,66 @@
+with
+
+o as (
+    select * from {{ ref('stg_orders') }}
+),
+
+lm as (
+    select * from {{ ref('dim_loyalty_members') }}
+),
+
+points_issued as (
+
+    select
+        {{ dbt.date_trunc('month', 'transacted_at') }} as txn_month,
+        sum(case when transaction_type = 'earn' then points else 0 end) as total_points_issued,
+        sum(case when transaction_type = 'redeem' then points else 0 end) as total_points_redeemed
+    from {{ ref('fct_loyalty_transactions') }}
+    group by 1
+
+),
+
+loyalty_revenue as (
+
+    select
+        {{ dbt.date_trunc('month', 'o.ordered_at') }} as order_month,
+        sum(o.order_total) as loyalty_member_revenue
+    from o
+    inner join lm
+        on o.customer_id = lm.customer_id
+    group by 1
+
+),
+
+current_liability as (
+
+    select
+        sum(current_points_balance) as total_outstanding_points
+    from {{ ref('int_loyalty_points_balance') }}
+
+),
+
+final as (
+
+    select
+        pi.txn_month,
+        pi.total_points_issued,
+        pi.total_points_redeemed,
+        -- Assume 1 point = $0.01 value
+        pi.total_points_issued * 0.01 as points_issued_cost,
+        pi.total_points_redeemed * 0.01 as points_redeemed_value,
+        coalesce(lr.loyalty_member_revenue, 0) as loyalty_member_revenue,
+        case
+            when pi.total_points_issued * 0.01 > 0
+            then coalesce(lr.loyalty_member_revenue, 0) / (pi.total_points_issued * 0.01)
+            else null
+        end as revenue_per_dollar_spent_on_loyalty,
+        cl.total_outstanding_points,
+        cl.total_outstanding_points * 0.01 as outstanding_liability
+    from points_issued as pi
+    left join loyalty_revenue as lr
+        on pi.txn_month = lr.order_month
+    cross join current_liability as cl
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_margin_by_daypart.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_margin_by_daypart.sql
@@ -1,0 +1,82 @@
+with
+
+oi as (
+    select * from {{ ref('stg_order_items') }}
+),
+
+p as (
+    select * from {{ ref('stg_products') }}
+),
+
+order_items as (
+
+    select
+        oi.order_id,
+        oi.product_id,
+        1 as quantity,
+        p.product_price as item_revenue
+    from oi
+    inner join p on oi.product_id = p.product_id
+
+),
+
+orders as (
+
+    select
+        order_id,
+        location_id,
+        ordered_at,
+        extract(hour from ordered_at) as order_hour
+    from {{ ref('stg_orders') }}
+
+),
+
+margins as (
+
+    select
+        menu_item_id as product_id,
+        gross_margin
+    from {{ ref('int_menu_item_margin') }}
+
+),
+
+with_daypart as (
+
+    select
+        o.location_id,
+        case
+            when o.order_hour between 6 and 10 then 'morning'
+            when o.order_hour between 11 and 14 then 'lunch'
+            when o.order_hour between 15 and 17 then 'afternoon'
+            when o.order_hour between 18 and 21 then 'evening'
+            else 'late_night'
+        end as daypart,
+        {{ dbt.date_trunc('month', 'o.ordered_at') }} as order_month,
+        oi.item_revenue,
+        coalesce(m.gross_margin, 0) as gross_margin
+    from order_items as oi
+    inner join orders as o on oi.order_id = o.order_id
+    left join margins as m on oi.product_id = m.product_id
+
+),
+
+final as (
+
+    select
+        location_id,
+        daypart,
+        order_month,
+        sum(item_revenue) as total_revenue,
+        sum(gross_margin) as total_margin,
+        case
+            when sum(item_revenue) > 0
+            then sum(gross_margin) / sum(item_revenue) * 100
+            else 0
+        end as gross_margin_pct,
+        count(*) as item_count
+    from with_daypart
+    group by 1, 2, 3
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_operating_leverage.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_operating_leverage.sql
@@ -1,0 +1,67 @@
+with
+
+expenses as (
+
+    select
+        location_id,
+        location_name,
+        {{ dbt.date_trunc('month', 'incurred_date') }} as expense_month,
+        category_name,
+        is_cost_of_goods_sold,
+        expense_amount,
+        case
+            when category_name in ('rent', 'insurance', 'depreciation', 'licenses') then 'fixed'
+            when is_cost_of_goods_sold then 'variable'
+            when category_name in ('utilities', 'maintenance') then 'semi_variable'
+            else 'variable'
+        end as cost_type
+    from {{ ref('fct_expenses') }}
+
+),
+
+monthly_summary as (
+
+    select
+        location_id,
+        location_name,
+        expense_month,
+        sum(case when cost_type = 'fixed' then expense_amount else 0 end) as fixed_costs,
+        sum(case when cost_type = 'variable' then expense_amount else 0 end) as variable_costs,
+        sum(case when cost_type = 'semi_variable' then expense_amount else 0 end) as semi_variable_costs,
+        sum(expense_amount) as total_costs
+    from expenses
+    group by 1, 2, 3
+
+),
+
+final as (
+
+    select
+        location_id,
+        location_name,
+        expense_month,
+        fixed_costs,
+        variable_costs,
+        semi_variable_costs,
+        total_costs,
+        case
+            when total_costs > 0
+            then fixed_costs / total_costs * 100
+            else 0
+        end as fixed_cost_pct,
+        case
+            when total_costs > 0
+            then variable_costs / total_costs * 100
+            else 0
+        end as variable_cost_pct,
+        -- Higher ratio = more operating leverage
+        case
+            when variable_costs > 0
+            then fixed_costs / variable_costs
+            else null
+        end as operating_leverage_ratio
+    from monthly_summary
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_payment_failure_rate.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_payment_failure_rate.sql
@@ -1,0 +1,59 @@
+with
+
+transactions as (
+
+    select
+        payment_transaction_id,
+        order_id,
+        payment_method,
+        payment_status,
+        payment_amount,
+        processed_date
+    from {{ ref('stg_payment_transactions') }}
+
+),
+
+daily_summary as (
+
+    select
+        processed_date,
+        payment_method,
+        count(*) as total_attempts,
+        sum(case when payment_status = 'completed' then 1 else 0 end) as successful,
+        sum(case when payment_status = 'failed' then 1 else 0 end) as failed,
+        sum(case when payment_status = 'declined' then 1 else 0 end) as declined,
+        sum(case when payment_status not in ('completed', 'failed', 'declined') then 1 else 0 end) as other_status,
+        sum(case when payment_status in ('failed', 'declined') then payment_amount else 0 end) as failed_amount,
+        sum(payment_amount) as total_attempted_amount
+    from transactions
+    group by 1, 2
+
+),
+
+final as (
+
+    select
+        processed_date,
+        payment_method,
+        total_attempts,
+        successful,
+        failed,
+        declined,
+        other_status,
+        failed_amount,
+        total_attempted_amount,
+        case
+            when total_attempts > 0
+            then cast(failed + declined as {{ dbt.type_float() }}) / total_attempts * 100
+            else 0
+        end as failure_rate_pct,
+        case
+            when total_attempted_amount > 0
+            then failed_amount / total_attempted_amount * 100
+            else 0
+        end as failed_amount_pct
+    from daily_summary
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_payment_reconciliation.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_payment_reconciliation.sql
@@ -1,0 +1,67 @@
+with
+
+payments as (
+
+    select
+        payment_transaction_id,
+        order_id,
+        payment_amount,
+        payment_status,
+        payment_method,
+        processed_date
+    from {{ ref('stg_payment_transactions') }}
+
+),
+
+invoices as (
+
+    select
+        invoice_id,
+        order_id,
+        total_amount,
+        invoice_status,
+        issued_date
+    from {{ ref('fct_invoices') }}
+
+),
+
+matched as (
+
+    select
+        p.payment_transaction_id,
+        p.order_id,
+        p.payment_amount,
+        p.payment_status,
+        p.payment_method,
+        p.processed_date,
+        i.invoice_id,
+        i.total_amount,
+        i.invoice_status,
+        i.issued_date,
+        case
+            when i.invoice_id is null then 'payment_no_invoice'
+            when abs(p.payment_amount - i.total_amount) < 0.01 then 'matched'
+            when p.payment_amount < i.total_amount then 'underpayment'
+            when p.payment_amount > i.total_amount then 'overpayment'
+            else 'unreconciled'
+        end as reconciliation_status,
+        coalesce(p.payment_amount - i.total_amount, p.payment_amount) as variance_amount
+    from payments as p
+    left join invoices as i
+        on p.order_id = i.order_id
+
+)
+
+select
+    payment_transaction_id,
+    order_id,
+    payment_amount,
+    payment_status,
+    payment_method,
+    processed_date,
+    invoice_id,
+    total_amount,
+    invoice_status,
+    reconciliation_status,
+    variance_amount
+from matched

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_refund_turnaround.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_refund_turnaround.sql
@@ -1,0 +1,65 @@
+with
+
+refunds as (
+
+    select
+        refund_id,
+        order_id,
+        refund_amount,
+        refund_reason,
+        refund_status,
+        requested_date,
+        resolved_date,
+        case
+            when resolved_date is not null
+            then {{ dbt.datediff('requested_date', 'resolved_date', 'day') }}
+            else null
+        end as turnaround_days
+    from {{ ref('fct_refunds') }}
+
+),
+
+summary as (
+
+    select
+        {{ dbt.date_trunc('month', 'requested_date') }} as refund_month,
+        refund_reason,
+        count(*) as total_refunds,
+        sum(case when resolved_date is not null then 1 else 0 end) as completed_refunds,
+        avg(turnaround_days) as avg_turnaround_days,
+        min(turnaround_days) as min_turnaround_days,
+        max(turnaround_days) as max_turnaround_days,
+        sum(case when turnaround_days <= 1 then 1 else 0 end) as within_1_day,
+        sum(case when turnaround_days <= 3 then 1 else 0 end) as within_3_days,
+        sum(case when turnaround_days <= 7 then 1 else 0 end) as within_7_days,
+        sum(refund_amount) as total_refund_amount
+    from refunds
+    group by 1, 2
+
+)
+
+select
+    refund_month,
+    refund_reason,
+    total_refunds,
+    completed_refunds,
+    avg_turnaround_days,
+    min_turnaround_days,
+    max_turnaround_days,
+    case
+        when completed_refunds > 0
+        then cast(within_1_day as {{ dbt.type_float() }}) / completed_refunds * 100
+        else 0
+    end as pct_within_1_day,
+    case
+        when completed_refunds > 0
+        then cast(within_3_days as {{ dbt.type_float() }}) / completed_refunds * 100
+        else 0
+    end as pct_within_3_days,
+    case
+        when completed_refunds > 0
+        then cast(within_7_days as {{ dbt.type_float() }}) / completed_refunds * 100
+        else 0
+    end as pct_within_7_days,
+    total_refund_amount
+from summary

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_revenue_by_daypart.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_revenue_by_daypart.sql
@@ -1,0 +1,63 @@
+with
+
+orders as (
+
+    select
+        order_id,
+        location_id,
+        ordered_at,
+        order_total,
+        {{ dbt.date_trunc('day', 'ordered_at') }} as order_date,
+        extract(hour from ordered_at) as order_hour
+    from {{ ref('stg_orders') }}
+
+),
+
+with_daypart as (
+
+    select
+        order_id,
+        location_id,
+        order_date,
+        order_total,
+        order_hour,
+        case
+            when order_hour between 6 and 10 then 'morning'
+            when order_hour between 11 and 14 then 'lunch'
+            when order_hour between 15 and 17 then 'afternoon'
+            when order_hour between 18 and 21 then 'evening'
+            else 'late_night'
+        end as daypart
+    from orders
+
+),
+
+store_names as (
+
+    select
+        location_id,
+        location_name as store_name
+    from {{ ref('stg_locations') }}
+
+),
+
+final as (
+
+    select
+        d.location_id,
+        s.store_name,
+        d.daypart,
+        {{ dbt.date_trunc('month', 'd.order_date') }} as revenue_month,
+        count(d.order_id) as order_count,
+        sum(d.order_total) as total_revenue,
+        avg(d.order_total) as avg_order_value,
+        cast(count(d.order_id) as {{ dbt.type_float() }})
+            / nullif(count(distinct d.order_date), 0) as avg_daily_orders
+    from with_daypart as d
+    inner join store_names as s
+        on d.location_id = s.location_id
+    group by 1, 2, 3, 4
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_revenue_forecast_simple.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_revenue_forecast_simple.sql
@@ -1,0 +1,70 @@
+with
+
+monthly_rev as (
+
+    select
+        location_id,
+        store_name,
+        month_start,
+        monthly_revenue,
+        row_number() over (partition by location_id order by month_start) as month_seq
+    from {{ ref('met_monthly_revenue_by_store') }}
+
+),
+
+store_stats as (
+
+    select
+        location_id,
+        store_name,
+        count(*) as n_months,
+        avg(monthly_revenue) as avg_revenue,
+        -- Simple linear regression: slope = (n*sum(xy) - sum(x)*sum(y)) / (n*sum(x^2) - (sum(x))^2)
+        (count(*) * sum(month_seq * monthly_revenue) - sum(month_seq) * sum(monthly_revenue))
+            / nullif(count(*) * sum(month_seq * month_seq) - sum(month_seq) * sum(month_seq), 0) as slope,
+        max(month_seq) as last_seq,
+        max(month_start) as last_month
+    from monthly_rev
+    group by 1, 2
+
+),
+
+with_intercept as (
+
+    select
+        location_id,
+        store_name,
+        n_months,
+        avg_revenue,
+        slope,
+        last_seq,
+        last_month,
+        avg_revenue - slope * (cast(n_months + 1 as {{ dbt.type_float() }}) / 2) as intercept
+    from store_stats
+
+),
+
+forecast as (
+
+    select
+        location_id,
+        store_name,
+        n_months,
+        avg_revenue,
+        slope,
+        intercept,
+        last_month,
+        -- Forecast next 3 months
+        {{ sf_greatest(["(intercept + slope * (last_seq + 1))", "0"]) }} as forecast_month_1,
+        {{ sf_greatest(["(intercept + slope * (last_seq + 2))", "0"]) }} as forecast_month_2,
+        {{ sf_greatest(["(intercept + slope * (last_seq + 3))", "0"]) }} as forecast_month_3,
+        case
+            when avg_revenue > 0
+            then slope / avg_revenue * 100
+            else 0
+        end as monthly_growth_rate_pct
+    from with_intercept
+
+)
+
+select * from forecast

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_revenue_mix_shift.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_revenue_mix_shift.sql
@@ -1,0 +1,83 @@
+with
+
+ps as (
+    select * from {{ ref('fct_product_sales') }}
+),
+
+product_sales as (
+
+    select
+        ps.product_id,
+        null::text,
+        ps.sale_date,
+        ps.daily_revenue,
+        ps.units_sold
+    from ps
+
+),
+
+products as (
+
+    select
+        product_id,
+        product_name,
+        product_type
+    from {{ ref('stg_products') }}
+
+),
+
+monthly_by_type as (
+
+    select
+        {{ dbt.date_trunc('month', 'ps.sale_date') }} as sale_month,
+        p.product_type,
+        sum(ps.daily_revenue) as type_revenue,
+        sum(ps.units_sold) as type_quantity
+    from product_sales as ps
+    inner join products as p on ps.product_id = p.product_id
+    group by 1, 2
+
+),
+
+monthly_total as (
+
+    select
+        sale_month,
+        sum(type_revenue) as total_revenue
+    from monthly_by_type
+    group by 1
+
+),
+
+with_share as (
+
+    select
+        m.sale_month,
+        m.product_type,
+        m.type_revenue,
+        m.type_quantity,
+        mt.total_revenue,
+        case
+            when mt.total_revenue > 0
+            then m.type_revenue / mt.total_revenue * 100
+            else 0
+        end as revenue_share_pct,
+        lag(
+            case when mt.total_revenue > 0 then m.type_revenue / mt.total_revenue * 100 else 0 end,
+            1
+        ) over (partition by m.product_type order by m.sale_month) as prev_month_share_pct
+    from monthly_by_type as m
+    inner join monthly_total as mt on m.sale_month = mt.sale_month
+
+)
+
+select
+    sale_month,
+    product_type,
+    type_revenue,
+    type_quantity,
+    total_revenue,
+    revenue_share_pct,
+    prev_month_share_pct,
+    revenue_share_pct - coalesce(prev_month_share_pct, revenue_share_pct) as share_shift_pct
+from with_share

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_revenue_per_sqft_proxy.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_revenue_per_sqft_proxy.sql
@@ -1,0 +1,55 @@
+with
+
+monthly_rev as (
+
+    select
+        location_id,
+        store_name,
+        month_start,
+        monthly_revenue
+    from {{ ref('met_monthly_revenue_by_store') }}
+
+),
+
+store_age as (
+
+    select
+        location_id,
+        location_name,
+        opened_date,
+        {{ dbt.datediff('opened_date', 'current_date', 'month') }} as months_open
+    from {{ ref('stg_locations') }}
+
+),
+
+final as (
+
+    select
+        mr.location_id,
+        mr.store_name,
+        mr.month_start,
+        mr.monthly_revenue,
+        sa.opened_date,
+        sa.months_open,
+        -- Use store age as proxy for size (older stores tend to be larger)
+        case
+            when sa.months_open > 60 then 1.5
+            when sa.months_open > 36 then 1.2
+            when sa.months_open > 12 then 1.0
+            else 0.8
+        end as size_proxy_factor,
+        mr.monthly_revenue / nullif(
+            case
+                when sa.months_open > 60 then 1.5
+                when sa.months_open > 36 then 1.2
+                when sa.months_open > 12 then 1.0
+                else 0.8
+            end, 0
+        ) as normalized_revenue
+    from monthly_rev as mr
+    inner join store_age as sa
+        on mr.location_id = sa.location_id
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_revenue_waterfall.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_revenue_waterfall.sql
@@ -1,0 +1,88 @@
+with
+
+monthly_orders as (
+
+    select
+        {{ dbt.date_trunc('month', 'ordered_at') }} as revenue_month,
+        customer_id,
+        sum(order_total) as customer_revenue
+    from {{ ref('stg_orders') }}
+    group by 1, 2
+
+),
+
+customer_first_month as (
+
+    select
+        customer_id,
+        min(revenue_month) as first_month
+    from monthly_orders
+    group by 1
+
+),
+
+classified as (
+
+    select
+        mo.revenue_month,
+        mo.customer_id,
+        mo.customer_revenue,
+        cfm.first_month,
+        case
+            when mo.revenue_month = cfm.first_month then 'new_customer'
+            else 'returning_customer'
+        end as customer_type,
+        lag(mo.customer_revenue) over (
+            partition by mo.customer_id order by mo.revenue_month
+        ) as prev_month_revenue
+    from monthly_orders as mo
+    inner join customer_first_month as cfm
+        on mo.customer_id = cfm.customer_id
+
+),
+
+waterfall as (
+
+    select
+        revenue_month,
+        sum(case when customer_type = 'new_customer' then customer_revenue else 0 end) as new_customer_revenue,
+        sum(case when customer_type = 'returning_customer' and prev_month_revenue is not null
+                      and customer_revenue > prev_month_revenue
+                 then customer_revenue - prev_month_revenue else 0 end) as upsell_revenue,
+        sum(case when customer_type = 'returning_customer' and prev_month_revenue is not null
+                      and customer_revenue <= prev_month_revenue
+                 then customer_revenue else 0 end) as stable_returning_revenue,
+        sum(case when customer_type = 'returning_customer' and prev_month_revenue is not null
+                      and customer_revenue < prev_month_revenue
+                 then prev_month_revenue - customer_revenue else 0 end) as downsell_amount,
+        sum(customer_revenue) as total_revenue
+    from classified
+    group by 1
+
+),
+
+with_churn as (
+
+    select
+        w.revenue_month,
+        w.new_customer_revenue,
+        w.upsell_revenue,
+        w.stable_returning_revenue,
+        w.downsell_amount,
+        coalesce(lag(w.total_revenue) over (order by w.revenue_month), 0) as opening_balance,
+        w.total_revenue as closing_balance
+    from waterfall as w
+
+)
+
+select
+    revenue_month,
+    opening_balance,
+    new_customer_revenue,
+    upsell_revenue,
+    stable_returning_revenue,
+    -1 * downsell_amount as downsell_impact,
+    opening_balance - closing_balance + new_customer_revenue + upsell_revenue - downsell_amount
+        - stable_returning_revenue as implied_churn_revenue,
+    closing_balance
+from with_churn

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_same_store_sales.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_same_store_sales.sql
@@ -1,0 +1,84 @@
+with
+
+mr as (
+    select * from {{ ref('met_monthly_revenue_by_store') }}
+),
+
+store_tenure as (
+
+    select
+        location_id,
+        opened_date,
+        {{ dbt.datediff('opened_date', 'current_date', 'month') }} as months_open
+    from {{ ref('stg_locations') }}
+
+),
+
+qualified_stores as (
+
+    select location_id
+    from store_tenure
+    where months_open >= 12
+
+),
+
+monthly_rev as (
+
+    select
+        mr.location_id,
+        mr.store_name,
+        mr.month_start,
+        mr.monthly_revenue,
+        mr.monthly_orders
+    from mr
+    inner join qualified_stores as qs
+        on mr.location_id = qs.location_id
+
+),
+
+with_growth as (
+
+    select
+        location_id,
+        store_name,
+        month_start,
+        monthly_revenue,
+        monthly_orders,
+        lag(monthly_revenue, 12) over (
+            partition by location_id order by month_start
+        ) as revenue_same_month_last_year,
+        lag(monthly_orders, 12) over (
+            partition by location_id order by month_start
+        ) as orders_same_month_last_year
+    from monthly_rev
+
+),
+
+final as (
+
+    select
+        location_id,
+        store_name,
+        month_start,
+        monthly_revenue,
+        monthly_orders,
+        revenue_same_month_last_year,
+        orders_same_month_last_year,
+        case
+            when revenue_same_month_last_year > 0
+            then (monthly_revenue - revenue_same_month_last_year)
+                / revenue_same_month_last_year * 100
+            else null
+        end as same_store_revenue_growth_pct,
+        case
+            when orders_same_month_last_year > 0
+            then (monthly_orders - orders_same_month_last_year)
+                / cast(orders_same_month_last_year as {{ dbt.type_float() }}) * 100
+            else null
+        end as same_store_order_growth_pct
+    from with_growth
+    where revenue_same_month_last_year is not null
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_seasonal_budget_adjustment.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_seasonal_budget_adjustment.sql
@@ -1,0 +1,60 @@
+with
+
+monthly_rev as (
+
+    select
+        month_start,
+        extract(month from month_start) as calendar_month,
+        sum(monthly_revenue) as total_monthly_revenue
+    from {{ ref('met_monthly_revenue_by_store') }}
+    group by 1, 2
+
+),
+
+annual_avg as (
+
+    select
+        extract(year from month_start) as year_val,
+        avg(total_monthly_revenue) as annual_avg_monthly_revenue
+    from monthly_rev
+    group by 1
+
+),
+
+seasonal_index as (
+
+    select
+        mr.calendar_month,
+        avg(mr.total_monthly_revenue) as avg_month_revenue,
+        avg(aa.annual_avg_monthly_revenue) as avg_annual_monthly,
+        case
+            when avg(aa.annual_avg_monthly_revenue) > 0
+            then avg(mr.total_monthly_revenue) / avg(aa.annual_avg_monthly_revenue)
+            else 1
+        end as seasonal_factor
+    from monthly_rev as mr
+    inner join annual_avg as aa
+        on extract(year from mr.month_start) = aa.year_val
+    group by 1
+
+),
+
+final as (
+
+    select
+        calendar_month,
+        avg_month_revenue,
+        avg_annual_monthly,
+        seasonal_factor,
+        case
+            when seasonal_factor > 1.15 then 'peak_season'
+            when seasonal_factor < 0.85 then 'off_season'
+            else 'normal_season'
+        end as season_classification,
+        -- Budget adjustment: multiply base budget by seasonal factor
+        round(seasonal_factor, 3) as budget_multiplier
+    from seasonal_index
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_store_roi.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_store_roi.sql
@@ -1,0 +1,73 @@
+with
+
+store_pnl as (
+
+    select
+        location_id,
+        store_name,
+        report_month,
+        monthly_revenue,
+        total_costs,
+        net_profit
+    from {{ ref('rpt_store_pnl') }}
+
+),
+
+store_info as (
+
+    select
+        location_id,
+        opened_date,
+        {{ dbt.datediff('opened_date', 'current_date', 'month') }} as months_open
+    from {{ ref('stg_locations') }}
+
+),
+
+cumulative as (
+
+    select
+        sp.location_id,
+        sp.store_name,
+        sp.report_month,
+        sp.monthly_revenue,
+        sp.net_profit,
+        si.opened_date,
+        si.months_open,
+        sum(sp.net_profit) over (
+            partition by sp.location_id order by sp.report_month
+        ) as cumulative_profit,
+        sum(sp.monthly_revenue) over (
+            partition by sp.location_id order by sp.report_month
+        ) as cumulative_revenue
+    from store_pnl as sp
+    inner join store_info as si on sp.location_id = si.location_id
+
+),
+
+final as (
+
+    select
+        location_id,
+        store_name,
+        report_month,
+        monthly_revenue,
+        net_profit,
+        opened_date,
+        months_open,
+        cumulative_profit,
+        cumulative_revenue,
+        -- Estimate setup cost as 3x first month total costs
+        first_value(net_profit) over (
+            partition by location_id order by report_month
+        ) * -3 as estimated_setup_cost,
+        case
+            when first_value(net_profit) over (partition by location_id order by report_month) * -3 != 0
+            then cumulative_profit / abs(first_value(net_profit) over (
+                partition by location_id order by report_month) * -3) * 100
+            else null
+        end as roi_pct
+    from cumulative
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_tax_efficiency.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_tax_efficiency.sql
@@ -1,0 +1,47 @@
+with
+
+tax_collected as (
+
+    select
+        jurisdiction,
+        tax_month,
+        tax_collected,
+        taxable_amount,
+        case when taxable_amount > 0 then tax_collected / taxable_amount else 0 end as effective_tax_rate
+    from {{ ref('int_tax_collected_by_jurisdiction') }}
+
+),
+
+statutory_rates as (
+
+    select
+        jurisdiction,
+        tax_rate_pct as statutory_rate
+    from {{ ref('stg_tax_rates') }}
+    where effective_to_date is null or effective_to_date >= current_date
+
+),
+
+final as (
+
+    select
+        tc.jurisdiction,
+        tc.tax_month,
+        tc.tax_collected,
+        tc.taxable_amount,
+        case when tc.taxable_amount > 0 then tc.tax_collected / tc.taxable_amount else 0 end,
+        sr.statutory_rate,
+        case when tc.taxable_amount > 0 then tc.tax_collected / tc.taxable_amount else 0 end - sr.statutory_rate as rate_gap,
+        abs(case when tc.taxable_amount > 0 then tc.tax_collected / tc.taxable_amount else 0 end - sr.statutory_rate) * tc.taxable_amount as implied_tax_leakage,
+        case
+            when abs(case when tc.taxable_amount > 0 then tc.tax_collected / tc.taxable_amount else 0 end - sr.statutory_rate) > 0.02 then 'significant_gap'
+            when abs(case when tc.taxable_amount > 0 then tc.tax_collected / tc.taxable_amount else 0 end - sr.statutory_rate) > 0.005 then 'minor_gap'
+            else 'aligned'
+        end as efficiency_status
+    from tax_collected as tc
+    left join statutory_rates as sr
+        on tc.jurisdiction = sr.jurisdiction
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_working_capital_cycle.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_advanced/fin_working_capital_cycle.sql
@@ -1,0 +1,68 @@
+with
+
+ar_aging as (
+
+    select
+        {{ dbt.date_trunc('month', 'created_date') }} as report_month,
+        avg(days_past_due) as avg_days_receivable
+    from {{ ref('int_accounts_receivable_aging') }}
+    group by 1
+
+),
+
+inventory as (
+
+    select
+        current_date as report_month,
+        sum(current_quantity) as total_units,
+        avg(current_quantity) as avg_units_per_product
+    from {{ ref('int_inventory_current_level') }}
+
+),
+
+daily_usage as (
+
+    select
+        avg(daily_depletion_rate) as avg_daily_depletion
+    from {{ ref('int_stock_depletion_rate') }}
+    where daily_depletion_rate > 0
+
+),
+
+po_payment as (
+
+    select
+        {{ dbt.date_trunc('month', 'ordered_at') }} as report_month,
+        avg({{ dbt.datediff('ordered_at', 'expected_delivery_at', 'day') }}) as avg_days_payable
+    from {{ ref('fct_purchase_orders') }}
+    group by 1
+
+),
+
+final as (
+
+    select
+        ar.report_month,
+        ar.avg_days_receivable,
+        case
+            when du.avg_daily_depletion > 0
+            then inv.total_units / du.avg_daily_depletion
+            else null
+        end as days_inventory_on_hand,
+        pp.avg_days_payable,
+        ar.avg_days_receivable
+            + coalesce(
+                case when du.avg_daily_depletion > 0
+                     then inv.total_units / du.avg_daily_depletion
+                     else 0 end, 0)
+            - coalesce(pp.avg_days_payable, 0)
+        as cash_conversion_cycle_days
+    from ar_aging as ar
+    cross join inventory as inv
+    cross join daily_usage as du
+    left join po_payment as pp
+        on ar.report_month = pp.report_month
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/_finance_deep__models.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/_finance_deep__models.yml
@@ -1,0 +1,185 @@
+models:
+  - name: int_revenue_by_daypart
+    description: Revenue split by daypart (morning, lunch, afternoon, evening) per store per day.
+    columns:
+      - name: revenue_date
+        description: The date of the revenue.
+      - name: location_id
+        description: Foreign key to the store location.
+      - name: daypart
+        description: Time-of-day classification (morning, lunch, afternoon, evening).
+      - name: order_count
+        description: Number of orders in this daypart.
+      - name: total_revenue
+        description: Total revenue for this daypart.
+      - name: avg_order_value
+        description: Average order value for this daypart.
+
+  - name: int_invoice_payment_matching
+    description: Matches invoices to payments and flags partial, over, or underpayments.
+    columns:
+      - name: invoice_id
+        description: The unique invoice identifier.
+        data_tests:
+          - not_null
+          - unique
+      - name: payment_match_status
+        description: Payment status (unpaid, underpaid, fully_paid, overpaid).
+
+  - name: int_refund_processing_time
+    description: Refund records enriched with processing time in days and speed tier.
+    columns:
+      - name: refund_id
+        description: The unique refund identifier.
+        data_tests:
+          - not_null
+          - unique
+      - name: processing_days
+        description: Number of days from refund request to resolution.
+      - name: processing_speed_tier
+        description: Classification of processing speed (same_day, fast, normal, slow, pending).
+
+  - name: int_gift_card_lifecycle
+    description: Gift card lifecycle metrics including age, usage frequency, and balance tier.
+    columns:
+      - name: gift_card_id
+        description: The unique gift card identifier.
+        data_tests:
+          - not_null
+          - unique
+      - name: card_age_days
+        description: Days since the gift card was issued.
+      - name: utilization_pct
+        description: Percentage of the initial balance that has been used.
+      - name: balance_tier
+        description: Current balance tier (high_balance, medium_balance, low_balance, depleted).
+
+  - name: int_expense_fixed_vs_variable
+    description: Classifies expense categories as fixed or variable based on coefficient of variation.
+    columns:
+      - name: location_id
+        description: Foreign key to the store location.
+      - name: expense_category_id
+        description: Foreign key to the expense category.
+      - name: expense_classification
+        description: Whether the expense is classified as fixed or variable.
+      - name: coefficient_of_variation
+        description: Statistical measure of relative variability.
+
+  - name: int_revenue_per_customer_monthly
+    config:
+      tags: ['cadence:monthly']
+    description: Monthly revenue and order count per customer.
+    columns:
+      - name: customer_id
+        description: The unique customer identifier.
+      - name: revenue_month
+        description: The month of the revenue.
+      - name: total_revenue
+        description: Total revenue from this customer in the month.
+
+  - name: int_payment_decline_rate
+    description: Payment decline and failure rate by payment method and store per day.
+    columns:
+      - name: location_id
+        description: Foreign key to the store location.
+      - name: payment_method
+        description: Payment method used.
+      - name: decline_rate_pct
+        description: Percentage of payment attempts that were declined or failed.
+
+  - name: int_average_transaction_value
+    description: Daily average transaction value by store with rolling 7-day and 30-day trends.
+    columns:
+      - name: location_id
+        description: Foreign key to the store location.
+      - name: transaction_date
+        description: The date of the transactions.
+      - name: avg_transaction_value
+        description: Average order total for the day.
+      - name: rolling_7d_avg_atv
+        description: Rolling 7-day average of daily ATV.
+      - name: rolling_30d_avg_atv
+        description: Rolling 30-day average of daily ATV.
+
+  - name: int_revenue_by_customer_segment
+    description: Revenue breakdown by customer RFM segment per month.
+    columns:
+      - name: rfm_segment
+        description: Customer RFM segment name.
+      - name: revenue_month
+        description: The month of the revenue.
+      - name: segment_revenue
+        description: Total revenue from this segment.
+      - name: customer_count
+        description: Number of customers in the segment that month.
+
+  - name: int_expense_by_revenue_ratio
+    description: Monthly expense-to-revenue ratio by expense category and store.
+    columns:
+      - name: location_id
+        description: Foreign key to the store location.
+      - name: expense_month
+        description: The month of the expense.
+      - name: expense_to_revenue_pct
+        description: Expense as a percentage of revenue.
+
+  - name: int_accounts_receivable_turnover
+    description: Accounts receivable turnover ratio and days sales outstanding per month.
+    columns:
+      - name: sales_month
+        description: The month of the analysis.
+      - name: ar_turnover_ratio
+        description: Net credit sales divided by average AR balance.
+      - name: days_sales_outstanding
+        description: Average number of days to collect receivables.
+
+  - name: int_budget_utilization_rate
+    description: Budget utilization percentage by category and store per month.
+    columns:
+      - name: budget_id
+        description: The unique budget identifier.
+        data_tests:
+          - not_null
+          - unique
+      - name: utilization_rate_pct
+        description: Percentage of budget consumed.
+      - name: budget_status
+        description: Budget health status (over_budget, near_budget, on_track, under_utilized).
+
+  - name: int_daily_profit_by_store
+    config:
+      tags: ['cadence:daily']
+    description: Daily profit calculated as revenue minus allocated expenses per store.
+    columns:
+      - name: location_id
+        description: Foreign key to the store location.
+      - name: profit_date
+        description: The date of the profit calculation.
+      - name: daily_profit
+        description: Revenue minus expenses for the day.
+      - name: profit_margin_pct
+        description: Profit as a percentage of revenue.
+
+  - name: int_payment_method_by_segment
+    description: Payment method preferences broken down by customer RFM segment.
+    columns:
+      - name: rfm_segment
+        description: Customer RFM segment name.
+      - name: payment_method
+        description: Payment method used.
+      - name: pct_of_segment_transactions
+        description: Percentage of segment transactions using this method.
+
+  - name: int_revenue_concentration_index
+    description: Herfindahl index measuring revenue concentration across customers per store.
+    columns:
+      - name: location_id
+        description: Foreign key to the store location.
+        data_tests:
+          - not_null
+          - unique
+      - name: herfindahl_index
+        description: Sum of squared revenue shares (0-1 scale).
+      - name: concentration_level
+        description: Concentration classification (highly_diversified to high_concentration).

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_accounts_receivable_turnover.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_accounts_receivable_turnover.sql
@@ -1,0 +1,62 @@
+with
+
+ar as (
+
+    select * from {{ ref('stg_accounts_receivable') }}
+
+),
+
+invoices as (
+
+    select * from {{ ref('stg_invoices') }}
+
+),
+
+monthly_credit_sales as (
+
+    select
+        {{ dbt.date_trunc('month', 'issued_date') }} as sales_month,
+        sum(total_amount) as net_credit_sales
+    from invoices
+    where invoice_status != 'draft'
+    group by 1
+
+),
+
+monthly_ar_balance as (
+
+    select
+        {{ dbt.date_trunc('month', 'created_date') }} as ar_month,
+        avg(amount_outstanding) as avg_ar_balance,
+        sum(amount_outstanding) as total_ar_outstanding,
+        count(receivable_id) as ar_count
+    from ar
+    group by 1
+
+),
+
+final as (
+
+    select
+        cs.sales_month,
+        cs.net_credit_sales,
+        coalesce(arb.avg_ar_balance, 0) as avg_ar_balance,
+        coalesce(arb.total_ar_outstanding, 0) as total_ar_outstanding,
+        arb.ar_count,
+        case
+            when coalesce(arb.avg_ar_balance, 0) > 0
+                then round(cast(cs.net_credit_sales / arb.avg_ar_balance as {{ dbt.type_float() }}), 2)
+            else null
+        end as ar_turnover_ratio,
+        case
+            when cs.net_credit_sales > 0 and coalesce(arb.avg_ar_balance, 0) > 0
+                then round(cast(365.0 * arb.avg_ar_balance / cs.net_credit_sales as {{ dbt.type_float() }}), 1)
+            else null
+        end as days_sales_outstanding
+    from monthly_credit_sales as cs
+    left join monthly_ar_balance as arb
+        on cs.sales_month = arb.ar_month
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_average_transaction_value.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_average_transaction_value.sql
@@ -1,0 +1,48 @@
+with
+
+orders as (
+
+    select * from {{ ref('stg_orders') }}
+
+),
+
+daily_atv as (
+
+    select
+        location_id,
+        ordered_at as transaction_date,
+        count(order_id) as daily_order_count,
+        sum(order_total) as daily_total_revenue,
+        avg(order_total) as avg_transaction_value,
+        min(order_total) as min_transaction_value,
+        max(order_total) as max_transaction_value
+    from orders
+    group by 1, 2
+
+),
+
+with_trend as (
+
+    select
+        location_id,
+        transaction_date,
+        daily_order_count,
+        daily_total_revenue,
+        avg_transaction_value,
+        min_transaction_value,
+        max_transaction_value,
+        avg(avg_transaction_value) over (
+            partition by location_id
+            order by transaction_date
+            rows between 6 preceding and current row
+        ) as rolling_7d_avg_atv,
+        avg(avg_transaction_value) over (
+            partition by location_id
+            order by transaction_date
+            rows between 29 preceding and current row
+        ) as rolling_30d_avg_atv
+    from daily_atv
+
+)
+
+select * from with_trend

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_budget_utilization_rate.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_budget_utilization_rate.sql
@@ -1,0 +1,59 @@
+with
+
+budgets as (
+
+    select * from {{ ref('stg_budgets') }}
+
+),
+
+expenses as (
+
+    select * from {{ ref('stg_expenses') }}
+
+),
+
+monthly_actual as (
+
+    select
+        location_id,
+        expense_category_id,
+        {{ dbt.date_trunc('month', 'incurred_date') }} as expense_month,
+        sum(expense_amount) as actual_spend
+    from expenses
+    group by 1, 2, 3
+
+),
+
+final as (
+
+    select
+        b.budget_id,
+        b.location_id,
+        b.expense_category_id,
+        b.budget_month,
+        b.budgeted_amount,
+        coalesce(ma.actual_spend, 0) as actual_spend,
+        b.budgeted_amount - coalesce(ma.actual_spend, 0) as budget_remaining,
+        case
+            when b.budgeted_amount > 0
+                then round(coalesce(ma.actual_spend, 0) / b.budgeted_amount * 100, 2)
+            else 0
+        end as utilization_rate_pct,
+        case
+            when b.budgeted_amount > 0 and coalesce(ma.actual_spend, 0) / b.budgeted_amount > 1.0
+                then 'over_budget'
+            when b.budgeted_amount > 0 and coalesce(ma.actual_spend, 0) / b.budgeted_amount > 0.9
+                then 'near_budget'
+            when b.budgeted_amount > 0 and coalesce(ma.actual_spend, 0) / b.budgeted_amount > 0.5
+                then 'on_track'
+            else 'under_utilized'
+        end as budget_status
+    from budgets as b
+    left join monthly_actual as ma
+        on b.location_id = ma.location_id
+        and b.expense_category_id = ma.expense_category_id
+        and b.budget_month = ma.expense_month
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_daily_profit_by_store.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_daily_profit_by_store.sql
@@ -1,0 +1,46 @@
+with
+
+daily_revenue as (
+
+    select
+        revenue_date,
+        location_id,
+        total_revenue
+    from {{ ref('int_daily_revenue') }}
+
+),
+
+expenses as (
+
+    select
+        location_id,
+        incurred_date,
+        sum(expense_amount) as daily_expenses
+    from {{ ref('stg_expenses') }}
+    group by 1, 2
+
+),
+
+final as (
+
+    select
+        dr.revenue_date as profit_date,
+        dr.location_id,
+        dr.total_revenue,
+        coalesce(e.daily_expenses, 0) as daily_expenses,
+        dr.total_revenue - coalesce(e.daily_expenses, 0) as daily_profit,
+        case
+            when dr.total_revenue > 0
+                then round(cast(
+                    (dr.total_revenue - coalesce(e.daily_expenses, 0)) / dr.total_revenue * 100
+                as {{ dbt.type_float() }}), 2)
+            else null
+        end as profit_margin_pct
+    from daily_revenue as dr
+    left join expenses as e
+        on dr.location_id = e.location_id
+        and dr.revenue_date = e.incurred_date
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_expense_by_revenue_ratio.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_expense_by_revenue_ratio.sql
@@ -1,0 +1,55 @@
+with
+
+expense_monthly as (
+
+    select
+        location_id,
+        expense_month,
+        category_name,
+        total_expense_amount
+    from {{ ref('int_expense_summary_monthly') }}
+
+),
+
+revenue as (
+
+    select
+        location_id,
+        revenue_date,
+        total_revenue
+    from {{ ref('int_daily_revenue') }}
+
+),
+
+monthly_revenue as (
+
+    select
+        location_id,
+        {{ dbt.date_trunc('month', 'revenue_date') }} as revenue_month,
+        sum(total_revenue) as monthly_revenue
+    from revenue
+    group by 1, 2
+
+),
+
+final as (
+
+    select
+        em.location_id,
+        em.expense_month,
+        em.category_name,
+        em.total_expense_amount,
+        coalesce(mr.monthly_revenue, 0) as monthly_revenue,
+        case
+            when coalesce(mr.monthly_revenue, 0) > 0
+                then round(cast(em.total_expense_amount / mr.monthly_revenue * 100 as {{ dbt.type_float() }}), 2)
+            else null
+        end as expense_to_revenue_pct
+    from expense_monthly as em
+    left join monthly_revenue as mr
+        on em.location_id = mr.location_id
+        and em.expense_month = mr.revenue_month
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_expense_fixed_vs_variable.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_expense_fixed_vs_variable.sql
@@ -1,0 +1,86 @@
+with
+
+expenses as (
+
+    select * from {{ ref('stg_expenses') }}
+
+),
+
+expense_categories as (
+
+    select * from {{ ref('stg_expense_categories') }}
+
+),
+
+orders as (
+
+    select
+        location_id,
+        {{ dbt.date_trunc('month', 'ordered_at') }} as order_month,
+        count(order_id) as order_count
+    from {{ ref('stg_orders') }}
+    group by 1, 2
+
+),
+
+monthly_expense as (
+
+    select
+        e.location_id,
+        e.expense_category_id,
+        ec.category_name,
+        {{ dbt.date_trunc('month', 'e.incurred_date') }} as expense_month,
+        sum(e.expense_amount) as monthly_expense
+    from expenses as e
+    left join expense_categories as ec
+        on e.expense_category_id = ec.expense_category_id
+    group by 1, 2, 3, 4
+
+),
+
+expense_with_volume as (
+
+    select
+        me.location_id,
+        me.expense_category_id,
+        me.category_name,
+        me.expense_month,
+        me.monthly_expense,
+        coalesce(o.order_count, 0) as order_count,
+        case
+            when coalesce(o.order_count, 0) > 0
+                then me.monthly_expense / o.order_count
+            else null
+        end as expense_per_order
+    from monthly_expense as me
+    left join orders as o
+        on me.location_id = o.location_id
+        and me.expense_month = o.order_month
+
+),
+
+category_variance as (
+
+    select
+        location_id,
+        expense_category_id,
+        category_name,
+        avg(monthly_expense) as avg_monthly_expense,
+        {{ dbt.safe_cast('stddev(monthly_expense)', dbt.type_float()) }} as stddev_expense,
+        case
+            when avg(monthly_expense) > 0
+                then {{ dbt.safe_cast('stddev(monthly_expense)', dbt.type_float()) }} / avg(monthly_expense)
+            else 0
+        end as coefficient_of_variation,
+        case
+            when avg(monthly_expense) > 0
+                and {{ dbt.safe_cast('stddev(monthly_expense)', dbt.type_float()) }} / avg(monthly_expense) < 0.15
+                then 'fixed'
+            else 'variable'
+        end as expense_classification
+    from expense_with_volume
+    group by 1, 2, 3
+
+)
+
+select * from category_variance

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_gift_card_lifecycle.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_gift_card_lifecycle.sql
@@ -1,0 +1,52 @@
+with
+
+gift_cards as (
+
+    select * from {{ ref('stg_gift_cards') }}
+
+),
+
+usage_stats as (
+
+    select
+        gift_card_id,
+        count(payment_transaction_id) as usage_count,
+        sum(payment_amount) as total_spent
+    from {{ ref('stg_payment_transactions') }}
+    where gift_card_id is not null
+    group by 1
+
+),
+
+final as (
+
+    select
+        gc.gift_card_id,
+        gc.customer_id,
+        gc.gift_card_status,
+        gc.initial_balance,
+        gc.current_balance,
+        gc.issued_date,
+        gc.expires_date,
+        {{ dbt.datediff('gc.issued_date', dbt.current_timestamp(), 'day') }} as card_age_days,
+        coalesce(us.usage_count, 0) as usage_count,
+        coalesce(us.total_spent, 0) as total_spent,
+        gc.initial_balance - gc.current_balance as amount_used,
+        case
+            when gc.initial_balance > 0
+                then round(cast((gc.initial_balance - gc.current_balance) / gc.initial_balance * 100 as {{ dbt.type_float() }}), 2)
+            else 0
+        end as utilization_pct,
+        case
+            when gc.current_balance >= 50 then 'high_balance'
+            when gc.current_balance >= 20 then 'medium_balance'
+            when gc.current_balance > 0 then 'low_balance'
+            else 'depleted'
+        end as balance_tier
+    from gift_cards as gc
+    left join usage_stats as us
+        on gc.gift_card_id = us.gift_card_id
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_invoice_payment_matching.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_invoice_payment_matching.sql
@@ -1,0 +1,47 @@
+with
+
+invoices as (
+
+    select * from {{ ref('stg_invoices') }}
+
+),
+
+payments as (
+
+    select * from {{ ref('stg_payment_transactions') }}
+
+),
+
+payment_totals as (
+
+    select
+        order_id,
+        sum(case when payment_status = 'completed' then payment_amount else 0 end) as total_paid,
+        count(payment_transaction_id) as payment_count
+    from payments
+    group by 1
+
+),
+
+matched as (
+
+    select
+        i.invoice_id,
+        i.order_id,
+        i.total_amount as invoice_amount,
+        coalesce(pt.total_paid, 0) as total_paid,
+        coalesce(pt.payment_count, 0) as payment_count,
+        coalesce(pt.total_paid, 0) - i.total_amount as payment_variance,
+        case
+            when coalesce(pt.total_paid, 0) = 0 then 'unpaid'
+            when coalesce(pt.total_paid, 0) < i.total_amount then 'underpaid'
+            when coalesce(pt.total_paid, 0) = i.total_amount then 'fully_paid'
+            else 'overpaid'
+        end as payment_match_status
+    from invoices as i
+    left join payment_totals as pt
+        on i.order_id = pt.order_id
+
+)
+
+select * from matched

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_payment_decline_rate.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_payment_decline_rate.sql
@@ -1,0 +1,55 @@
+with
+
+payments as (
+
+    select * from {{ ref('stg_payment_transactions') }}
+
+),
+
+orders as (
+
+    select
+        order_id,
+        location_id
+    from {{ ref('stg_orders') }}
+
+),
+
+payment_with_store as (
+
+    select
+        p.payment_transaction_id,
+        p.payment_method,
+        p.payment_status,
+        p.payment_amount,
+        p.processed_date,
+        o.location_id
+    from payments as p
+    left join orders as o
+        on p.order_id = o.order_id
+
+),
+
+final as (
+
+    select
+        location_id,
+        payment_method,
+        processed_date,
+        count(payment_transaction_id) as total_attempts,
+        count(case when payment_status = 'completed' then 1 end) as successful_payments,
+        count(case when payment_status in ('failed', 'declined') then 1 end) as declined_payments,
+        case
+            when count(payment_transaction_id) > 0
+                then round(cast(
+                    count(case when payment_status in ('failed', 'declined') then 1 end) * 100.0
+                    / count(payment_transaction_id)
+                as {{ dbt.type_float() }}), 2)
+            else 0
+        end as decline_rate_pct
+    from payment_with_store
+    group by 1, 2, 3
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_payment_method_by_segment.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_payment_method_by_segment.sql
@@ -1,0 +1,59 @@
+with
+
+payments as (
+
+    select * from {{ ref('stg_payment_transactions') }}
+
+),
+
+orders as (
+
+    select
+        order_id,
+        customer_id
+    from {{ ref('stg_orders') }}
+
+),
+
+rfm as (
+
+    select
+        customer_id,
+        rfm_segment_code as rfm_segment
+    from {{ ref('int_customer_rfm_scores') }}
+
+),
+
+payment_with_segment as (
+
+    select
+        p.payment_method,
+        r.rfm_segment,
+        p.payment_amount,
+        p.payment_status
+    from payments as p
+    inner join orders as o
+        on p.order_id = o.order_id
+    inner join rfm as r
+        on o.customer_id = r.customer_id
+    where p.payment_status = 'completed'
+
+),
+
+final as (
+
+    select
+        rfm_segment,
+        payment_method,
+        count(*) as transaction_count,
+        sum(payment_amount) as total_amount,
+        avg(payment_amount) as avg_amount,
+        round(
+            count(*) * 100.0 / sum(count(*)) over (partition by rfm_segment)
+        , 2) as pct_of_segment_transactions
+    from payment_with_segment
+    group by 1, 2
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_refund_processing_time.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_refund_processing_time.sql
@@ -1,0 +1,40 @@
+with
+
+refunds as (
+
+    select * from {{ ref('stg_refunds') }}
+
+),
+
+final as (
+
+    select
+        refund_id,
+        order_id,
+        invoice_id,
+        refund_reason,
+        refund_status,
+        refund_amount,
+        requested_date,
+        resolved_date,
+        case
+            when resolved_date is not null
+                then {{ dbt.datediff('requested_date', 'resolved_date', 'day') }}
+            else null
+        end as processing_days,
+        case
+            when resolved_date is not null and {{ dbt.datediff('requested_date', 'resolved_date', 'day') }} <= 1
+                then 'same_day'
+            when resolved_date is not null and {{ dbt.datediff('requested_date', 'resolved_date', 'day') }} <= 3
+                then 'fast'
+            when resolved_date is not null and {{ dbt.datediff('requested_date', 'resolved_date', 'day') }} <= 7
+                then 'normal'
+            when resolved_date is not null
+                then 'slow'
+            else 'pending'
+        end as processing_speed_tier
+    from refunds
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_revenue_by_customer_segment.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_revenue_by_customer_segment.sql
@@ -1,0 +1,43 @@
+with
+
+rfm as (
+
+    select * from {{ ref('int_customer_rfm_scores') }}
+
+),
+
+orders as (
+
+    select * from {{ ref('stg_orders') }}
+
+),
+
+order_revenue as (
+
+    select
+        o.customer_id,
+        {{ dbt.date_trunc('month', 'o.ordered_at') }} as revenue_month,
+        sum(o.order_total) as total_revenue,
+        count(o.order_id) as order_count
+    from orders as o
+    group by 1, 2
+
+),
+
+final as (
+
+    select
+        r.rfm_segment_code as rfm_segment,
+        orv.revenue_month,
+        count(distinct orv.customer_id) as customer_count,
+        sum(orv.total_revenue) as segment_revenue,
+        sum(orv.order_count) as segment_orders,
+        avg(orv.total_revenue) as avg_revenue_per_customer
+    from order_revenue as orv
+    inner join rfm as r
+        on orv.customer_id = r.customer_id
+    group by 1, 2
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_revenue_by_daypart.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_revenue_by_daypart.sql
@@ -1,0 +1,64 @@
+with
+
+orders as (
+
+    select * from {{ ref('stg_orders') }}
+
+),
+
+invoices as (
+
+    select * from {{ ref('stg_invoices') }}
+
+),
+
+order_with_invoice as (
+
+    select
+        o.order_id,
+        o.location_id,
+        o.ordered_at,
+        i.total_amount,
+        i.invoice_id
+    from orders as o
+    inner join invoices as i
+        on o.order_id = i.order_id
+    where i.invoice_status != 'draft'
+
+),
+
+daypart_classified as (
+
+    select
+        order_id,
+        location_id,
+        ordered_at,
+        total_amount,
+        case
+            when extract(hour from ordered_at) >= 6 and extract(hour from ordered_at) < 11
+                then 'morning'
+            when extract(hour from ordered_at) >= 11 and extract(hour from ordered_at) < 14
+                then 'lunch'
+            when extract(hour from ordered_at) >= 14 and extract(hour from ordered_at) < 17
+                then 'afternoon'
+            else 'evening'
+        end as daypart
+    from order_with_invoice
+
+),
+
+final as (
+
+    select
+        ordered_at as revenue_date,
+        location_id,
+        daypart,
+        count(distinct order_id) as order_count,
+        sum(total_amount) as total_revenue,
+        avg(total_amount) as avg_order_value
+    from daypart_classified
+    group by 1, 2, 3
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_revenue_concentration_index.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_revenue_concentration_index.sql
@@ -1,0 +1,69 @@
+with
+
+orders as (
+
+    select * from {{ ref('stg_orders') }}
+
+),
+
+customer_revenue_by_store as (
+
+    select
+        location_id,
+        customer_id,
+        sum(order_total) as customer_revenue
+    from orders
+    group by 1, 2
+
+),
+
+store_total as (
+
+    select
+        location_id,
+        sum(customer_revenue) as store_total_revenue,
+        count(distinct customer_id) as customer_count
+    from customer_revenue_by_store
+    group by 1
+
+),
+
+market_share as (
+
+    select
+        crs.location_id,
+        crs.customer_id,
+        crs.customer_revenue,
+        st.store_total_revenue,
+        case
+            when st.store_total_revenue > 0
+                then crs.customer_revenue / st.store_total_revenue
+            else 0
+        end as revenue_share
+    from customer_revenue_by_store as crs
+    inner join store_total as st
+        on crs.location_id = st.location_id
+
+),
+
+herfindahl as (
+
+    select
+        ms.location_id,
+        st.customer_count,
+        st.store_total_revenue,
+        sum(ms.revenue_share * ms.revenue_share) as herfindahl_index,
+        case
+            when sum(ms.revenue_share * ms.revenue_share) < 0.01 then 'highly_diversified'
+            when sum(ms.revenue_share * ms.revenue_share) < 0.05 then 'diversified'
+            when sum(ms.revenue_share * ms.revenue_share) < 0.15 then 'moderate_concentration'
+            else 'high_concentration'
+        end as concentration_level
+    from market_share as ms
+    inner join store_total as st
+        on ms.location_id = st.location_id
+    group by 1, 2, 3
+
+)
+
+select * from herfindahl

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_revenue_per_customer_monthly.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/finance_deep/int_revenue_per_customer_monthly.sql
@@ -1,0 +1,31 @@
+with
+
+orders as (
+
+    select * from {{ ref('stg_orders') }}
+
+),
+
+customers as (
+
+    select * from {{ ref('stg_customers') }}
+
+),
+
+monthly_customer_revenue as (
+
+    select
+        o.customer_id,
+        c.customer_name,
+        {{ dbt.date_trunc('month', 'o.ordered_at') }} as revenue_month,
+        count(distinct o.order_id) as order_count,
+        sum(o.order_total) as total_revenue,
+        avg(o.order_total) as avg_order_value
+    from orders as o
+    left join customers as c
+        on o.customer_id = c.customer_id
+    group by 1, 2, 3
+
+)
+
+select * from monthly_customer_revenue

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/_kpis__models.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/_kpis__models.yml
@@ -1,0 +1,178 @@
+version: 2
+
+models:
+  - name: kpi_avg_basket_size
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for avg basket size.
+  - name: kpi_avg_customer_lifetime
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for avg customer lifetime.
+  - name: kpi_avg_order_value
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for avg order value.
+  - name: kpi_campaign_roi_avg
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for campaign roi avg.
+  - name: kpi_coupon_redemption_rate
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for coupon redemption rate.
+  - name: kpi_customer_acquisition_cost
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for customer acquisition cost.
+  - name: kpi_customer_churn_rate
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for customer churn rate.
+  - name: kpi_customer_retention_rate
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for customer retention rate.
+  - name: kpi_email_conversion_rate
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for email conversion rate.
+  - name: kpi_employee_productivity
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for employee productivity.
+  - name: kpi_employee_turnover_rate
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for employee turnover rate.
+  - name: kpi_equipment_uptime
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for equipment uptime.
+  - name: kpi_food_cost_ratio
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for food cost ratio.
+  - name: kpi_gross_margin_by_product
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for gross margin by product.
+  - name: kpi_inventory_days_on_hand
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for inventory days on hand.
+  - name: kpi_inventory_turnover_ratio
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for inventory turnover ratio.
+  - name: kpi_labor_cost_ratio
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for labor cost ratio.
+  - name: kpi_loyalty_active_rate
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for loyalty active rate.
+  - name: kpi_loyalty_enrollment_rate
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for loyalty enrollment rate.
+  - name: kpi_loyalty_redemption_rate
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for loyalty redemption rate.
+  - name: kpi_maintenance_cost_ratio
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for maintenance cost ratio.
+  - name: kpi_net_margin_monthly
+    config:
+      tags: ['type:kpi', 'cadence:monthly']
+    description: >
+      Key performance indicator for net margin monthly.
+  - name: kpi_overhead_ratio
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for overhead ratio.
+  - name: kpi_procurement_cycle_time
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for procurement cycle time.
+  - name: kpi_profit_margin_by_store
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for profit margin by store.
+  - name: kpi_refund_rate
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for refund rate.
+  - name: kpi_revenue_per_customer
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for revenue per customer.
+  - name: kpi_revenue_per_employee
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for revenue per employee.
+  - name: kpi_revenue_per_order
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for revenue per order.
+  - name: kpi_revenue_per_store
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for revenue per store.
+  - name: kpi_stockout_rate
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for stockout rate.
+  - name: kpi_supplier_defect_rate
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for supplier defect rate.
+  - name: kpi_supplier_on_time_delivery
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for supplier on time delivery.
+  - name: kpi_training_completion_rate
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for training completion rate.
+  - name: kpi_waste_to_revenue_ratio
+    config:
+      tags: ['type:kpi']
+    description: >
+      Key performance indicator for waste to revenue ratio.

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_avg_basket_size.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_avg_basket_size.sql
@@ -1,0 +1,29 @@
+with 
+o as (
+    select * from {{ ref('stg_orders') }}
+),
+
+oi as (
+    select * from {{ ref('stg_order_items') }}
+),
+
+monthly as (
+    select
+        {{ sf_date_trunc('month', "o.ordered_at") }} as order_month,
+        count(distinct o.order_id) as total_orders,
+        count(oi.order_item_id) as total_items,
+        round(count(oi.order_item_id) * 1.0 / nullif(count(distinct o.order_id), 0), 2) as avg_basket_size
+    from o
+    inner join oi on o.order_id = oi.order_id
+    group by 1
+),
+final as (
+    select
+        order_month,
+        total_orders,
+        total_items,
+        avg_basket_size,
+        lag(avg_basket_size) over (order by order_month) as prior_month_basket
+    from monthly
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_avg_customer_lifetime.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_avg_customer_lifetime.sql
@@ -1,0 +1,12 @@
+with final as (
+    select
+        count(distinct customer_id) as total_customers,
+        round(avg(customer_tenure_days), 0) as avg_tenure_days,
+        round(avg(case when total_orders > 1 then customer_tenure_days end), 0) as avg_repeat_tenure_days,
+        round(avg(lifetime_spend), 2) as avg_ltv,
+        round(avg(total_orders), 1) as avg_order_count,
+        round(avg(avg_order_value), 2) as avg_aov
+    from {{ ref('dim_customer_360') }}
+    where customer_tenure_days > 0
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_avg_order_value.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_avg_order_value.sql
@@ -1,0 +1,13 @@
+with final as (
+    select
+        month_start,
+        location_id,
+        monthly_revenue,
+        monthly_orders,
+        round(monthly_revenue * 1.0 / nullif(monthly_orders, 0), 2) as avg_order_value,
+        lag(round(monthly_revenue * 1.0 / nullif(monthly_orders, 0), 2)) over (
+            partition by location_id order by month_start
+        ) as prior_month_aov
+    from {{ ref('met_monthly_revenue_by_store') }}
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_campaign_roi_avg.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_campaign_roi_avg.sql
@@ -1,0 +1,10 @@
+with final as (
+    select
+        month_start,
+        total_marketing_spend,
+        total_campaign_days,
+        round(total_marketing_spend * 1.0 / nullif(total_marketing_spend, 0), 2) as avg_roi,
+        round(total_marketing_spend * 1.0 / nullif(total_campaign_days, 0), 2) as avg_spend_per_campaign
+    from {{ ref('met_monthly_marketing_metrics') }}
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_coupon_redemption_rate.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_coupon_redemption_rate.sql
@@ -1,0 +1,26 @@
+with monthly as (
+    select
+        {{ sf_date_trunc('month', "redeemed_at") }} as redemption_month,
+        count(*) as redemptions,
+        sum(discount_applied) as total_discount
+    from {{ ref('fct_coupon_redemptions') }}
+    group by 1
+),
+orders as (
+    select
+        {{ sf_date_trunc('month', "ordered_at") }} as order_month,
+        count(*) as total_orders
+    from {{ ref('stg_orders') }}
+    group by 1
+),
+final as (
+    select
+        o.order_month,
+        coalesce(m.redemptions, 0) as redemptions,
+        o.total_orders,
+        round(coalesce(m.redemptions, 0) * 100.0 / nullif(o.total_orders, 0), 2) as redemption_rate_pct,
+        coalesce(m.total_discount, 0) as total_discount
+    from orders as o
+    left join monthly as m on o.order_month = m.redemption_month
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_customer_acquisition_cost.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_customer_acquisition_cost.sql
@@ -1,0 +1,18 @@
+with mkt_spend as (
+    select month_start, total_marketing_spend
+    from {{ ref('met_monthly_marketing_metrics') }}
+),
+new_cust as (
+    select month_start, new_customers
+    from {{ ref('met_monthly_customer_metrics') }}
+),
+final as (
+    select
+        ms.month_start,
+        ms.total_marketing_spend as marketing_spend,
+        nc.new_customers,
+        round(ms.total_marketing_spend * 1.0 / nullif(nc.new_customers, 0), 2) as cac
+    from mkt_spend as ms
+    inner join new_cust as nc on ms.month_start = nc.month_start
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_customer_churn_rate.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_customer_churn_rate.sql
@@ -1,0 +1,10 @@
+with final as (
+    select
+        month_start,
+        tracked_active_customers,
+        churned_customers,
+        round(churned_customers * 100.0 / nullif(tracked_active_customers, 0), 2) as churn_rate_pct,
+        lag(round(churned_customers * 100.0 / nullif(tracked_active_customers, 0), 2)) over (order by month_start) as prior_month_churn
+    from {{ ref('met_monthly_customer_metrics') }}
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_customer_retention_rate.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_customer_retention_rate.sql
@@ -1,0 +1,9 @@
+with final as (
+    select
+        month_start,
+        tracked_active_customers,
+        round(tracked_active_customers * 100.0 / nullif(tracked_active_customers, 0), 2) as retention_rate_pct,
+        lag(round(tracked_active_customers * 100.0 / nullif(tracked_active_customers, 0), 2)) over (order by month_start) as prior_month_rate
+    from {{ ref('met_monthly_customer_metrics') }}
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_email_conversion_rate.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_email_conversion_rate.sql
@@ -1,0 +1,23 @@
+with monthly as (
+    select
+        {{ sf_date_trunc('month', "event_date") }} as email_month,
+        count(case when email_event_type = 'sent' then 1 end) as sent,
+        count(case when email_event_type = 'opened' then 1 end) as opened,
+        count(case when email_event_type = 'clicked' then 1 end) as clicked,
+        count(case when email_event_type = 'converted' then 1 end) as converted
+    from {{ ref('fct_email_events') }}
+    group by 1
+),
+final as (
+    select
+        email_month,
+        sent,
+        opened,
+        clicked,
+        converted,
+        round(opened * 100.0 / nullif(sent, 0), 2) as open_rate,
+        round(clicked * 100.0 / nullif(opened, 0), 2) as click_to_open_rate,
+        round(converted * 100.0 / nullif(sent, 0), 2) as conversion_rate
+    from monthly
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_employee_productivity.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_employee_productivity.sql
@@ -1,0 +1,23 @@
+with 
+r as (
+    select * from {{ ref('met_monthly_revenue_by_store') }}
+),
+
+l as (
+    select * from {{ ref('met_monthly_labor_metrics') }}
+),
+
+final as (
+    select
+        r.month_start as metric_month,
+        r.location_id,
+        r.monthly_revenue,
+        l.monthly_labor_hours,
+        round(r.monthly_revenue * 1.0 / nullif(l.monthly_labor_hours, 0), 2) as revenue_per_labor_hour,
+        r.monthly_orders,
+        round(r.monthly_orders * 1.0 / nullif(l.monthly_labor_hours, 0), 2) as orders_per_labor_hour
+    from r
+    inner join l
+        on r.month_start = l.month_start and r.location_id = l.location_id
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_employee_turnover_rate.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_employee_turnover_rate.sql
@@ -1,0 +1,25 @@
+with monthly as (
+    select
+        month_start,
+        headcount,
+        terminations_in_month as departures
+    from {{ ref('int_employee_roster_monthly') }}
+),
+agg as (
+    select
+        month_start,
+        sum(headcount) as headcount,
+        sum(departures) as departures
+    from monthly
+    group by 1
+),
+final as (
+    select
+        month_start,
+        headcount,
+        departures,
+        round(departures * 100.0 / nullif(headcount, 0), 2) as turnover_rate_pct,
+        round(departures * 12.0 / nullif(headcount, 0) * 100, 2) as annualized_turnover_pct
+    from agg
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_equipment_uptime.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_equipment_uptime.sql
@@ -1,0 +1,12 @@
+with final as (
+    select
+        equipment_id,
+        location_id,
+        age_days,
+        total_downtime_hours,
+        age_days - coalesce(total_downtime_hours, 0) as uptime_days,
+        round((age_days - coalesce(total_downtime_hours, 0)) * 100.0
+            / nullif(age_days, 0), 2) as uptime_pct
+    from {{ ref('int_equipment_lifecycle') }}
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_food_cost_ratio.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_food_cost_ratio.sql
@@ -1,0 +1,22 @@
+with ingredient_usage as (
+    select
+        {{ dbt.date_trunc('month', 'order_date') }} as usage_month,
+        sum(total_quantity_used) as total_quantity_used
+    from {{ ref('fct_ingredient_usage') }}
+    group by 1
+),
+rev as (
+    select month_start, sum(monthly_revenue) as monthly_revenue
+    from {{ ref('met_monthly_revenue_by_store') }}
+    group by 1
+),
+final as (
+    select
+        iu.usage_month,
+        iu.total_quantity_used,
+        r.monthly_revenue,
+        round(iu.total_quantity_used * 1.0 / nullif(r.monthly_revenue, 0) * 100, 2) as food_cost_ratio
+    from ingredient_usage as iu
+    inner join rev as r on iu.usage_month = r.month_start
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_gross_margin_by_product.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_gross_margin_by_product.sql
@@ -1,0 +1,23 @@
+with 
+ps as (
+    select * from {{ ref('int_product_sales_by_location') }}
+),
+
+rc as (
+    select * from {{ ref('int_total_cost_of_goods') }}
+),
+
+final as (
+    select
+        ps.product_id,
+        {{ dbt.date_trunc('month', 'ps.sale_date') }} as sale_month,
+        sum(ps.daily_revenue) as revenue,
+        sum(ps.units_sold * coalesce(rc.total_cogs_per_unit, 0)) as cogs,
+        sum(ps.daily_revenue) - sum(ps.units_sold * coalesce(rc.total_cogs_per_unit, 0)) as gross_profit,
+        round((sum(ps.daily_revenue) - sum(ps.units_sold * coalesce(rc.total_cogs_per_unit, 0))) * 100.0
+            / nullif(sum(ps.daily_revenue), 0), 2) as gross_margin_pct
+    from ps
+    left join rc on cast(ps.product_id as {{ dbt.type_string() }}) = cast(rc.product_id as {{ dbt.type_string() }})
+    group by 1, 2
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_inventory_days_on_hand.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_inventory_days_on_hand.sql
@@ -1,0 +1,14 @@
+with final as (
+    select
+        product_id,
+        location_id,
+        days_on_hand,
+        case
+            when days_on_hand < 3 then 'critical'
+            when days_on_hand < 7 then 'low'
+            when days_on_hand < 30 then 'healthy'
+            else 'excess'
+        end as doh_status
+    from {{ ref('sc_inventory_days_on_hand') }}
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_inventory_turnover_ratio.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_inventory_turnover_ratio.sql
@@ -1,0 +1,15 @@
+with final as (
+    select
+        month_start,
+        location_id,
+        total_units_on_hand,
+        monthly_movements,
+        round(monthly_movements * 1.0 / nullif(total_units_on_hand, 0), 2) as turnover_ratio,
+        case
+            when monthly_movements * 1.0 / nullif(total_units_on_hand, 0) > 4 then 'fast'
+            when monthly_movements * 1.0 / nullif(total_units_on_hand, 0) > 2 then 'moderate'
+            else 'slow'
+        end as turnover_band
+    from {{ ref('met_monthly_inventory_metrics') }}
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_labor_cost_ratio.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_labor_cost_ratio.sql
@@ -1,0 +1,21 @@
+with 
+r as (
+    select * from {{ ref('met_monthly_revenue_by_store') }}
+),
+
+l as (
+    select * from {{ ref('met_monthly_labor_metrics') }}
+),
+
+final as (
+    select
+        l.month_start,
+        l.location_id,
+        l.monthly_labor_cost,
+        r.monthly_revenue,
+        round(monthly_labor_cost * 100.0 / nullif(r.monthly_revenue, 0), 2) as labor_cost_ratio
+    from l
+    inner join r
+        on l.month_start = r.month_start and l.location_id = r.location_id
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_loyalty_active_rate.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_loyalty_active_rate.sql
@@ -1,0 +1,20 @@
+with monthly_active as (
+    select
+        {{ sf_date_trunc('month', "transacted_at") }} as txn_month,
+        count(distinct loyalty_member_id) as active_members
+    from {{ ref('fct_loyalty_transactions') }}
+    group by 1
+),
+total_members as (
+    select count(distinct loyalty_member_id) as total_enrolled from {{ ref('dim_loyalty_members') }}
+),
+final as (
+    select
+        a.txn_month,
+        a.active_members,
+        t.total_enrolled,
+        round(a.active_members * 100.0 / nullif(t.total_enrolled, 0), 2) as active_rate_pct
+    from monthly_active as a
+    cross join total_members as t
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_loyalty_enrollment_rate.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_loyalty_enrollment_rate.sql
@@ -1,0 +1,21 @@
+with monthly_enrollments as (
+    select
+        {{ sf_date_trunc('month', "enrolled_at") }} as enrollment_month,
+        count(*) as new_enrollments
+    from {{ ref('dim_loyalty_members') }}
+    group by 1
+),
+monthly_customers as (
+    select month_start, tracked_active_customers
+    from {{ ref('met_monthly_customer_metrics') }}
+),
+final as (
+    select
+        e.enrollment_month,
+        e.new_enrollments,
+        c.tracked_active_customers,
+        round(e.new_enrollments * 100.0 / nullif(c.tracked_active_customers, 0), 2) as enrollment_rate_pct
+    from monthly_enrollments as e
+    inner join monthly_customers as c on e.enrollment_month = c.month_start
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_loyalty_redemption_rate.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_loyalty_redemption_rate.sql
@@ -1,0 +1,17 @@
+with monthly as (
+    select
+        {{ sf_date_trunc('month', "transacted_at") }} as txn_month,
+        sum(case when transaction_type = 'redeem' then points else 0 end) as points_redeemed,
+        sum(case when transaction_type = 'earn' then points else 0 end) as points_earned
+    from {{ ref('fct_loyalty_transactions') }}
+    group by 1
+),
+final as (
+    select
+        txn_month,
+        points_earned,
+        points_redeemed,
+        round(points_redeemed * 100.0 / nullif(points_earned, 0), 2) as redemption_rate_pct
+    from monthly
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_maintenance_cost_ratio.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_maintenance_cost_ratio.sql
@@ -1,0 +1,25 @@
+with 
+r as (
+    select * from {{ ref('met_monthly_revenue_by_store') }}
+),
+
+monthly_maint as (
+    select
+        {{ sf_date_trunc('month', "scheduled_date") }} as maint_month,
+        location_id,
+        sum(maintenance_cost) as total_maintenance_cost
+    from {{ ref('fct_maintenance_events') }}
+    group by 1, 2
+),
+final as (
+    select
+        mm.maint_month,
+        mm.location_id,
+        mm.total_maintenance_cost,
+        r.monthly_revenue,
+        round(mm.total_maintenance_cost * 100.0 / nullif(r.monthly_revenue, 0), 2) as maintenance_cost_ratio
+    from monthly_maint as mm
+    inner join r
+        on mm.maint_month = r.month_start and mm.location_id = r.location_id
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_net_margin_monthly.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_net_margin_monthly.sql
@@ -1,0 +1,21 @@
+with rev as (
+    select month_start, sum(monthly_revenue) as monthly_revenue
+    from {{ ref('met_monthly_revenue_by_store') }}
+    group by 1
+),
+expenses as (
+    select expense_month, sum(total_expense_amount) as total_expenses
+    from {{ ref('int_expense_summary_monthly') }}
+    group by 1
+),
+final as (
+    select
+        r.month_start,
+        r.monthly_revenue,
+        coalesce(e.total_expenses, 0) as total_expenses,
+        r.monthly_revenue - coalesce(e.total_expenses, 0) as net_income,
+        round((r.monthly_revenue - coalesce(e.total_expenses, 0)) * 100.0 / nullif(r.monthly_revenue, 0), 2) as net_margin_pct
+    from rev as r
+    left join expenses as e on r.month_start = e.expense_month
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_overhead_ratio.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_overhead_ratio.sql
@@ -1,0 +1,20 @@
+with rev as (
+    select month_start, sum(monthly_revenue) as monthly_revenue
+    from {{ ref('met_monthly_revenue_by_store') }}
+    group by 1
+),
+overhead as (
+    select expense_month, sum(total_expense_amount) as overhead_cost
+    from {{ ref('int_expense_summary_monthly') }}
+    group by 1
+),
+final as (
+    select
+        r.month_start,
+        coalesce(o.overhead_cost, 0) as overhead_cost,
+        r.monthly_revenue,
+        round(coalesce(o.overhead_cost, 0) * 100.0 / nullif(r.monthly_revenue, 0), 2) as overhead_ratio
+    from rev as r
+    left join overhead as o on r.month_start = o.expense_month
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_procurement_cycle_time.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_procurement_cycle_time.sql
@@ -1,0 +1,12 @@
+with final as (
+    select
+        {{ sf_date_trunc('month', "ordered_at") }} as order_month,
+        supplier_id,
+        round(avg(cycle_time_days), 1) as avg_cycle_time,
+        min(cycle_time_days) as min_cycle_time,
+        max(cycle_time_days) as max_cycle_time,
+        count(*) as po_count
+    from {{ ref('int_procurement_cycle_time') }}
+    group by 1, 2
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_profit_margin_by_store.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_profit_margin_by_store.sql
@@ -1,0 +1,37 @@
+with 
+r as (
+    select * from {{ ref('met_monthly_revenue_by_store') }}
+),
+
+w as (
+    select * from {{ ref('met_monthly_waste_metrics') }}
+),
+
+l as (
+    select * from {{ ref('met_monthly_labor_metrics') }}
+),
+
+store_financials as (
+    select
+        r.month_start,
+        r.location_id,
+        r.monthly_revenue,
+        coalesce(l.monthly_labor_cost, 0) as labor_cost,
+        coalesce(w.monthly_waste_cost, 0) as waste_cost,
+        r.monthly_revenue - coalesce(l.monthly_labor_cost, 0) - coalesce(w.monthly_waste_cost, 0) as operating_profit
+    from r
+    left join l
+        on r.month_start = l.month_start and r.location_id = l.location_id
+    left join w
+        on r.month_start = w.month_start and r.location_id = w.location_id
+),
+final as (
+    select
+        month_start,
+        location_id,
+        monthly_revenue,
+        operating_profit,
+        round(operating_profit * 100.0 / nullif(monthly_revenue, 0), 2) as profit_margin_pct
+    from store_financials
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_refund_rate.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_refund_rate.sql
@@ -1,0 +1,21 @@
+with monthly_refunds as (
+    select {{ sf_date_trunc('month', "requested_date") }} as refund_month, count(*) as refunds, sum(refund_amount) as total_refunds
+    from {{ ref('fct_refunds') }}
+    group by 1
+),
+monthly_orders as (
+    select {{ sf_date_trunc('month', "ordered_at") }} as order_month, count(*) as total_orders, sum(order_total) as total_revenue
+    from {{ ref('stg_orders') }}
+    group by 1
+),
+final as (
+    select
+        mo.order_month,
+        mo.total_orders,
+        coalesce(mr.refunds, 0) as refunds,
+        round(coalesce(mr.refunds, 0) * 100.0 / nullif(mo.total_orders, 0), 2) as refund_rate_pct,
+        round(coalesce(mr.total_refunds, 0) * 100.0 / nullif(mo.total_revenue, 0), 2) as refund_value_rate_pct
+    from monthly_orders as mo
+    left join monthly_refunds as mr on mo.order_month = mr.refund_month
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_revenue_per_customer.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_revenue_per_customer.sql
@@ -1,0 +1,19 @@
+with monthly_rev as (
+    select month_start, sum(monthly_revenue) as monthly_revenue
+    from {{ ref('met_monthly_revenue_by_store') }}
+    group by 1
+),
+monthly_cust as (
+    select month_start, tracked_active_customers
+    from {{ ref('met_monthly_customer_metrics') }}
+),
+final as (
+    select
+        r.month_start as month_start,
+        r.monthly_revenue,
+        c.tracked_active_customers,
+        round(r.monthly_revenue * 1.0 / nullif(c.tracked_active_customers, 0), 2) as revenue_per_customer
+    from monthly_rev as r
+    inner join monthly_cust as c on r.month_start = c.month_start
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_revenue_per_employee.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_revenue_per_employee.sql
@@ -1,0 +1,23 @@
+with monthly_rev as (
+    select month_start, location_id, monthly_revenue
+    from {{ ref('met_monthly_revenue_by_store') }}
+),
+monthly_emp as (
+    select 
+        {{ dbt.date_trunc('month', 'work_date') }} as month_start,
+        location_id, 
+        avg(employee_count) as avg_employees
+    from {{ ref('met_daily_labor_metrics') }}
+    group by 1, 2
+),
+final as (
+    select
+        r.month_start,
+        r.location_id,
+        r.monthly_revenue,
+        coalesce(round(e.avg_employees, 0), 0) as avg_employees,
+        round(r.monthly_revenue * 1.0 / nullif(e.avg_employees, 0), 2) as revenue_per_employee
+    from monthly_rev as r
+    left join monthly_emp as e on r.month_start = e.month_start and r.location_id = e.location_id
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_revenue_per_order.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_revenue_per_order.sql
@@ -1,0 +1,15 @@
+with monthly as (
+    select month_start, sum(monthly_revenue) as monthly_revenue, sum(monthly_orders) as total_orders
+    from {{ ref('met_monthly_revenue_by_store') }}
+    group by 1
+),
+final as (
+    select
+        month_start,
+        monthly_revenue,
+        total_orders,
+        round(monthly_revenue * 1.0 / nullif(total_orders, 0), 2) as revenue_per_order,
+        lag(round(monthly_revenue * 1.0 / nullif(total_orders, 0), 2)) over (order by month_start) as prior_month_rpo
+    from monthly
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_revenue_per_store.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_revenue_per_store.sql
@@ -1,0 +1,15 @@
+with monthly as (
+    select month_start, location_id, monthly_revenue
+    from {{ ref('met_monthly_revenue_by_store') }}
+),
+final as (
+    select
+        month_start,
+        count(distinct location_id) as store_count,
+        sum(monthly_revenue) as monthly_revenue,
+        round(sum(monthly_revenue) * 1.0 / nullif(count(distinct location_id), 0), 2) as revenue_per_store,
+        lag(round((sum(monthly_revenue) * 1.0 / nullif(count(distinct location_id), 0)), 2)) over (order by month_start) as prior_month_rps
+    from monthly
+    group by 1
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_stockout_rate.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_stockout_rate.sql
@@ -1,0 +1,19 @@
+with stockout_events as (
+    select
+        {{ sf_date_trunc('month', "moved_at") }} as metric_month,
+        location_id,
+        count(distinct case when movement_type = 'stockout' then product_id end) as stockout_products,
+        count(distinct product_id) as total_products
+    from {{ ref('fct_inventory_movements') }}
+    group by 1, 2
+),
+final as (
+    select
+        metric_month,
+        location_id,
+        stockout_products,
+        total_products,
+        round(stockout_products * 100.0 / nullif(total_products, 0), 2) as stockout_rate_pct
+    from stockout_events
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_supplier_defect_rate.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_supplier_defect_rate.sql
@@ -1,0 +1,33 @@
+with
+
+qc as (
+    select * from {{ ref('stg_po_receipts') }}
+),
+
+po as (
+    select * from {{ ref('stg_purchase_orders') }}
+),
+
+receipt_quality as (
+    select
+        qc.purchase_order_id,
+        po.supplier_id,
+        qc.received_at,
+        qc.quantity_received,
+        qc.quality_status
+    from qc
+    inner join po on qc.purchase_order_id = po.purchase_order_id
+),
+
+final as (
+    select
+        {{ dbt.date_trunc('month', 'received_at') }} as receipt_month,
+        supplier_id,
+        count(*) as total_receipts,
+        count(case when quality_status = 'rejected' then 1 end) as defects,
+        round(count(case when quality_status = 'rejected' then 1 end) * 100.0 / nullif(count(*), 0), 2) as defect_rate_pct
+    from receipt_quality
+    group by 1, 2
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_supplier_on_time_delivery.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_supplier_on_time_delivery.sql
@@ -1,0 +1,11 @@
+with final as (
+    select
+        {{ sf_date_trunc('month', "actual_arrival_at") }} as delivery_month,
+        supplier_id,
+        count(*) as total_deliveries,
+        count(case when is_on_time then 1 end) as on_time_count,
+        round(count(case when is_on_time then 1 end) * 100.0 / nullif(count(*), 0), 2) as on_time_pct
+    from {{ ref('fct_deliveries') }}
+    group by 1, 2
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_training_completion_rate.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_training_completion_rate.sql
@@ -1,0 +1,24 @@
+with employees as (
+    select count(distinct employee_id) as total_employees
+    from {{ ref('dim_employees') }}
+    where is_active
+),
+trained as (
+    select
+        {{ sf_date_trunc('month', "completed_date") }} as completion_month,
+        count(distinct employee_id) as trained_employees,
+        count(*) as total_completions
+    from {{ ref('stg_training_completions') }}
+    group by 1
+),
+final as (
+    select
+        t.completion_month,
+        t.trained_employees,
+        t.total_completions,
+        e.total_employees,
+        round(t.trained_employees * 100.0 / nullif(e.total_employees, 0), 2) as completion_rate_pct
+    from trained as t
+    cross join employees as e
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_waste_to_revenue_ratio.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/kpis/kpi_waste_to_revenue_ratio.sql
@@ -1,0 +1,21 @@
+with 
+r as (
+    select * from {{ ref('met_monthly_revenue_by_store') }}
+),
+
+w as (
+    select * from {{ ref('met_monthly_waste_metrics') }}
+),
+
+final as (
+    select
+        w.month_start,
+        w.location_id,
+        w.monthly_waste_cost,
+        r.monthly_revenue,
+        round(w.monthly_waste_cost * 100.0 / nullif(r.monthly_revenue, 0), 2) as waste_to_revenue_pct
+    from w
+    inner join r
+        on w.month_start = r.month_start and w.location_id = r.location_id
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/locations.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/locations.sql
@@ -1,0 +1,9 @@
+with
+
+locations as (
+
+    select * from {{ ref('stg_locations') }}
+
+)
+
+select * from locations

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/metricflow_time_spine.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/metricflow_time_spine.sql
@@ -1,0 +1,19 @@
+-- metricflow_time_spine.sql
+with
+
+days as (
+
+    --for BQ adapters use "DATE('01/01/2000','mm/dd/yyyy')"
+    {{ dbt_date.get_base_dates(n_dateparts=365*10, datepart="day") }}
+
+),
+
+cast_to_date as (
+
+    select cast(date_day as date) as date_day
+
+    from days
+
+)
+
+select * from cast_to_date

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/metricflow_time_spine.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/metricflow_time_spine.yml
@@ -1,0 +1,11 @@
+models:
+  - name: metricflow_time_spine
+    description: >
+      MetricFlow time spine table providing a continuous series of daily dates
+      for metric calculations.
+    time_spine:
+      standard_granularity_column: date_day
+    columns:
+      - name: date_day
+        description: Calendar date
+        granularity: day

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/_metrics__models.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/_metrics__models.yml
@@ -1,0 +1,293 @@
+version: 2
+
+models:
+  - name: met_daily_revenue_by_store
+    config:
+      tags: ['type:metric', 'cadence:daily']
+    description: >
+      Daily revenue metrics per store with 7-day and 28-day rolling averages.
+      Sourced from int_daily_revenue joined with store locations.
+    columns:
+      - name: revenue_date
+        description: Calendar date of the revenue.
+      - name: location_id
+        description: Store location identifier.
+        tests:
+          - not_null
+      - name: store_name
+        description: Human-readable store name.
+      - name: total_revenue
+        description: Total revenue for the day at this store.
+      - name: revenue_7d_avg
+        description: 7-day rolling average of total revenue.
+      - name: revenue_28d_avg
+        description: 28-day rolling average of total revenue.
+
+  - name: met_weekly_revenue_by_store
+    config:
+      tags: ['type:metric', 'cadence:weekly']
+    description: >
+      Weekly revenue aggregation per store with week-over-week growth.
+    columns:
+      - name: week_start
+        description: Start date of the week.
+      - name: location_id
+        description: Store location identifier.
+        tests:
+          - not_null
+      - name: wow_revenue_growth
+        description: Week-over-week revenue growth rate.
+
+  - name: met_monthly_revenue_by_store
+    config:
+      tags: ['type:metric', 'cadence:monthly']
+    description: >
+      Monthly revenue per store with MoM and YoY growth rates,
+      mapped to fiscal periods.
+    columns:
+      - name: month_start
+        description: First day of the calendar month.
+      - name: location_id
+        description: Store location identifier.
+        tests:
+          - not_null
+      - name: mom_revenue_growth
+        description: Month-over-month revenue growth rate.
+      - name: yoy_revenue_growth
+        description: Year-over-year revenue growth rate.
+      - name: fiscal_year
+        description: Fiscal year from util_fiscal_periods.
+      - name: fiscal_quarter
+        description: Fiscal quarter from util_fiscal_periods.
+
+  - name: met_daily_product_sales
+    config:
+      tags: ['type:metric', 'cadence:daily']
+    description: >
+      Daily product sales combining units, revenue, and margin
+      from int_product_sales_daily and int_menu_item_margin.
+    columns:
+      - name: sale_date
+        description: Date of the sales.
+      - name: product_id
+        description: Product identifier.
+        tests:
+          - not_null
+      - name: daily_margin
+        description: Daily gross margin (units sold x unit margin).
+
+  - name: met_weekly_product_sales
+    config:
+      tags: ['type:metric', 'cadence:weekly']
+    description: >
+      Weekly product sales aggregation with WoW growth.
+    columns:
+      - name: week_start
+        description: Start of the week.
+      - name: product_id
+        description: Product identifier.
+        tests:
+          - not_null
+      - name: wow_revenue_growth
+        description: Week-over-week revenue growth.
+
+  - name: met_monthly_product_sales
+    config:
+      tags: ['type:metric', 'cadence:monthly']
+    description: >
+      Monthly product sales with MoM growth.
+    columns:
+      - name: month_start
+        description: First day of the month.
+      - name: product_id
+        description: Product identifier.
+        tests:
+          - not_null
+      - name: mom_revenue_growth
+        description: Month-over-month revenue growth.
+
+  - name: met_daily_labor_metrics
+    config:
+      tags: ['type:metric', 'cadence:daily']
+    description: >
+      Daily labor cost, hours, and efficiency per store.
+      Joins int_labor_cost_daily with int_daily_orders_by_store.
+    columns:
+      - name: work_date
+        description: Date of the labor metrics.
+      - name: location_id
+        description: Store location identifier.
+        tests:
+          - not_null
+      - name: orders_per_labor_hour
+        description: Number of orders per labor hour worked.
+      - name: labor_cost_pct_of_revenue
+        description: Labor cost as a percentage of daily revenue.
+
+  - name: met_weekly_labor_metrics
+    config:
+      tags: ['type:metric', 'cadence:weekly']
+    description: >
+      Weekly labor aggregation per store.
+    columns:
+      - name: week_start
+        description: Start of the week.
+      - name: location_id
+        description: Store location identifier.
+        tests:
+          - not_null
+
+  - name: met_monthly_labor_metrics
+    config:
+      tags: ['type:metric', 'cadence:monthly']
+    description: >
+      Monthly labor metrics per store with MoM change.
+    columns:
+      - name: month_start
+        description: First day of the month.
+      - name: location_id
+        description: Store location identifier.
+        tests:
+          - not_null
+      - name: mom_labor_cost_change
+        description: Month-over-month labor cost change rate.
+
+  - name: met_daily_inventory_metrics
+    config:
+      tags: ['type:metric', 'cadence:daily']
+    description: >
+      Daily inventory movement count and value per warehouse/location.
+    columns:
+      - name: movement_date
+        description: Date of inventory movements.
+      - name: location_id
+        description: Warehouse/location identifier.
+        tests:
+          - not_null
+      - name: total_movements
+        description: Number of inventory movements on this day.
+
+  - name: met_weekly_inventory_metrics
+    config:
+      tags: ['type:metric', 'cadence:weekly']
+    description: >
+      Weekly inventory metrics aggregation.
+    columns:
+      - name: week_start
+        description: Start of the week.
+      - name: location_id
+        description: Warehouse/location identifier.
+        tests:
+          - not_null
+
+  - name: met_monthly_inventory_metrics
+    config:
+      tags: ['type:metric', 'cadence:monthly']
+    description: >
+      Monthly inventory metrics with MoM movement change.
+    columns:
+      - name: month_start
+        description: First day of the month.
+      - name: location_id
+        description: Warehouse/location identifier.
+        tests:
+          - not_null
+      - name: mom_movement_change
+        description: Month-over-month change in movement count.
+
+  - name: met_daily_marketing_spend
+    config:
+      tags: ['type:metric', 'cadence:daily']
+    description: >
+      Daily marketing spend by channel with 7-day rolling averages.
+    columns:
+      - name: spend_date
+        description: Date of the marketing spend.
+      - name: spend_channel
+        description: Marketing channel name.
+        tests:
+          - not_null
+      - name: total_spend_7d_avg
+        description: 7-day rolling average of total daily spend across all channels.
+
+  - name: met_monthly_marketing_metrics
+    config:
+      tags: ['type:metric', 'cadence:monthly']
+    description: >
+      Monthly marketing spend, loyalty signups, and coupon redemptions.
+    columns:
+      - name: month_start
+        description: First day of the month.
+        tests:
+          - unique
+          - not_null
+      - name: total_marketing_spend
+        description: Total marketing spend for the month.
+      - name: coupon_redemptions
+        description: Number of coupon redemptions in the month.
+
+  - name: met_daily_customer_metrics
+    config:
+      tags: ['type:metric', 'cadence:daily']
+    description: >
+      Daily new, active, and returning customer counts with rolling averages.
+    columns:
+      - name: activity_date
+        description: Date of customer activity.
+        tests:
+          - unique
+          - not_null
+      - name: active_customers
+        description: Unique customers who placed orders.
+      - name: new_customers
+        description: First-time customers.
+      - name: returning_customers
+        description: Repeat customers.
+
+  - name: met_monthly_customer_metrics
+    config:
+      tags: ['type:metric', 'cadence:monthly']
+    description: >
+      Monthly customer metrics with cohort counts and churn/active percentages.
+    columns:
+      - name: month_start
+        description: First day of the month.
+        tests:
+          - unique
+          - not_null
+      - name: active_pct
+        description: Percentage of tracked customers who are active.
+      - name: churn_pct
+        description: Percentage of tracked customers who have churned.
+
+  - name: met_daily_waste_metrics
+    config:
+      tags: ['type:metric', 'cadence:daily']
+    description: >
+      Daily waste events and cost per store.
+    columns:
+      - name: waste_date
+        description: Date of waste events.
+      - name: location_id
+        description: Store location identifier.
+        tests:
+          - not_null
+      - name: total_waste_cost
+        description: Total cost of waste for the day.
+
+  - name: met_monthly_waste_metrics
+    config:
+      tags: ['type:metric', 'cadence:monthly']
+    description: >
+      Monthly waste with MoM change and waste-to-revenue ratio.
+    columns:
+      - name: month_start
+        description: First day of the month.
+      - name: location_id
+        description: Store location identifier.
+        tests:
+          - not_null
+      - name: waste_to_revenue_pct
+        description: Waste cost as a percentage of monthly revenue.
+      - name: mom_waste_cost_change
+        description: Month-over-month waste cost change rate.

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_daily_customer_metrics.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_daily_customer_metrics.sql
@@ -1,0 +1,43 @@
+with
+
+daily_activity as (
+
+    select * from {{ ref('int_daily_customer_activity') }}
+
+),
+
+final as (
+
+    select
+        activity_date,
+        unique_customers as active_customers,
+        new_customers,
+        returning_customers,
+        total_orders,
+        total_revenue,
+        case
+            when unique_customers > 0
+            then total_orders * 1.0 / unique_customers
+            else 0
+        end as orders_per_customer,
+        case
+            when unique_customers > 0
+            then total_revenue / unique_customers
+            else 0
+        end as revenue_per_customer,
+
+        -- 7-day rolling
+        avg(new_customers) over (
+            order by activity_date
+            rows between 6 preceding and current row
+        ) as new_customers_7d_avg,
+        avg(unique_customers) over (
+            order by activity_date
+            rows between 6 preceding and current row
+        ) as active_customers_7d_avg
+
+    from daily_activity
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_daily_inventory_metrics.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_daily_inventory_metrics.sql
@@ -1,0 +1,64 @@
+with
+
+movements as (
+
+    select * from {{ ref('fct_inventory_movements') }}
+
+),
+
+current_levels as (
+
+    select * from {{ ref('int_inventory_current_level') }}
+
+),
+
+daily_movements as (
+
+    select
+        {{ dbt.date_trunc('day', 'moved_at') }} as movement_date,
+        location_id,
+        location_name,
+        count(movement_id) as total_movements,
+        sum(case when is_inbound then absolute_quantity else 0 end) as inbound_quantity,
+        sum(case when is_outbound then absolute_quantity else 0 end) as outbound_quantity,
+        count(distinct product_id) as distinct_products_moved
+
+    from movements
+    group by 1, 2, 3
+
+),
+
+warehouse_inventory_value as (
+
+    select
+        location_id,
+        count(distinct product_id) as products_in_stock,
+        sum(current_quantity) as total_units_on_hand,
+        sum(total_movements) as lifetime_movements
+
+    from current_levels
+    group by location_id
+
+),
+
+final as (
+
+    select
+        dm.movement_date,
+        dm.location_id,
+        dm.location_name,
+        dm.total_movements,
+        dm.inbound_quantity,
+        dm.outbound_quantity,
+        dm.distinct_products_moved,
+        coalesce(wiv.products_in_stock, 0) as products_in_stock,
+        coalesce(wiv.total_units_on_hand, 0) as total_units_on_hand
+
+    from daily_movements as dm
+
+    left join warehouse_inventory_value as wiv
+        on dm.location_id = wiv.location_id
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_daily_labor_metrics.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_daily_labor_metrics.sql
@@ -1,0 +1,50 @@
+with
+
+labor as (
+
+    select * from {{ ref('int_labor_cost_daily') }}
+
+),
+
+orders as (
+
+    select * from {{ ref('int_daily_orders_by_store') }}
+
+),
+
+final as (
+
+    select
+        labor.work_date,
+        labor.location_id,
+        orders.location_name as store_name,
+        labor.total_hours as total_labor_hours,
+        labor.total_labor_cost,
+        labor.employee_count,
+        coalesce(orders.order_count, 0) as order_count,
+        coalesce(orders.total_revenue, 0) as daily_revenue,
+        case
+            when labor.total_hours > 0
+            then coalesce(orders.order_count, 0) * 1.0 / labor.total_hours
+            else 0
+        end as orders_per_labor_hour,
+        case
+            when coalesce(orders.total_revenue, 0) > 0
+            then labor.total_labor_cost * 100.0 / orders.total_revenue
+            else null
+        end as labor_cost_pct_of_revenue,
+        case
+            when labor.total_hours > 0
+            then coalesce(orders.total_revenue, 0) / labor.total_hours
+            else 0
+        end as revenue_per_labor_hour
+
+    from labor
+
+    left join orders
+        on labor.location_id = orders.location_id
+        and labor.work_date = orders.order_date
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_daily_marketing_spend.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_daily_marketing_spend.sql
@@ -1,0 +1,32 @@
+with
+
+marketing as (
+
+    select * from {{ ref('int_marketing_spend_daily') }}
+
+),
+
+daily_totals as (
+
+    select
+        spend_date,
+        spend_channel,
+        channel_spend,
+        campaigns_active,
+        total_daily_spend,
+        total_campaigns_active,
+        channels_active,
+        channel_daily_share,
+        channel_spend_7d_avg,
+
+        -- 7-day rolling avg of total daily spend
+        avg(total_daily_spend) over (
+            order by spend_date
+            rows between 6 preceding and current row
+        ) as total_spend_7d_avg
+
+    from marketing
+
+)
+
+select * from daily_totals

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_daily_product_sales.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_daily_product_sales.sql
@@ -1,0 +1,41 @@
+with
+
+product_sales as (
+
+    select * from {{ ref('int_product_sales_daily') }}
+
+),
+
+margins as (
+
+    select
+        menu_item_id,
+        menu_item_name,
+        gross_margin,
+        gross_margin_pct
+    from {{ ref('int_menu_item_margin') }}
+
+),
+
+final as (
+
+    select
+        ps.sale_date,
+        ps.product_id,
+        ps.product_name,
+        ps.product_type,
+        ps.units_sold,
+        ps.order_count,
+        ps.daily_revenue,
+        coalesce(m.gross_margin, 0) as unit_margin,
+        coalesce(m.gross_margin_pct, 0) as margin_pct,
+        ps.units_sold * coalesce(m.gross_margin, 0) as daily_margin
+
+    from product_sales as ps
+
+    left join margins as m
+        on ps.product_id = m.menu_item_id
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_daily_revenue_by_store.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_daily_revenue_by_store.sql
@@ -1,0 +1,61 @@
+with
+
+daily_revenue as (
+
+    select * from {{ ref('int_daily_revenue') }}
+
+),
+
+locations as (
+
+    select
+        location_id,
+        location_name
+    from {{ ref('stg_locations') }}
+
+),
+
+enriched as (
+
+    select
+        dr.revenue_date,
+        dr.location_id,
+        coalesce(l.location_name, 'Unknown') as store_name,
+        dr.invoice_count as order_count,
+        dr.total_revenue,
+        dr.avg_invoice_amount as avg_order_value,
+        dr.gross_revenue,
+        dr.tax_collected,
+
+        -- 7-day rolling averages
+        avg(dr.total_revenue) over (
+            partition by dr.location_id
+            order by dr.revenue_date
+            rows between 6 preceding and current row
+        ) as revenue_7d_avg,
+        avg(dr.invoice_count) over (
+            partition by dr.location_id
+            order by dr.revenue_date
+            rows between 6 preceding and current row
+        ) as orders_7d_avg,
+
+        -- 28-day rolling averages
+        avg(dr.total_revenue) over (
+            partition by dr.location_id
+            order by dr.revenue_date
+            rows between 27 preceding and current row
+        ) as revenue_28d_avg,
+        avg(dr.invoice_count) over (
+            partition by dr.location_id
+            order by dr.revenue_date
+            rows between 27 preceding and current row
+        ) as orders_28d_avg
+
+    from daily_revenue as dr
+
+    left join locations as l
+        on dr.location_id = l.location_id
+
+)
+
+select * from enriched

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_daily_waste_metrics.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_daily_waste_metrics.sql
@@ -1,0 +1,26 @@
+with
+
+waste as (
+
+    select * from {{ ref('fct_waste_events') }}
+
+),
+
+daily_waste as (
+
+    select
+        {{ dbt.date_trunc('day', 'wasted_at') }} as waste_date,
+        location_id,
+        location_name,
+        count(waste_log_id) as waste_events,
+        sum(quantity_wasted) as total_quantity_wasted,
+        sum(cost_of_waste) as total_waste_cost,
+        count(distinct product_id) as distinct_products_wasted,
+        count(distinct waste_reason) as distinct_waste_reasons
+
+    from waste
+    group by 1, 2, 3
+
+)
+
+select * from daily_waste

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_monthly_customer_metrics.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_monthly_customer_metrics.sql
@@ -1,0 +1,63 @@
+with
+
+monthly_active as (
+
+    select * from {{ ref('int_monthly_active_customers') }}
+
+),
+
+customer_status as (
+
+    select * from {{ ref('int_customer_status_monthly') }}
+
+),
+
+status_counts as (
+
+    select
+        month_start,
+        count(distinct customer_id) as total_tracked_customers,
+        count(distinct case when customer_status = 'active' then customer_id end) as active_customers,
+        count(distinct case when customer_status = 'dormant' then customer_id end) as dormant_customers,
+        count(distinct case when customer_status = 'churned' then customer_id end) as churned_customers
+
+    from customer_status
+    group by 1
+
+),
+
+final as (
+
+    select
+        ma.month_start,
+        ma.total_customer_visits,
+        ma.total_orders,
+        ma.total_revenue,
+        ma.new_customers,
+        ma.returning_customer_visits,
+        ma.avg_daily_customers,
+        ma.mom_customer_visit_change,
+        ma.mom_new_customer_change,
+        coalesce(sc.total_tracked_customers, 0) as total_tracked_customers,
+        coalesce(sc.active_customers, 0) as tracked_active_customers,
+        coalesce(sc.dormant_customers, 0) as dormant_customers,
+        coalesce(sc.churned_customers, 0) as churned_customers,
+        case
+            when coalesce(sc.total_tracked_customers, 0) > 0
+            then sc.active_customers * 100.0 / sc.total_tracked_customers
+            else 0
+        end as active_pct,
+        case
+            when coalesce(sc.total_tracked_customers, 0) > 0
+            then sc.churned_customers * 100.0 / sc.total_tracked_customers
+            else 0
+        end as churn_pct
+
+    from monthly_active as ma
+
+    left join status_counts as sc
+        on ma.month_start = sc.month_start
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_monthly_inventory_metrics.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_monthly_inventory_metrics.sql
@@ -1,0 +1,49 @@
+with
+
+daily as (
+
+    select * from {{ ref('met_daily_inventory_metrics') }}
+
+),
+
+monthly_agg as (
+
+    select
+        {{ dbt.date_trunc('month', 'movement_date') }} as month_start,
+        location_id,
+        location_name,
+        sum(total_movements) as monthly_movements,
+        sum(inbound_quantity) as monthly_inbound,
+        sum(outbound_quantity) as monthly_outbound,
+        avg(distinct_products_moved) as avg_daily_products_moved,
+        max(products_in_stock) as products_in_stock,
+        max(total_units_on_hand) as total_units_on_hand
+
+    from daily
+    group by 1, 2, 3
+
+),
+
+with_change as (
+
+    select
+        *,
+        lag(monthly_movements) over (
+            partition by location_id order by month_start
+        ) as prev_month_movements,
+        case
+            when lag(monthly_movements) over (
+                partition by location_id order by month_start
+            ) > 0
+            then (monthly_movements - lag(monthly_movements) over (
+                partition by location_id order by month_start
+            )) * 1.0 / lag(monthly_movements) over (
+                partition by location_id order by month_start
+            )
+        end as mom_movement_change
+
+    from monthly_agg
+
+)
+
+select * from with_change

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_monthly_labor_metrics.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_monthly_labor_metrics.sql
@@ -1,0 +1,58 @@
+with
+
+daily as (
+
+    select * from {{ ref('met_daily_labor_metrics') }}
+
+),
+
+monthly_agg as (
+
+    select
+        {{ dbt.date_trunc('month', 'work_date') }} as month_start,
+        location_id,
+        store_name,
+        sum(total_labor_hours) as monthly_labor_hours,
+        sum(total_labor_cost) as monthly_labor_cost,
+        avg(employee_count) as avg_daily_employees,
+        sum(order_count) as monthly_orders,
+        sum(daily_revenue) as monthly_revenue,
+        case
+            when sum(total_labor_hours) > 0
+            then sum(order_count) * 1.0 / sum(total_labor_hours)
+            else 0
+        end as orders_per_labor_hour,
+        case
+            when sum(daily_revenue) > 0
+            then sum(total_labor_cost) * 100.0 / sum(daily_revenue)
+            else null
+        end as labor_cost_pct_of_revenue
+
+    from daily
+    group by 1, 2, 3
+
+),
+
+with_change as (
+
+    select
+        *,
+        lag(monthly_labor_cost) over (
+            partition by location_id order by month_start
+        ) as prev_month_labor_cost,
+        case
+            when lag(monthly_labor_cost) over (
+                partition by location_id order by month_start
+            ) > 0
+            then (monthly_labor_cost - lag(monthly_labor_cost) over (
+                partition by location_id order by month_start
+            )) * 1.0 / lag(monthly_labor_cost) over (
+                partition by location_id order by month_start
+            )
+        end as mom_labor_cost_change
+
+    from monthly_agg
+
+)
+
+select * from with_change

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_monthly_marketing_metrics.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_monthly_marketing_metrics.sql
@@ -1,0 +1,88 @@
+with
+
+marketing as (
+
+    select * from {{ ref('int_marketing_spend_daily') }}
+
+),
+
+loyalty_txns as (
+
+    select * from {{ ref('fct_loyalty_transactions') }}
+
+),
+
+coupons as (
+
+    select * from {{ ref('fct_coupon_redemptions') }}
+
+),
+
+monthly_spend as (
+
+    select
+        {{ dbt.date_trunc('month', 'spend_date') }} as month_start,
+        sum(channel_spend) as total_marketing_spend,
+        count(distinct spend_channel) as channels_used,
+        sum(campaigns_active) as total_campaign_days
+
+    from marketing
+    group by 1
+
+),
+
+monthly_loyalty as (
+
+    select
+        {{ dbt.date_trunc('month', 'transacted_at') }} as month_start,
+        count(distinct case when transaction_type = 'earn' then loyalty_member_id end) as active_loyalty_members,
+        count(case when transaction_type = 'earn' then 1 end) as loyalty_earn_events,
+        count(case when transaction_type = 'redeem' then 1 end) as loyalty_redeem_events,
+        sum(case when transaction_type = 'earn' then points else 0 end) as points_earned,
+        sum(case when transaction_type = 'redeem' then abs(points) else 0 end) as points_redeemed
+
+    from loyalty_txns
+    group by 1
+
+),
+
+monthly_coupons as (
+
+    select
+        {{ dbt.date_trunc('month', 'redeemed_at') }} as month_start,
+        count(redemption_id) as coupon_redemptions,
+        sum(discount_applied) as total_discount_given,
+        count(distinct customer_id) as customers_using_coupons
+
+    from coupons
+    group by 1
+
+),
+
+final as (
+
+    select
+        ms.month_start,
+        ms.total_marketing_spend,
+        ms.channels_used,
+        ms.total_campaign_days,
+        coalesce(ml.active_loyalty_members, 0) as active_loyalty_members,
+        coalesce(ml.loyalty_earn_events, 0) as loyalty_earn_events,
+        coalesce(ml.loyalty_redeem_events, 0) as loyalty_redeem_events,
+        coalesce(ml.points_earned, 0) as points_earned,
+        coalesce(ml.points_redeemed, 0) as points_redeemed,
+        coalesce(mc.coupon_redemptions, 0) as coupon_redemptions,
+        coalesce(mc.total_discount_given, 0) as total_discount_given,
+        coalesce(mc.customers_using_coupons, 0) as customers_using_coupons
+
+    from monthly_spend as ms
+
+    left join monthly_loyalty as ml
+        on ms.month_start = ml.month_start
+
+    left join monthly_coupons as mc
+        on ms.month_start = mc.month_start
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_monthly_product_sales.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_monthly_product_sales.sql
@@ -1,0 +1,53 @@
+with
+
+daily as (
+
+    select * from {{ ref('met_daily_product_sales') }}
+
+),
+
+monthly_agg as (
+
+    select
+        {{ dbt.date_trunc('month', 'sale_date') }} as month_start,
+        product_id,
+        product_name,
+        product_type,
+        sum(units_sold) as monthly_units,
+        sum(order_count) as monthly_orders,
+        sum(daily_revenue) as monthly_revenue,
+        sum(daily_margin) as monthly_margin,
+        case
+            when sum(daily_revenue) > 0
+            then sum(daily_margin) * 100.0 / sum(daily_revenue)
+            else 0
+        end as margin_pct
+
+    from daily
+    group by 1, 2, 3, 4
+
+),
+
+with_growth as (
+
+    select
+        *,
+        lag(monthly_revenue) over (
+            partition by product_id order by month_start
+        ) as prev_month_revenue,
+        case
+            when lag(monthly_revenue) over (
+                partition by product_id order by month_start
+            ) > 0
+            then (monthly_revenue - lag(monthly_revenue) over (
+                partition by product_id order by month_start
+            )) * 1.0 / lag(monthly_revenue) over (
+                partition by product_id order by month_start
+            )
+        end as mom_revenue_growth
+
+    from monthly_agg
+
+)
+
+select * from with_growth

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_monthly_revenue_by_store.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_monthly_revenue_by_store.sql
@@ -1,0 +1,84 @@
+with
+
+daily as (
+
+    select * from {{ ref('met_daily_revenue_by_store') }}
+
+),
+
+fiscal as (
+
+    select
+        date_day,
+        fiscal_year,
+        fiscal_month,
+        fiscal_quarter
+    from {{ ref('util_fiscal_periods') }}
+
+),
+
+monthly_agg as (
+
+    select
+        {{ dbt.date_trunc('month', 'd.revenue_date') }} as month_start,
+        d.location_id,
+        d.store_name,
+        max(f.fiscal_year) as fiscal_year,
+        max(f.fiscal_month) as fiscal_month,
+        max(f.fiscal_quarter) as fiscal_quarter,
+        sum(d.total_revenue) as monthly_revenue,
+        sum(d.order_count) as monthly_orders,
+        sum(d.gross_revenue) as monthly_gross_revenue,
+        sum(d.tax_collected) as monthly_tax_collected,
+        case
+            when sum(d.order_count) > 0
+            then sum(d.total_revenue) / sum(d.order_count)
+            else 0
+        end as avg_order_value,
+        count(d.revenue_date) as active_days
+
+    from daily as d
+
+    left join fiscal as f
+        on d.revenue_date = f.date_day
+
+    group by 1, 2, 3
+
+),
+
+with_growth as (
+
+    select
+        *,
+        lag(monthly_revenue) over (
+            partition by location_id order by month_start
+        ) as prev_month_revenue,
+        case
+            when lag(monthly_revenue) over (
+                partition by location_id order by month_start
+            ) > 0
+            then (monthly_revenue - lag(monthly_revenue) over (
+                partition by location_id order by month_start
+            )) * 1.0 / lag(monthly_revenue) over (
+                partition by location_id order by month_start
+            )
+        end as mom_revenue_growth,
+        lag(monthly_revenue, 12) over (
+            partition by location_id order by month_start
+        ) as same_month_last_year_revenue,
+        case
+            when lag(monthly_revenue, 12) over (
+                partition by location_id order by month_start
+            ) > 0
+            then (monthly_revenue - lag(monthly_revenue, 12) over (
+                partition by location_id order by month_start
+            )) * 1.0 / lag(monthly_revenue, 12) over (
+                partition by location_id order by month_start
+            )
+        end as yoy_revenue_growth
+
+    from monthly_agg
+
+)
+
+select * from with_growth

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_monthly_waste_metrics.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_monthly_waste_metrics.sql
@@ -1,0 +1,69 @@
+with
+
+daily_waste as (
+
+    select * from {{ ref('met_daily_waste_metrics') }}
+
+),
+
+monthly_revenue as (
+
+    select * from {{ ref('met_monthly_revenue_by_store') }}
+
+),
+
+monthly_waste as (
+
+    select
+        {{ dbt.date_trunc('month', 'waste_date') }} as month_start,
+        location_id,
+        location_name,
+        sum(waste_events) as monthly_waste_events,
+        sum(total_quantity_wasted) as monthly_quantity_wasted,
+        sum(total_waste_cost) as monthly_waste_cost,
+        avg(distinct_products_wasted) as avg_daily_products_wasted
+
+    from daily_waste
+    group by 1, 2, 3
+
+),
+
+with_revenue as (
+
+    select
+        mw.month_start,
+        mw.location_id,
+        mw.location_name,
+        mw.monthly_waste_events,
+        mw.monthly_quantity_wasted,
+        mw.monthly_waste_cost,
+        mw.avg_daily_products_wasted,
+        coalesce(mr.monthly_revenue, 0) as monthly_revenue,
+        case
+            when coalesce(mr.monthly_revenue, 0) > 0
+            then mw.monthly_waste_cost * 100.0 / mr.monthly_revenue
+            else null
+        end as waste_to_revenue_pct,
+        lag(mw.monthly_waste_cost) over (
+            partition by mw.location_id order by mw.month_start
+        ) as prev_month_waste_cost,
+        case
+            when lag(mw.monthly_waste_cost) over (
+                partition by mw.location_id order by mw.month_start
+            ) > 0
+            then (mw.monthly_waste_cost - lag(mw.monthly_waste_cost) over (
+                partition by mw.location_id order by mw.month_start
+            )) * 1.0 / lag(mw.monthly_waste_cost) over (
+                partition by mw.location_id order by mw.month_start
+            )
+        end as mom_waste_cost_change
+
+    from monthly_waste as mw
+
+    left join monthly_revenue as mr
+        on mw.location_id = mr.location_id
+        and mw.month_start = mr.month_start
+
+)
+
+select * from with_revenue

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_weekly_inventory_metrics.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_weekly_inventory_metrics.sql
@@ -1,0 +1,27 @@
+with
+
+daily as (
+
+    select * from {{ ref('met_daily_inventory_metrics') }}
+
+),
+
+weekly_agg as (
+
+    select
+        {{ dbt.date_trunc('week', 'movement_date') }} as week_start,
+        location_id,
+        location_name,
+        sum(total_movements) as weekly_movements,
+        sum(inbound_quantity) as weekly_inbound,
+        sum(outbound_quantity) as weekly_outbound,
+        avg(distinct_products_moved) as avg_daily_products_moved,
+        max(products_in_stock) as products_in_stock,
+        max(total_units_on_hand) as total_units_on_hand
+
+    from daily
+    group by 1, 2, 3
+
+)
+
+select * from weekly_agg

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_weekly_labor_metrics.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_weekly_labor_metrics.sql
@@ -1,0 +1,36 @@
+with
+
+daily as (
+
+    select * from {{ ref('met_daily_labor_metrics') }}
+
+),
+
+weekly_agg as (
+
+    select
+        {{ dbt.date_trunc('week', 'work_date') }} as week_start,
+        location_id,
+        store_name,
+        sum(total_labor_hours) as weekly_labor_hours,
+        sum(total_labor_cost) as weekly_labor_cost,
+        avg(employee_count) as avg_daily_employees,
+        sum(order_count) as weekly_orders,
+        sum(daily_revenue) as weekly_revenue,
+        case
+            when sum(total_labor_hours) > 0
+            then sum(order_count) * 1.0 / sum(total_labor_hours)
+            else 0
+        end as orders_per_labor_hour,
+        case
+            when sum(daily_revenue) > 0
+            then sum(total_labor_cost) * 100.0 / sum(daily_revenue)
+            else null
+        end as labor_cost_pct_of_revenue
+
+    from daily
+    group by 1, 2, 3
+
+)
+
+select * from weekly_agg

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_weekly_product_sales.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_weekly_product_sales.sql
@@ -1,0 +1,53 @@
+with
+
+daily as (
+
+    select * from {{ ref('met_daily_product_sales') }}
+
+),
+
+weekly_agg as (
+
+    select
+        {{ dbt.date_trunc('week', 'sale_date') }} as week_start,
+        product_id,
+        product_name,
+        product_type,
+        sum(units_sold) as weekly_units,
+        sum(order_count) as weekly_orders,
+        sum(daily_revenue) as weekly_revenue,
+        sum(daily_margin) as weekly_margin,
+        case
+            when sum(daily_revenue) > 0
+            then sum(daily_margin) * 100.0 / sum(daily_revenue)
+            else 0
+        end as margin_pct
+
+    from daily
+    group by 1, 2, 3, 4
+
+),
+
+with_growth as (
+
+    select
+        *,
+        lag(weekly_revenue) over (
+            partition by product_id order by week_start
+        ) as prev_week_revenue,
+        case
+            when lag(weekly_revenue) over (
+                partition by product_id order by week_start
+            ) > 0
+            then (weekly_revenue - lag(weekly_revenue) over (
+                partition by product_id order by week_start
+            )) * 1.0 / lag(weekly_revenue) over (
+                partition by product_id order by week_start
+            )
+        end as wow_revenue_growth
+
+    from weekly_agg
+
+)
+
+select * from with_growth

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_weekly_revenue_by_store.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/metrics/met_weekly_revenue_by_store.sql
@@ -1,0 +1,53 @@
+with
+
+daily as (
+
+    select * from {{ ref('met_daily_revenue_by_store') }}
+
+),
+
+weekly_agg as (
+
+    select
+        {{ dbt.date_trunc('week', 'revenue_date') }} as week_start,
+        location_id,
+        store_name,
+        sum(total_revenue) as weekly_revenue,
+        sum(order_count) as weekly_orders,
+        sum(gross_revenue) as weekly_gross_revenue,
+        sum(tax_collected) as weekly_tax_collected,
+        case
+            when sum(order_count) > 0
+            then sum(total_revenue) / sum(order_count)
+            else 0
+        end as avg_order_value
+
+    from daily
+    group by 1, 2, 3
+
+),
+
+with_growth as (
+
+    select
+        *,
+        lag(weekly_revenue) over (
+            partition by location_id
+            order by week_start
+        ) as prev_week_revenue,
+        case
+            when lag(weekly_revenue) over (
+                partition by location_id order by week_start
+            ) > 0
+            then (weekly_revenue - lag(weekly_revenue) over (
+                partition by location_id order by week_start
+            )) * 1.0 / lag(weekly_revenue) over (
+                partition by location_id order by week_start
+            )
+        end as wow_revenue_growth
+
+    from weekly_agg
+
+)
+
+select * from with_growth

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/order_items.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/order_items.sql
@@ -1,0 +1,66 @@
+with
+
+order_items as (
+
+    select * from {{ ref('stg_order_items') }}
+
+),
+
+
+orders as (
+
+    select * from {{ ref('stg_orders') }}
+
+),
+
+products as (
+
+    select * from {{ ref('stg_products') }}
+
+),
+
+supplies as (
+
+    select * from {{ ref('stg_supplies') }}
+
+),
+
+order_supplies_summary as (
+
+    select
+        product_id,
+
+        sum(supply_cost) as supply_cost
+
+    from supplies
+
+    group by 1
+
+),
+
+joined as (
+
+    select
+        order_items.*,
+
+        orders.ordered_at,
+
+        products.product_name,
+        products.product_price,
+        products.is_food_item,
+        products.is_drink_item,
+
+        order_supplies_summary.supply_cost
+
+    from order_items
+
+    left join orders on order_items.order_id = orders.order_id
+
+    left join products on order_items.product_id = products.product_id
+
+    left join order_supplies_summary
+        on order_items.product_id = order_supplies_summary.product_id
+
+)
+
+select * from joined

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/order_items.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/order_items.yml
@@ -1,0 +1,53 @@
+models:
+- name: order_items
+  columns:
+  - name: order_item_id
+    data_tests:
+    - not_null
+    - unique
+  - name: order_id
+    data_tests:
+    - relationships:
+        arguments:
+          to: ref('orders')
+          field: order_id
+unit_tests:
+- name: test_supply_costs_sum_correctly
+  description: Test that the counts of drinks and food orders convert to booleans properly.
+  model: order_items
+  given:
+  - input: ref('stg_supplies')
+    rows:
+    - product_id: 1
+      supply_cost: 4.5
+    - product_id: 2
+      supply_cost: 3.5
+    - product_id: 2
+      supply_cost: 5.0
+  - input: ref('stg_products')
+    rows:
+    - product_id: 1
+    - product_id: 2
+  - input: ref('stg_order_items')
+    rows:
+    - order_id: 1
+      product_id: 1
+    - order_id: 2
+      product_id: 2
+    - order_id: 2
+      product_id: 2
+  - input: ref('stg_orders')
+    rows:
+    - order_id: 1
+    - order_id: 2
+  expect:
+    rows:
+    - order_id: 1
+      product_id: 1
+      supply_cost: 4.5
+    - order_id: 2
+      product_id: 2
+      supply_cost: 8.5
+    - order_id: 2
+      product_id: 2
+      supply_cost: 8.5

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/orders.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/orders.sql
@@ -1,0 +1,77 @@
+with
+
+orders as (
+
+    select * from {{ ref('stg_orders') }}
+
+),
+
+order_items as (
+
+    select * from {{ ref('order_items') }}
+
+),
+
+order_items_summary as (
+
+    select
+        order_id,
+
+        sum(supply_cost) as order_cost,
+        sum(product_price) as order_items_subtotal,
+        count(order_item_id) as count_order_items,
+        sum(
+            case
+                when is_food_item then 1
+                else 0
+            end
+        ) as count_food_items,
+        sum(
+            case
+                when is_drink_item then 1
+                else 0
+            end
+        ) as count_drink_items
+
+    from order_items
+
+    group by 1
+
+),
+
+compute_booleans as (
+
+    select
+        orders.*,
+
+        order_items_summary.order_cost,
+        order_items_summary.order_items_subtotal,
+        order_items_summary.count_food_items,
+        order_items_summary.count_drink_items,
+        order_items_summary.count_order_items,
+        order_items_summary.count_food_items > 0 as is_food_order,
+        order_items_summary.count_drink_items > 0 as is_drink_order
+
+    from orders
+
+    left join
+        order_items_summary
+        on orders.order_id = order_items_summary.order_id
+
+),
+
+customer_order_count as (
+
+    select
+        *,
+
+        row_number() over (
+            partition by customer_id
+            order by ordered_at asc
+        ) as customer_order_number
+
+    from compute_booleans
+
+)
+
+select * from customer_order_count

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/orders.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/orders.yml
@@ -1,0 +1,69 @@
+models:
+- name: orders
+  description: Order overview data mart, offering key details for each order inlcluding if it's a customer's
+    first order and a food vs. drink item breakdown. One row per order.
+  data_tests:
+  - dbt_utils.expression_is_true:
+      arguments:
+        expression: order_items_subtotal = subtotal
+  - dbt_utils.expression_is_true:
+      arguments:
+        expression: order_total = subtotal + tax_paid
+  columns:
+  - name: order_id
+    description: The unique key of the orders mart.
+    data_tests:
+    - not_null
+    - unique
+  - name: customer_id
+    description: The foreign key relating to the customer who placed the order.
+    data_tests:
+    - relationships:
+        arguments:
+          to: ref('stg_customers')
+          field: customer_id
+  - name: order_total
+    description: The total amount of the order in USD including tax.
+  - name: ordered_at
+    description: The timestamp the order was placed at.
+  - name: order_cost
+    description: The sum of supply expenses to fulfill the order.
+  - name: is_food_order
+    description: A boolean indicating if this order included any food items.
+  - name: is_drink_order
+    description: A boolean indicating if this order included any drink items.
+unit_tests:
+- name: test_order_items_compute_to_bools_correctly
+  description: Test that the counts of drinks and food orders convert to booleans properly.
+  model: orders
+  given:
+  - input: ref('order_items')
+    rows:
+    - order_id: 1
+      order_item_id: 1
+      is_drink_item: false
+      is_food_item: true
+    - order_id: 1
+      order_item_id: 2
+      is_drink_item: true
+      is_food_item: false
+    - order_id: 2
+      order_item_id: 3
+      is_drink_item: false
+      is_food_item: true
+  - input: ref('stg_orders')
+    rows:
+    - order_id: 1
+    - order_id: 2
+  expect:
+    rows:
+    - order_id: 1
+      count_food_items: 1
+      count_drink_items: 1
+      is_drink_order: true
+      is_food_order: true
+    - order_id: 2
+      count_food_items: 1
+      count_drink_items: 0
+      is_drink_order: false
+      is_food_order: true

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/products.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/products.sql
@@ -1,0 +1,9 @@
+with
+
+products as (
+
+    select * from {{ ref('stg_products') }}
+
+)
+
+select * from products

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/_summaries__models.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/_summaries__models.yml
@@ -1,0 +1,153 @@
+version: 2
+
+models:
+  - name: sum_annual_company_summary
+    config:
+      tags: ['type:summary']
+    description: >
+      Pre-computed summary of annual company summary for fast BI queries.
+  - name: sum_daily_category_totals
+    config:
+      tags: ['type:summary', 'cadence:daily']
+    description: >
+      Pre-computed summary of daily category totals for fast BI queries.
+  - name: sum_daily_company_totals
+    config:
+      tags: ['type:summary', 'cadence:daily']
+    description: >
+      Pre-computed summary of daily company totals for fast BI queries.
+  - name: sum_daily_product_totals
+    config:
+      tags: ['type:summary', 'cadence:daily']
+    description: >
+      Pre-computed summary of daily product totals for fast BI queries.
+  - name: sum_daily_store_totals
+    config:
+      tags: ['type:summary', 'cadence:daily']
+    description: >
+      Pre-computed summary of daily store totals for fast BI queries.
+  - name: sum_monthly_campaign_totals
+    config:
+      tags: ['type:summary', 'cadence:monthly']
+    description: >
+      Pre-computed summary of monthly campaign totals for fast BI queries.
+  - name: sum_monthly_category_totals
+    config:
+      tags: ['type:summary', 'cadence:monthly']
+    description: >
+      Pre-computed summary of monthly category totals for fast BI queries.
+  - name: sum_monthly_company_totals
+    config:
+      tags: ['type:summary', 'cadence:monthly']
+    description: >
+      Pre-computed summary of monthly company totals for fast BI queries.
+  - name: sum_monthly_customer_totals
+    config:
+      tags: ['type:summary', 'cadence:monthly']
+    description: >
+      Pre-computed summary of monthly customer totals for fast BI queries.
+  - name: sum_monthly_department_totals
+    config:
+      tags: ['type:summary', 'cadence:monthly']
+    description: >
+      Pre-computed summary of monthly department totals for fast BI queries.
+  - name: sum_monthly_expense_totals
+    config:
+      tags: ['type:summary', 'cadence:monthly']
+    description: >
+      Pre-computed summary of monthly expense totals for fast BI queries.
+  - name: sum_monthly_inventory_totals
+    config:
+      tags: ['type:summary', 'cadence:monthly']
+    description: >
+      Pre-computed summary of monthly inventory totals for fast BI queries.
+  - name: sum_monthly_loyalty_totals
+    config:
+      tags: ['type:summary', 'cadence:monthly']
+    description: >
+      Pre-computed summary of monthly loyalty totals for fast BI queries.
+  - name: sum_monthly_maintenance_totals
+    config:
+      tags: ['type:summary', 'cadence:monthly']
+    description: >
+      Pre-computed summary of monthly maintenance totals for fast BI queries.
+  - name: sum_monthly_payroll_totals
+    config:
+      tags: ['type:summary', 'cadence:monthly']
+    description: >
+      Pre-computed summary of monthly payroll totals for fast BI queries.
+  - name: sum_monthly_product_totals
+    config:
+      tags: ['type:summary', 'cadence:monthly']
+    description: >
+      Pre-computed summary of monthly product totals for fast BI queries.
+  - name: sum_monthly_store_totals
+    config:
+      tags: ['type:summary', 'cadence:monthly']
+    description: >
+      Pre-computed summary of monthly store totals for fast BI queries.
+  - name: sum_monthly_supplier_totals
+    config:
+      tags: ['type:summary', 'cadence:monthly']
+    description: >
+      Pre-computed summary of monthly supplier totals for fast BI queries.
+  - name: sum_monthly_waste_totals
+    config:
+      tags: ['type:summary', 'cadence:monthly']
+    description: >
+      Pre-computed summary of monthly waste totals for fast BI queries.
+  - name: sum_quarterly_campaign_totals
+    config:
+      tags: ['type:summary', 'cadence:quarterly']
+    description: >
+      Pre-computed summary of quarterly campaign totals for fast BI queries.
+  - name: sum_quarterly_customer_totals
+    config:
+      tags: ['type:summary', 'cadence:quarterly']
+    description: >
+      Pre-computed summary of quarterly customer totals for fast BI queries.
+  - name: sum_quarterly_department_totals
+    config:
+      tags: ['type:summary', 'cadence:quarterly']
+    description: >
+      Pre-computed summary of quarterly department totals for fast BI queries.
+  - name: sum_quarterly_expense_totals
+    config:
+      tags: ['type:summary', 'cadence:quarterly']
+    description: >
+      Pre-computed summary of quarterly expense totals for fast BI queries.
+  - name: sum_quarterly_inventory_totals
+    config:
+      tags: ['type:summary', 'cadence:quarterly']
+    description: >
+      Pre-computed summary of quarterly inventory totals for fast BI queries.
+  - name: sum_quarterly_loyalty_totals
+    config:
+      tags: ['type:summary', 'cadence:quarterly']
+    description: >
+      Pre-computed summary of quarterly loyalty totals for fast BI queries.
+  - name: sum_quarterly_supplier_totals
+    config:
+      tags: ['type:summary', 'cadence:quarterly']
+    description: >
+      Pre-computed summary of quarterly supplier totals for fast BI queries.
+  - name: sum_weekly_company_totals
+    config:
+      tags: ['type:summary', 'cadence:weekly']
+    description: >
+      Pre-computed summary of weekly company totals for fast BI queries.
+  - name: sum_weekly_product_totals
+    config:
+      tags: ['type:summary', 'cadence:weekly']
+    description: >
+      Pre-computed summary of weekly product totals for fast BI queries.
+  - name: sum_weekly_store_totals
+    config:
+      tags: ['type:summary', 'cadence:weekly']
+    description: >
+      Pre-computed summary of weekly store totals for fast BI queries.
+  - name: sum_ytd_company_totals
+    config:
+      tags: ['type:summary']
+    description: >
+      Pre-computed summary of ytd company totals for fast BI queries.

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_annual_company_summary.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_annual_company_summary.sql
@@ -1,0 +1,18 @@
+with monthly as (
+    select month_start, sum(monthly_revenue) as monthly_revenue, sum(monthly_orders) as total_orders
+    from {{ ref('met_monthly_revenue_by_store') }}
+    group by 1
+),
+final as (
+    select
+        {{ sf_date_trunc('year', "month_start") }} as fiscal_year,
+        sum(monthly_revenue) as annual_revenue,
+        sum(total_orders) as annual_orders,
+        round(sum(monthly_revenue) * 1.0 / nullif(sum(total_orders), 0), 2) as annual_aov,
+        round(avg(monthly_revenue), 2) as avg_monthly_revenue,
+        min(monthly_revenue) as min_monthly_revenue,
+        max(monthly_revenue) as max_monthly_revenue
+    from monthly
+    group by 1
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_daily_category_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_daily_category_totals.sql
@@ -1,0 +1,21 @@
+with 
+ps as (
+    select * from {{ ref('int_product_sales_by_location') }}
+),
+
+p as (
+    select * from {{ ref('stg_products') }}
+),
+
+final as (
+    select
+        ps.sale_date,
+        p.product_type as category,
+        sum(ps.units_sold) as total_quantity,
+        sum(ps.daily_revenue) as total_revenue,
+        count(distinct ps.product_id) as active_products
+    from ps
+    inner join p on ps.product_id = p.product_id
+    group by 1, 2
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_daily_company_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_daily_company_totals.sql
@@ -1,0 +1,37 @@
+with
+
+revenue as (
+    select revenue_date, sum(total_revenue) as total_revenue, sum(order_count) as total_orders
+    from {{ ref('met_daily_revenue_by_store') }}
+    group by 1
+),
+
+labor as (
+    select work_date, sum(total_labor_cost) as total_labor_cost, sum(total_labor_hours) as total_labor_hours
+    from {{ ref('met_daily_labor_metrics') }}
+    group by 1
+),
+
+waste as (
+    select waste_date, sum(total_waste_cost) as total_waste_cost
+    from {{ ref('met_daily_waste_metrics') }}
+    group by 1
+),
+
+final as (
+    select
+        r.revenue_date as report_date,
+        r.total_revenue,
+        r.total_orders,
+        round(r.total_revenue * 1.0 / nullif(r.total_orders, 0), 2) as avg_order_value,
+        coalesce(l.total_labor_cost, 0) as total_labor_cost,
+        coalesce(l.total_labor_hours, 0) as total_labor_hours,
+        coalesce(w.total_waste_cost, 0) as total_waste_cost,
+        round(coalesce(l.total_labor_cost, 0) * 100.0 / nullif(r.total_revenue, 0), 2) as labor_cost_pct,
+        round(coalesce(w.total_waste_cost, 0) * 100.0 / nullif(r.total_revenue, 0), 2) as waste_cost_pct
+    from revenue as r
+    left join labor as l on r.revenue_date = l.work_date
+    left join waste as w on r.revenue_date = w.waste_date
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_daily_product_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_daily_product_totals.sql
@@ -1,0 +1,11 @@
+with final as (
+    select
+        sale_date,
+        product_id,
+        units_sold,
+        daily_revenue,
+        round(daily_revenue * 1.0 / nullif(units_sold, 0), 2) as avg_unit_price,
+        sum(daily_revenue) over (partition by product_id order by sale_date) as cumulative_revenue
+    from {{ ref('fct_product_sales') }}
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_daily_store_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_daily_store_totals.sql
@@ -1,0 +1,30 @@
+with 
+r as (
+    select * from {{ ref('int_daily_revenue') }}
+),
+
+w as (
+    select * from {{ ref('met_daily_waste_metrics') }}
+),
+
+l as (
+    select * from {{ ref('int_labor_cost_daily') }}
+),
+
+final as (
+    select
+        r.revenue_date as waste_date,
+        r.location_id,
+        r.total_revenue,
+        r.invoice_count,
+        round(r.total_revenue * 1.0 / nullif(r.invoice_count, 0), 2) as avg_order_value,
+        coalesce(l.total_labor_cost, 0) as labor_cost,
+        coalesce(w.total_waste_cost, 0) as waste_cost,
+        r.total_revenue - coalesce(l.total_labor_cost, 0) - coalesce(w.total_waste_cost, 0) as net_contribution
+    from r
+    left join l
+        on r.revenue_date = l.work_date and r.location_id = l.location_id
+    left join w
+        on r.revenue_date = w.waste_date and r.location_id = w.location_id
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_campaign_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_campaign_totals.sql
@@ -1,0 +1,10 @@
+with final as (
+    select
+        month_start,
+        total_marketing_spend,
+        total_campaign_days,
+        round(total_marketing_spend * 1.0 / nullif(total_marketing_spend, 0), 2) as overall_roi,
+        lag(total_marketing_spend) over (order by month_start) as prior_month_spend
+    from {{ ref('met_monthly_marketing_metrics') }}
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_category_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_category_totals.sql
@@ -1,0 +1,24 @@
+with 
+ps as (
+    select * from {{ ref('int_product_sales_by_location') }}
+),
+
+p as (
+    select * from {{ ref('stg_products') }}
+),
+
+final as (
+    select
+        {{ sf_date_trunc('month', "ps.sale_date") }} as sale_month,
+        p.product_type as category,
+        sum(ps.units_sold) as total_quantity,
+        sum(ps.daily_revenue) as total_revenue,
+        count(distinct ps.product_id) as active_products,
+        round(sum(ps.daily_revenue) * 100.0 / nullif(sum(sum(ps.daily_revenue)) over (
+            partition by {{ sf_date_trunc('month', "ps.sale_date") }}
+        ), 0), 2) as revenue_share_pct
+    from ps
+    inner join p on ps.product_id = p.product_id
+    group by 1, 2
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_company_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_company_totals.sql
@@ -1,0 +1,39 @@
+with
+
+monthly_rev as (
+    select month_start, sum(monthly_revenue) as monthly_revenue, sum(monthly_orders) as total_orders
+    from {{ ref('met_monthly_revenue_by_store') }}
+    group by 1
+),
+
+monthly_labor as (
+    select month_start, sum(monthly_labor_cost) as monthly_labor_cost, sum(monthly_labor_hours) as monthly_labor_hours
+    from {{ ref('met_monthly_labor_metrics') }}
+    group by 1
+),
+
+monthly_waste as (
+    select month_start, sum(monthly_waste_cost) as monthly_waste_cost
+    from {{ ref('met_monthly_waste_metrics') }}
+    group by 1
+),
+
+final as (
+    select
+        r.month_start as month_start,
+        r.monthly_revenue,
+        r.total_orders,
+        round(r.monthly_revenue * 1.0 / nullif(r.total_orders, 0), 2) as avg_order_value,
+        coalesce(l.monthly_labor_cost, 0) as monthly_labor_cost,
+        coalesce(l.monthly_labor_hours, 0) as total_labor_hours,
+        coalesce(w.monthly_waste_cost, 0) as monthly_waste_cost,
+        r.monthly_revenue - coalesce(l.monthly_labor_cost, 0) - coalesce(w.monthly_waste_cost, 0) as operating_income_proxy,
+        lag(r.monthly_revenue) over (order by r.month_start) as prior_month_revenue,
+        round((r.monthly_revenue - lag(r.monthly_revenue) over (order by r.month_start)) * 100.0
+            / nullif(lag(r.monthly_revenue) over (order by r.month_start), 0), 2) as mom_revenue_change_pct
+    from monthly_rev as r
+    left join monthly_labor as l on r.month_start = l.month_start
+    left join monthly_waste as w on r.month_start = w.month_start
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_customer_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_customer_totals.sql
@@ -1,0 +1,11 @@
+with final as (
+    select
+        month_start,
+        tracked_active_customers,
+        new_customers,
+        churned_customers,
+        round(tracked_active_customers * 100.0 / nullif(total_tracked_customers, 0), 2) as retention_rate_pct,
+        lag(tracked_active_customers) over (order by month_start) as prior_month_customers
+    from {{ ref('met_monthly_customer_metrics') }}
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_department_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_department_totals.sql
@@ -1,0 +1,22 @@
+with 
+p as (
+    select * from {{ ref('stg_payroll') }}
+),
+
+e as (
+    select * from {{ ref('dim_employees') }}
+),
+
+final as (
+    select
+        {{ sf_date_trunc('month', "p.pay_period_start") }} as payroll_month,
+        e.department_id,
+        count(distinct p.employee_id) as employee_count,
+        sum(p.gross_pay) as total_gross_pay,
+        sum(p.net_pay) as total_net_pay,
+        round(sum(p.gross_pay) * 1.0 / nullif(count(distinct p.employee_id), 0), 2) as avg_pay_per_employee
+    from p
+    inner join e on p.employee_id = e.employee_id
+    group by 1, 2
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_expense_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_expense_totals.sql
@@ -1,0 +1,11 @@
+with final as (
+    select
+        expense_month,
+        expense_category_id,
+        total_expense_amount,
+        expense_count,
+        round(total_expense_amount * 1.0 / nullif(expense_count, 0), 2) as avg_expense_amount,
+        lag(total_expense_amount) over (partition by expense_category_id order by expense_month) as prior_month_amount
+    from {{ ref('int_expense_summary_monthly') }}
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_inventory_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_inventory_totals.sql
@@ -1,0 +1,11 @@
+with final as (
+    select
+        month_start,
+        location_id,
+        total_units_on_hand,
+        monthly_movements,
+        round(monthly_movements * 1.0 / nullif(total_units_on_hand, 0), 2) as turnover_ratio,
+        lag(total_units_on_hand) over (partition by location_id order by month_start) as prior_month_value
+    from {{ ref('met_monthly_inventory_metrics') }}
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_loyalty_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_loyalty_totals.sql
@@ -1,0 +1,12 @@
+with final as (
+    select
+        {{ sf_date_trunc('month', "transacted_at") }} as txn_month,
+        count(distinct loyalty_member_id) as active_members,
+        sum(case when transaction_type = 'earn' then points else 0 end) as points_earned,
+        sum(case when transaction_type = 'redeem' then points else 0 end) as points_redeemed,
+        sum(case when transaction_type = 'earn' then points else 0 end) - sum(case when transaction_type = 'redeem' then points else 0 end) as net_points,
+        count(*) as total_transactions
+    from {{ ref('fct_loyalty_transactions') }}
+    group by 1
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_maintenance_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_maintenance_totals.sql
@@ -1,0 +1,12 @@
+with final as (
+    select
+        {{ sf_date_trunc('month', "completed_date") }} as maint_month,
+        location_id,
+        count(*) as event_count,
+        sum(maintenance_cost) as total_cost,
+        round(avg(maintenance_cost), 2) as avg_cost_per_event,
+        count(distinct equipment_id) as unique_equipment
+    from {{ ref('fct_maintenance_events') }}
+    group by 1, 2
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_payroll_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_payroll_totals.sql
@@ -1,0 +1,13 @@
+with final as (
+    select
+        pay_period_start,
+        count(distinct employee_id) as employee_count,
+        sum(gross_pay) as total_gross_pay,
+        sum(net_pay) as total_net_pay,
+        sum(gross_pay) - sum(net_pay) as total_deductions,
+        round(sum(gross_pay) * 1.0 / nullif(count(distinct employee_id), 0), 2) as avg_gross_per_employee,
+        lag(sum(gross_pay)) over (order by pay_period_start) as prior_period_gross
+    from {{ ref('fct_payroll') }}
+    group by 1
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_product_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_product_totals.sql
@@ -1,0 +1,14 @@
+with final as (
+    select
+        month_start,
+        product_id,
+        monthly_units,
+        monthly_revenue,
+        round(monthly_revenue * 1.0 / nullif(monthly_units, 0), 2) as avg_unit_price,
+        lag(monthly_revenue) over (partition by product_id order by month_start) as prior_month_revenue,
+        round(((monthly_revenue - lag(monthly_revenue) over (partition by product_id order by month_start))) * 100.0
+            / nullif(lag(monthly_revenue) over (partition by product_id order by month_start), 0), 2) as mom_change_pct,
+        rank() over (partition by month_start order by monthly_revenue desc) as revenue_rank
+    from {{ ref('met_monthly_product_sales') }}
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_store_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_store_totals.sql
@@ -1,0 +1,31 @@
+with 
+r as (
+    select * from {{ ref('met_monthly_revenue_by_store') }}
+),
+
+w as (
+    select * from {{ ref('met_monthly_waste_metrics') }}
+),
+
+l as (
+    select * from {{ ref('met_monthly_labor_metrics') }}
+),
+
+final as (
+    select
+        r.month_start,
+        r.location_id,
+        r.monthly_revenue,
+        r.monthly_orders,
+        round(r.monthly_revenue * 1.0 / nullif(r.monthly_orders, 0), 2) as avg_order_value,
+        coalesce(l.monthly_labor_cost, 0) as labor_cost,
+        coalesce(w.monthly_waste_cost, 0) as waste_cost,
+        r.monthly_revenue - coalesce(l.monthly_labor_cost, 0) - coalesce(w.monthly_waste_cost, 0) as net_contribution,
+        lag(r.monthly_revenue) over (partition by r.location_id order by r.month_start) as prior_month_revenue
+    from r
+    left join l
+        on r.month_start = l.month_start and r.location_id = l.location_id
+    left join w
+        on r.month_start = w.month_start and r.location_id = w.location_id
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_supplier_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_supplier_totals.sql
@@ -1,0 +1,11 @@
+with final as (
+    select
+        order_month,
+        supplier_id,
+        total_spend,
+        count_purchase_orders,
+        round(total_spend * 1.0 / nullif(count_purchase_orders, 0), 2) as avg_po_value,
+        lag(total_spend) over (partition by supplier_id order by order_month) as prior_month_spend
+    from {{ ref('int_supplier_spend_monthly') }}
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_waste_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_monthly_waste_totals.sql
@@ -1,0 +1,10 @@
+with final as (
+    select
+        month_start,
+        location_id,
+        monthly_waste_events,
+        round(monthly_waste_events * 1.0 / nullif(monthly_waste_events, 0), 2) as avg_waste_per_event,
+        lag(monthly_waste_events) over (partition by location_id order by month_start) as prior_month_waste
+    from {{ ref('met_monthly_waste_metrics') }}
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_quarterly_campaign_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_quarterly_campaign_totals.sql
@@ -1,0 +1,15 @@
+with monthly as (
+    select month_start, total_marketing_spend, total_campaign_days
+    from {{ ref('met_monthly_marketing_metrics') }}
+),
+final as (
+    select
+        {{ sf_date_trunc('quarter', "month_start") }} as metric_quarter,
+        sum(total_marketing_spend) as quarterly_spend,
+        sum(total_campaign_days) as quarterly_campaigns,
+        sum(total_marketing_spend) as quarterly_revenue,
+        round(sum(total_marketing_spend) * 1.0 / nullif(sum(total_marketing_spend), 0), 2) as quarterly_roi
+    from monthly
+    group by 1
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_quarterly_customer_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_quarterly_customer_totals.sql
@@ -1,0 +1,17 @@
+with monthly as (
+    select
+        month_start,
+        tracked_active_customers,
+        new_customers
+    from {{ ref('met_monthly_customer_metrics') }}
+),
+final as (
+    select
+        {{ sf_date_trunc('quarter', "month_start") }} as metric_quarter,
+        sum(tracked_active_customers) as total_customer_months,
+        sum(new_customers) as total_new_customers,
+        round(avg(tracked_active_customers), 0) as avg_monthly_customers
+    from monthly
+    group by 1
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_quarterly_department_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_quarterly_department_totals.sql
@@ -1,0 +1,30 @@
+with 
+p as (
+    select * from {{ ref('stg_payroll') }}
+),
+
+e as (
+    select * from {{ ref('dim_employees') }}
+),
+
+monthly as (
+    select
+        {{ sf_date_trunc('month', "p.pay_period_start") }} as payroll_month,
+        e.department_id,
+        count(distinct p.employee_id) as employee_count,
+        sum(p.gross_pay) as total_gross_pay
+    from p
+    inner join e on p.employee_id = e.employee_id
+    group by 1, 2
+),
+final as (
+    select
+        {{ sf_date_trunc('quarter', "payroll_month") }} as payroll_quarter,
+        department_id,
+        round(avg(employee_count), 0) as avg_headcount,
+        sum(total_gross_pay) as total_payroll,
+        round(sum(total_gross_pay) * 1.0 / nullif(sum(employee_count), 0), 2) as avg_pay_per_employee_month
+    from monthly
+    group by 1, 2
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_quarterly_expense_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_quarterly_expense_totals.sql
@@ -1,0 +1,15 @@
+with monthly as (
+    select expense_month, expense_category_id, total_expense_amount, expense_count
+    from {{ ref('int_expense_summary_monthly') }}
+),
+final as (
+    select
+        {{ sf_date_trunc('quarter', "expense_month") }} as expense_quarter,
+        expense_category_id,
+        sum(total_expense_amount) as quarterly_amount,
+        sum(expense_count) as quarterly_count,
+        round(sum(total_expense_amount) * 1.0 / nullif(sum(expense_count), 0), 2) as avg_expense
+    from monthly
+    group by 1, 2
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_quarterly_inventory_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_quarterly_inventory_totals.sql
@@ -1,0 +1,15 @@
+with monthly as (
+    select month_start, location_id, total_units_on_hand, monthly_movements
+    from {{ ref('met_monthly_inventory_metrics') }}
+),
+final as (
+    select
+        {{ sf_date_trunc('quarter', "month_start") }} as metric_quarter,
+        location_id,
+        round(avg(total_units_on_hand), 2) as avg_quarterly_value,
+        sum(monthly_movements) as quarterly_movement,
+        round(sum(monthly_movements) * 1.0 / nullif(avg(total_units_on_hand), 0), 2) as quarterly_turnover
+    from monthly
+    group by 1, 2
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_quarterly_loyalty_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_quarterly_loyalty_totals.sql
@@ -1,0 +1,19 @@
+with monthly as (
+    select
+        {{ sf_date_trunc('month', "transacted_at") }} as txn_month,
+        count(distinct loyalty_member_id) as active_members,
+        sum(case when transaction_type = 'earn' then points else 0 end) as points_earned,
+        sum(case when transaction_type = 'redeem' then points else 0 end) as points_redeemed
+    from {{ ref('fct_loyalty_transactions') }}
+    group by 1
+),
+final as (
+    select
+        {{ sf_date_trunc('quarter', "txn_month") }} as txn_quarter,
+        round(avg(active_members), 0) as avg_monthly_members,
+        sum(points_earned) as quarterly_points_earned,
+        sum(points_redeemed) as quarterly_points_redeemed
+    from monthly
+    group by 1
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_quarterly_supplier_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_quarterly_supplier_totals.sql
@@ -1,0 +1,15 @@
+with monthly as (
+    select order_month, supplier_id, total_spend, count_purchase_orders
+    from {{ ref('int_supplier_spend_monthly') }}
+),
+final as (
+    select
+        {{ sf_date_trunc('quarter', "order_month") }} as order_quarter,
+        supplier_id,
+        sum(total_spend) as quarterly_spend,
+        sum(count_purchase_orders) as quarterly_pos,
+        round(sum(total_spend) * 1.0 / nullif(sum(count_purchase_orders), 0), 2) as avg_po_value
+    from monthly
+    group by 1, 2
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_weekly_company_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_weekly_company_totals.sql
@@ -1,0 +1,35 @@
+with
+
+weekly_rev as (
+    select
+        {{ sf_date_trunc('week', "revenue_date") }} as week_start,
+        sum(total_revenue) as total_revenue,
+        sum(order_count) as total_orders
+    from {{ ref('met_daily_revenue_by_store') }}
+    group by 1
+),
+
+weekly_labor as (
+    select
+        {{ sf_date_trunc('week', "work_date") }} as week_start,
+        sum(total_labor_cost) as total_labor_cost
+    from {{ ref('met_daily_labor_metrics') }}
+    group by 1
+),
+
+final as (
+    select
+        r.week_start,
+        r.total_revenue,
+        r.total_orders,
+        round(r.total_revenue * 1.0 / nullif(r.total_orders, 0), 2) as avg_order_value,
+        coalesce(l.total_labor_cost, 0) as total_labor_cost,
+        round(coalesce(l.total_labor_cost, 0) * 100.0 / nullif(r.total_revenue, 0), 2) as labor_cost_pct,
+        lag(r.total_revenue) over (order by r.week_start) as prior_week_revenue,
+        round((r.total_revenue - lag(r.total_revenue) over (order by r.week_start)) * 100.0
+            / nullif(lag(r.total_revenue) over (order by r.week_start), 0), 2) as wow_revenue_change_pct
+    from weekly_rev as r
+    left join weekly_labor as l on r.week_start = l.week_start
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_weekly_product_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_weekly_product_totals.sql
@@ -1,0 +1,11 @@
+with final as (
+    select
+        week_start,
+        product_id,
+        weekly_units,
+        weekly_revenue,
+        round(weekly_revenue * 1.0 / nullif(weekly_units, 0), 2) as avg_unit_price,
+        lag(weekly_revenue) over (partition by product_id order by week_start) as prior_week_revenue
+    from {{ ref('met_weekly_product_sales') }}
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_weekly_store_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_weekly_store_totals.sql
@@ -1,0 +1,31 @@
+with
+
+r as (
+    select * from {{ ref('int_revenue_by_store_daily') }}
+),
+
+weekly_agg as (
+    select
+        {{ dbt.date_trunc('week', 'r.revenue_date') }} as week_start,
+        r.location_id,
+        sum(r.total_revenue) as weekly_revenue,
+        sum(r.invoice_count) as weekly_orders,
+        round(sum(r.total_revenue) * 1.0 / nullif(sum(r.invoice_count), 0), 2) as avg_order_value,
+        0 as labor_cost
+    from r
+    group by 1, 2
+),
+
+final as (
+    select
+        week_start,
+        location_id,
+        weekly_revenue,
+        weekly_orders,
+        avg_order_value,
+        labor_cost,
+        lag(weekly_revenue) over (partition by location_id order by week_start) as prior_week_revenue
+    from weekly_agg
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_ytd_company_totals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/summaries/sum_ytd_company_totals.sql
@@ -1,0 +1,22 @@
+with daily as (
+    select revenue_date, sum(total_revenue) as total_revenue, sum(order_count) as total_orders
+    from {{ ref('met_daily_revenue_by_store') }}
+    group by 1
+),
+final as (
+    select
+        revenue_date,
+        total_revenue,
+        total_orders,
+        sum(total_revenue) over (
+            partition by {{ sf_date_trunc('year', "revenue_date") }} order by revenue_date
+        ) as ytd_revenue,
+        sum(total_orders) over (
+            partition by {{ sf_date_trunc('year', "revenue_date") }} order by revenue_date
+        ) as ytd_orders,
+        row_number() over (
+            partition by {{ sf_date_trunc('year', "revenue_date") }} order by revenue_date
+        ) as day_of_year
+    from daily
+)
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/supplies.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/supplies.sql
@@ -1,0 +1,9 @@
+with
+
+supplies as (
+
+    select * from {{ ref('stg_supplies') }}
+
+)
+
+select * from supplies

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/__sources.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/__sources.yml
@@ -1,0 +1,26 @@
+version: 2
+
+sources:
+  - name: ecom
+    schema: "{{ target.schema }}_raw"
+    description: E-commerce data for the Jaffle Shop
+    tables:
+      - name: raw_customers
+        description: One record per person who has purchased one or more items
+      - name: raw_orders
+        description: One record per order (consisting of one or more order items)
+        loaded_at_field: ordered_at
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
+      - name: raw_items
+        description: Items included in an order
+      - name: raw_stores
+        loaded_at_field: opened_at
+        freshness:
+          warn_after: {count: 72, period: hour}
+          error_after: {count: 168, period: hour}
+      - name: raw_products
+        description: One record per SKU for items sold in stores
+      - name: raw_supplies
+        description: One record per supply per SKU of items sold in stores

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/__sources.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/__sources.yml
@@ -1,0 +1,35 @@
+version: 2
+
+sources:
+  - name: finance
+    schema: "{{ target.schema }}_raw"
+    description: Finance and payments data for the Jaffle Shop
+    tables:
+      - name: raw_invoices
+        description: One record per invoice generated from an order
+        loaded_at_field: issued_at
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
+      - name: raw_invoice_line_items
+        description: Individual line items on each invoice
+      - name: raw_refunds
+        description: Refund requests and their resolution
+      - name: raw_tax_rates
+        description: Tax rate configuration by jurisdiction
+      - name: raw_gift_cards
+        description: Gift card issuance and balance tracking
+      - name: raw_payment_transactions
+        description: Individual payment transactions against orders
+        loaded_at_field: processed_at
+        freshness:
+          warn_after: {count: 12, period: hour}
+          error_after: {count: 24, period: hour}
+      - name: raw_accounts_receivable
+        description: Outstanding receivables from corporate/catering customers
+      - name: raw_expense_categories
+        description: Expense classification categories
+      - name: raw_expenses
+        description: Operating expenses by store
+      - name: raw_budgets
+        description: Monthly budget targets by store and category

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/_finance__models.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/_finance__models.yml
@@ -1,0 +1,222 @@
+models:
+  - name: stg_invoices
+    description: Invoices generated from orders, one row per invoice.
+    columns:
+      - name: invoice_id
+        description: The unique key for each invoice.
+        data_tests:
+          - not_null
+          - unique
+      - name: order_id
+        description: Foreign key to the order this invoice was generated from.
+      - name: customer_id
+        description: Foreign key to the customer billed on the invoice.
+      - name: invoice_status
+        description: Current status of the invoice (e.g., draft, sent, paid, overdue).
+      - name: subtotal
+        description: Invoice subtotal in USD before tax.
+      - name: tax_amount
+        description: Tax amount in USD applied to the invoice.
+      - name: total_amount
+        description: Total invoice amount in USD including tax.
+      - name: amount_paid
+        description: Amount paid against this invoice in USD.
+      - name: amount_due
+        description: Remaining amount due on this invoice in USD.
+      - name: issued_date
+        description: Date the invoice was issued.
+      - name: due_date
+        description: Date the invoice payment is due.
+      - name: paid_date
+        description: Date the invoice was fully paid.
+
+  - name: stg_invoice_line_items
+    description: Individual line items on each invoice, one row per line item.
+    columns:
+      - name: invoice_line_item_id
+        description: The unique key for each invoice line item.
+        data_tests:
+          - not_null
+          - unique
+      - name: invoice_id
+        description: Foreign key to the parent invoice.
+      - name: product_id
+        description: Foreign key to the product on this line item.
+      - name: line_item_description
+        description: Description of the line item.
+      - name: quantity
+        description: Quantity of the product on this line item.
+      - name: unit_price
+        description: Unit price in USD.
+      - name: line_total
+        description: Total for this line item in USD (quantity x unit price).
+
+  - name: stg_refunds
+    description: Refund requests and their resolution, one row per refund.
+    columns:
+      - name: refund_id
+        description: The unique key for each refund.
+        data_tests:
+          - not_null
+          - unique
+      - name: order_id
+        description: Foreign key to the order being refunded.
+      - name: invoice_id
+        description: Foreign key to the invoice being refunded.
+      - name: refund_reason
+        description: Reason provided for the refund request.
+      - name: refund_status
+        description: Current status of the refund (e.g., pending, approved, denied).
+      - name: refund_amount
+        description: Refund amount in USD.
+      - name: requested_date
+        description: Date the refund was requested.
+      - name: resolved_date
+        description: Date the refund was resolved.
+
+  - name: stg_tax_rates
+    description: Tax rate configuration by jurisdiction, one row per tax rate.
+    columns:
+      - name: tax_rate_id
+        description: The unique key for each tax rate configuration.
+        data_tests:
+          - not_null
+          - unique
+      - name: jurisdiction
+        description: The jurisdiction this tax rate applies to (e.g., state, city).
+      - name: tax_type
+        description: Type of tax (e.g., sales tax, excise tax).
+      - name: tax_rate_pct
+        description: The tax rate as a decimal percentage.
+      - name: effective_from_date
+        description: Date this tax rate became effective.
+      - name: effective_to_date
+        description: Date this tax rate expires (null if currently active).
+
+  - name: stg_gift_cards
+    description: Gift card issuance and balance tracking, one row per gift card.
+    columns:
+      - name: gift_card_id
+        description: The unique key for each gift card.
+        data_tests:
+          - not_null
+          - unique
+      - name: customer_id
+        description: Foreign key to the customer who purchased the gift card.
+      - name: card_number
+        description: The gift card number.
+      - name: gift_card_status
+        description: Current status of the gift card (e.g., active, redeemed, expired).
+      - name: initial_balance
+        description: Original balance loaded onto the gift card in USD.
+      - name: current_balance
+        description: Current remaining balance on the gift card in USD.
+      - name: issued_date
+        description: Date the gift card was issued.
+      - name: expires_date
+        description: Date the gift card expires.
+
+  - name: stg_payment_transactions
+    description: Individual payment transactions against orders, one row per transaction.
+    columns:
+      - name: payment_transaction_id
+        description: The unique key for each payment transaction.
+        data_tests:
+          - not_null
+          - unique
+      - name: order_id
+        description: Foreign key to the order this payment applies to.
+      - name: gift_card_id
+        description: Foreign key to the gift card used (null if not a gift card payment).
+      - name: payment_method
+        description: Payment method used (e.g., credit_card, debit_card, gift_card, cash).
+      - name: payment_status
+        description: Current status of the transaction (e.g., completed, pending, failed).
+      - name: reference_number
+        description: External reference number from the payment processor.
+      - name: payment_amount
+        description: Transaction amount in USD.
+      - name: processed_date
+        description: Date the payment was processed.
+
+  - name: stg_accounts_receivable
+    description: Outstanding receivables from corporate/catering customers, one row per receivable.
+    columns:
+      - name: receivable_id
+        description: The unique key for each accounts receivable record.
+        data_tests:
+          - not_null
+          - unique
+      - name: customer_id
+        description: Foreign key to the corporate/catering customer.
+      - name: invoice_id
+        description: Foreign key to the associated invoice.
+      - name: receivable_status
+        description: Current status of the receivable (e.g., open, partial, paid, written_off).
+      - name: amount_due
+        description: Original amount due in USD.
+      - name: amount_paid
+        description: Amount paid so far in USD.
+      - name: amount_outstanding
+        description: Remaining outstanding balance in USD.
+      - name: due_date
+        description: Date the payment is due.
+      - name: created_date
+        description: Date the receivable record was created.
+
+  - name: stg_expense_categories
+    description: Expense classification categories, one row per category.
+    columns:
+      - name: expense_category_id
+        description: The unique key for each expense category.
+        data_tests:
+          - not_null
+          - unique
+      - name: category_name
+        description: Name of the expense category.
+      - name: category_description
+        description: Description of what this category covers.
+      - name: is_operating_expense
+        description: Whether this category is an operating expense.
+      - name: is_cost_of_goods_sold
+        description: Whether this category is a cost of goods sold.
+
+  - name: stg_expenses
+    description: Operating expenses by store, one row per expense.
+    columns:
+      - name: expense_id
+        description: The unique key for each expense.
+        data_tests:
+          - not_null
+          - unique
+      - name: location_id
+        description: Foreign key to the store location.
+      - name: expense_category_id
+        description: Foreign key to the expense category.
+      - name: expense_description
+        description: Description of the expense.
+      - name: vendor
+        description: Vendor or supplier for this expense.
+      - name: expense_amount
+        description: Expense amount in USD.
+      - name: incurred_date
+        description: Date the expense was incurred.
+
+  - name: stg_budgets
+    description: Monthly budget targets by store and category, one row per budget entry.
+    columns:
+      - name: budget_id
+        description: The unique key for each budget entry.
+        data_tests:
+          - not_null
+          - unique
+      - name: location_id
+        description: Foreign key to the store location.
+      - name: expense_category_id
+        description: Foreign key to the budget category.
+      - name: budget_type
+        description: Type of budget (e.g., revenue, expense).
+      - name: budgeted_amount
+        description: Budgeted amount in USD.
+      - name: budget_month
+        description: The month this budget applies to.

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_accounts_receivable.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_accounts_receivable.sql
@@ -1,0 +1,34 @@
+with
+
+source as (
+
+    select * from {{ source('finance', 'raw_accounts_receivable') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as receivable_id,
+        cast(customer_id as varchar) as customer_id,
+        cast(invoice_id as varchar) as invoice_id,
+
+        ---------- text
+        status as receivable_status,
+
+        ---------- numerics
+        {{ cents_to_dollars('amount_due') }} as amount_due,
+        {{ cents_to_dollars('amount_paid') }} as amount_paid,
+        {{ cents_to_dollars('amount_outstanding') }} as amount_outstanding,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'due_at') }} as due_date,
+        {{ dbt.date_trunc('day', 'created_at') }} as created_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_budgets.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_budgets.sql
@@ -1,0 +1,31 @@
+with
+
+source as (
+
+    select * from {{ source('finance', 'raw_budgets') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as budget_id,
+        cast(store_id as varchar) as location_id,
+        cast(category_id as varchar) as expense_category_id,
+
+        ---------- text
+        budget_type,
+
+        ---------- numerics
+        {{ cents_to_dollars('budgeted_amount') }} as budgeted_amount,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'month_start') }} as budget_month
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_expense_categories.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_expense_categories.sql
@@ -1,0 +1,28 @@
+with
+
+source as (
+
+    select * from {{ source('finance', 'raw_expense_categories') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as expense_category_id,
+
+        ---------- text
+        name as category_name,
+        description as category_description,
+
+        ---------- booleans
+        coalesce(is_operating, false) as is_operating_expense,
+        coalesce(is_cogs, false) as is_cost_of_goods_sold
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_expenses.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_expenses.sql
@@ -1,0 +1,32 @@
+with
+
+source as (
+
+    select * from {{ source('finance', 'raw_expenses') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as expense_id,
+        cast(store_id as varchar) as location_id,
+        cast(category_id as varchar) as expense_category_id,
+
+        ---------- text
+        description as expense_description,
+        vendor,
+
+        ---------- numerics
+        {{ cents_to_dollars('amount') }} as expense_amount,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'incurred_at') }} as incurred_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_gift_cards.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_gift_cards.sql
@@ -1,0 +1,33 @@
+with
+
+source as (
+
+    select * from {{ source('finance', 'raw_gift_cards') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as gift_card_id,
+        cast(customer_id as varchar) as customer_id,
+
+        ---------- text
+        card_number,
+        status as gift_card_status,
+
+        ---------- numerics
+        {{ cents_to_dollars('initial_balance') }} as initial_balance,
+        {{ cents_to_dollars('current_balance') }} as current_balance,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'issued_at') }} as issued_date,
+        {{ dbt.date_trunc('day', 'expires_at') }} as expires_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_invoice_line_items.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_invoice_line_items.sql
@@ -1,0 +1,30 @@
+with
+
+source as (
+
+    select * from {{ source('finance', 'raw_invoice_line_items') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as invoice_line_item_id,
+        cast(invoice_id as varchar) as invoice_id,
+        cast(product_id as varchar) as product_id,
+
+        ---------- text
+        description as line_item_description,
+
+        ---------- numerics
+        quantity,
+        {{ cents_to_dollars('unit_price') }} as unit_price,
+        {{ cents_to_dollars('line_total') }} as line_total
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_invoices.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_invoices.sql
@@ -1,0 +1,37 @@
+with
+
+source as (
+
+    select * from {{ source('finance', 'raw_invoices') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as invoice_id,
+        cast(order_id as varchar) as order_id,
+        cast(customer_id as varchar) as customer_id,
+
+        ---------- text
+        status as invoice_status,
+
+        ---------- numerics
+        {{ cents_to_dollars('subtotal') }} as subtotal,
+        {{ cents_to_dollars('tax_amount') }} as tax_amount,
+        {{ cents_to_dollars('total_amount') }} as total_amount,
+        {{ cents_to_dollars('amount_paid') }} as amount_paid,
+        {{ cents_to_dollars('amount_due') }} as amount_due,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'issued_at') }} as issued_date,
+        {{ dbt.date_trunc('day', 'due_at') }} as due_date,
+        {{ dbt.date_trunc('day', 'paid_at') }} as paid_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_payment_transactions.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_payment_transactions.sql
@@ -1,0 +1,33 @@
+with
+
+source as (
+
+    select * from {{ source('finance', 'raw_payment_transactions') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as payment_transaction_id,
+        cast(order_id as varchar) as order_id,
+        cast(gift_card_id as varchar) as gift_card_id,
+
+        ---------- text
+        payment_method,
+        status as payment_status,
+        reference_number,
+
+        ---------- numerics
+        {{ cents_to_dollars('amount') }} as payment_amount,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'processed_at') }} as processed_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_refunds.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_refunds.sql
@@ -1,0 +1,33 @@
+with
+
+source as (
+
+    select * from {{ source('finance', 'raw_refunds') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as refund_id,
+        cast(order_id as varchar) as order_id,
+        cast(invoice_id as varchar) as invoice_id,
+
+        ---------- text
+        reason as refund_reason,
+        status as refund_status,
+
+        ---------- numerics
+        {{ cents_to_dollars('refund_amount') }} as refund_amount,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'requested_at') }} as requested_date,
+        {{ dbt.date_trunc('day', 'resolved_at') }} as resolved_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_tax_rates.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/finance/stg_tax_rates.sql
@@ -1,0 +1,31 @@
+with
+
+source as (
+
+    select * from {{ source('finance', 'raw_tax_rates') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as tax_rate_id,
+
+        ---------- text
+        jurisdiction,
+        tax_type,
+
+        ---------- numerics
+        rate as tax_rate_pct,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'effective_from') }} as effective_from_date,
+        {{ dbt.date_trunc('day', 'effective_to') }} as effective_to_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/__sources.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/__sources.yml
@@ -1,0 +1,39 @@
+version: 2
+
+sources:
+  - name: hr_ops
+    schema: "{{ target.schema }}_raw"
+    description: HR and store operations data for the Jaffle Shop
+    tables:
+      - name: raw_employees
+        description: Employee records including name, hire date, role, and store assignment
+      - name: raw_departments
+        description: Department definitions (operations, kitchen, front-of-house, management)
+      - name: raw_positions
+        description: Job position definitions with pay grades
+      - name: raw_shifts
+        description: Scheduled and actual shift records
+      - name: raw_timecards
+        description: Clock-in/clock-out records for employees
+        loaded_at_field: work_date
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
+      - name: raw_payroll
+        description: Payroll records per employee per pay period
+        loaded_at_field: pay_date
+        freshness:
+          warn_after: {count: 48, period: hour}
+          error_after: {count: 168, period: hour}
+      - name: raw_performance_reviews
+        description: Employee performance review scores
+      - name: raw_training_courses
+        description: Available training courses for employees
+      - name: raw_training_completions
+        description: Employee training completion records
+      - name: raw_equipment
+        description: Store equipment inventory (espresso machines, grinders, etc.)
+      - name: raw_maintenance_logs
+        description: Equipment maintenance and repair records
+      - name: raw_store_hours
+        description: Operating hours by store by day of week

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/_hr_ops__models.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/_hr_ops__models.yml
@@ -1,0 +1,292 @@
+models:
+  - name: stg_employees
+    description: Employee records with basic cleaning applied, one row per employee.
+    columns:
+      - name: employee_id
+        description: The unique key for each employee.
+        data_tests:
+          - not_null
+          - unique
+      - name: location_id
+        description: Foreign key to the store location where the employee works.
+      - name: department_id
+        description: Foreign key to the employee's department.
+      - name: position_id
+        description: Foreign key to the employee's position.
+      - name: first_name
+        description: Employee's first name.
+      - name: last_name
+        description: Employee's last name.
+      - name: full_name
+        description: Employee's full name (first + last).
+      - name: email
+        description: Employee's email address.
+      - name: employment_status
+        description: Current employment status (e.g., active, terminated, on_leave).
+      - name: hire_date
+        description: Date the employee was hired.
+      - name: termination_date
+        description: Date the employee was terminated (null if still active).
+
+  - name: stg_departments
+    description: Department definitions, one row per department.
+    columns:
+      - name: department_id
+        description: The unique key for each department.
+        data_tests:
+          - not_null
+          - unique
+      - name: department_name
+        description: Name of the department.
+      - name: department_description
+        description: Description of the department's function.
+
+  - name: stg_positions
+    description: Job position definitions with pay grades, one row per position.
+    columns:
+      - name: position_id
+        description: The unique key for each position.
+        data_tests:
+          - not_null
+          - unique
+      - name: department_id
+        description: Foreign key to the department this position belongs to.
+      - name: position_title
+        description: Title of the position.
+      - name: pay_grade
+        description: Pay grade classification for the position.
+      - name: min_hourly_rate
+        description: Minimum hourly pay rate in USD.
+      - name: max_hourly_rate
+        description: Maximum hourly pay rate in USD.
+      - name: is_management
+        description: Whether this position is a management role.
+
+  - name: stg_shifts
+    description: Scheduled and actual shift records, one row per shift.
+    columns:
+      - name: shift_id
+        description: The unique key for each shift.
+        data_tests:
+          - not_null
+          - unique
+      - name: employee_id
+        description: Foreign key to the employee assigned to the shift.
+      - name: location_id
+        description: Foreign key to the store location for the shift.
+      - name: shift_type
+        description: Type of shift (e.g., morning, afternoon, evening, closing).
+      - name: shift_status
+        description: Status of the shift (e.g., scheduled, completed, no_show).
+      - name: shift_date
+        description: Date of the shift.
+      - name: scheduled_start
+        description: Scheduled start time of the shift.
+      - name: scheduled_end
+        description: Scheduled end time of the shift.
+      - name: actual_start
+        description: Actual start time of the shift.
+      - name: actual_end
+        description: Actual end time of the shift.
+      - name: scheduled_hours
+        description: Number of hours the shift is scheduled for.
+
+  - name: stg_timecards
+    description: Clock-in/clock-out records, one row per timecard entry.
+    columns:
+      - name: timecard_id
+        description: The unique key for each timecard entry.
+        data_tests:
+          - not_null
+          - unique
+      - name: employee_id
+        description: Foreign key to the employee.
+      - name: location_id
+        description: Foreign key to the store location.
+      - name: work_date
+        description: Date of the work entry.
+      - name: clock_in
+        description: Clock-in timestamp.
+      - name: clock_out
+        description: Clock-out timestamp.
+      - name: hours_worked
+        description: Total hours worked for this entry.
+      - name: break_minutes
+        description: Total break time in minutes.
+      - name: timecard_status
+        description: Status of the timecard (e.g., approved, pending, rejected).
+
+  - name: stg_payroll
+    description: Payroll records per employee per pay period, one row per payroll entry.
+    columns:
+      - name: payroll_id
+        description: The unique key for each payroll record.
+        data_tests:
+          - not_null
+          - unique
+      - name: employee_id
+        description: Foreign key to the employee.
+      - name: pay_period_start
+        description: Start date of the pay period.
+      - name: pay_period_end
+        description: End date of the pay period.
+      - name: pay_date
+        description: Date the payment was issued.
+      - name: payroll_hours
+        description: Total regular hours worked in the pay period.
+      - name: payroll_overtime_hours
+        description: Total overtime hours in the pay period.
+      - name: gross_pay
+        description: Gross pay amount in USD.
+      - name: deductions
+        description: Total deductions in USD.
+      - name: net_pay
+        description: Net pay amount in USD.
+
+  - name: stg_performance_reviews
+    description: Employee performance review scores, one row per review.
+    columns:
+      - name: review_id
+        description: The unique key for each performance review.
+        data_tests:
+          - not_null
+          - unique
+      - name: employee_id
+        description: Foreign key to the employee being reviewed.
+      - name: reviewer_id
+        description: Foreign key to the employee conducting the review.
+      - name: review_period
+        description: Period the review covers (e.g., Q1 2024).
+      - name: review_comments
+        description: Reviewer comments.
+      - name: overall_score
+        description: Overall performance score.
+      - name: attendance_score
+        description: Attendance component score.
+      - name: quality_score
+        description: Work quality component score.
+      - name: teamwork_score
+        description: Teamwork component score.
+      - name: review_date
+        description: Date the review was conducted.
+
+  - name: stg_training_courses
+    description: Available training courses, one row per course.
+    columns:
+      - name: training_course_id
+        description: The unique key for each training course.
+        data_tests:
+          - not_null
+          - unique
+      - name: course_name
+        description: Name of the training course.
+      - name: course_description
+        description: Description of the training course.
+      - name: course_category
+        description: Category of the course (e.g., safety, barista, management).
+      - name: duration_hours
+        description: Duration of the course in hours.
+      - name: is_required
+        description: Whether the course is required for all employees.
+      - name: is_active
+        description: Whether the course is currently active.
+
+  - name: stg_training_completions
+    description: Employee training completion records, one row per completion.
+    columns:
+      - name: training_completion_id
+        description: The unique key for each training completion record.
+        data_tests:
+          - not_null
+          - unique
+      - name: employee_id
+        description: Foreign key to the employee.
+      - name: training_course_id
+        description: Foreign key to the training course.
+      - name: completion_status
+        description: Status of the training (e.g., in_progress, completed, failed).
+      - name: completion_score
+        description: Score achieved on the training assessment.
+      - name: started_date
+        description: Date the employee started the training.
+      - name: completed_date
+        description: Date the employee completed the training.
+
+  - name: stg_equipment
+    description: Store equipment inventory, one row per piece of equipment.
+    columns:
+      - name: equipment_id
+        description: The unique key for each piece of equipment.
+        data_tests:
+          - not_null
+          - unique
+      - name: location_id
+        description: Foreign key to the store location.
+      - name: equipment_name
+        description: Name of the equipment.
+      - name: equipment_type
+        description: Type of equipment (e.g., espresso_machine, grinder, oven).
+      - name: manufacturer
+        description: Equipment manufacturer.
+      - name: model_number
+        description: Equipment model number.
+      - name: serial_number
+        description: Equipment serial number.
+      - name: equipment_status
+        description: Current status (e.g., operational, maintenance, retired).
+      - name: purchase_cost
+        description: Purchase cost in USD.
+      - name: purchase_date
+        description: Date the equipment was purchased.
+      - name: warranty_expiry_date
+        description: Date the warranty expires.
+      - name: last_maintenance_date
+        description: Date of the last maintenance performed.
+
+  - name: stg_maintenance_logs
+    description: Equipment maintenance and repair records, one row per log entry.
+    columns:
+      - name: maintenance_log_id
+        description: The unique key for each maintenance log entry.
+        data_tests:
+          - not_null
+          - unique
+      - name: equipment_id
+        description: Foreign key to the equipment.
+      - name: technician_id
+        description: ID of the technician who performed the maintenance.
+      - name: maintenance_type
+        description: Type of maintenance (e.g., preventive, corrective, emergency).
+      - name: maintenance_description
+        description: Description of the maintenance performed.
+      - name: maintenance_status
+        description: Status of the maintenance (e.g., scheduled, in_progress, completed).
+      - name: maintenance_cost
+        description: Cost of the maintenance in USD.
+      - name: downtime_hours
+        description: Hours of equipment downtime due to this maintenance.
+      - name: scheduled_date
+        description: Date the maintenance was scheduled.
+      - name: completed_date
+        description: Date the maintenance was completed.
+
+  - name: stg_store_hours
+    description: Operating hours by store by day of week, one row per store-day combination.
+    columns:
+      - name: store_hours_id
+        description: The unique key for each store hours record.
+        data_tests:
+          - not_null
+          - unique
+      - name: location_id
+        description: Foreign key to the store location.
+      - name: day_of_week
+        description: Day of week as integer (0=Sunday, 6=Saturday).
+      - name: day_name
+        description: Day of week as human-readable name.
+      - name: open_time
+        description: Store opening time.
+      - name: close_time
+        description: Store closing time.
+      - name: is_closed
+        description: Whether the store is closed on this day.

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_departments.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_departments.sql
@@ -1,0 +1,24 @@
+with
+
+source as (
+
+    select * from {{ source('hr_ops', 'raw_departments') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as department_id,
+
+        ---------- text
+        name as department_name,
+        description as department_description
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_employees.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_employees.sql
@@ -1,0 +1,34 @@
+with
+
+source as (
+
+    select * from {{ source('hr_ops', 'raw_employees') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as employee_id,
+        cast(store_id as varchar) as location_id,
+        cast(department_id as varchar) as department_id,
+        cast(position_id as varchar) as position_id,
+
+        ---------- text
+        first_name,
+        last_name,
+        first_name || ' ' || last_name as full_name,
+        email,
+        employment_status,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'hire_date') }} as hire_date,
+        {{ dbt.date_trunc('day', 'termination_date') }} as termination_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_equipment.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_equipment.sql
@@ -1,0 +1,37 @@
+with
+
+source as (
+
+    select * from {{ source('hr_ops', 'raw_equipment') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as equipment_id,
+        cast(store_id as varchar) as location_id,
+
+        ---------- text
+        name as equipment_name,
+        type as equipment_type,
+        manufacturer,
+        model_number,
+        serial_number,
+        status as equipment_status,
+
+        ---------- numerics
+        {{ cents_to_dollars('purchase_cost') }} as purchase_cost,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'purchase_date') }} as purchase_date,
+        {{ dbt.date_trunc('day', 'warranty_expiry') }} as warranty_expiry_date,
+        {{ dbt.date_trunc('day', 'last_maintenance_date') }} as last_maintenance_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_maintenance_logs.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_maintenance_logs.sql
@@ -1,0 +1,35 @@
+with
+
+source as (
+
+    select * from {{ source('hr_ops', 'raw_maintenance_logs') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as maintenance_log_id,
+        cast(equipment_id as varchar) as equipment_id,
+        cast(performed_by as varchar) as technician_id,
+
+        ---------- text
+        maintenance_type,
+        description as maintenance_description,
+        status as maintenance_status,
+
+        ---------- numerics
+        {{ cents_to_dollars('cost') }} as maintenance_cost,
+        downtime_hours,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'scheduled_date') }} as scheduled_date,
+        {{ dbt.date_trunc('day', 'completed_date') }} as completed_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_payroll.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_payroll.sql
@@ -1,0 +1,33 @@
+with
+
+source as (
+
+    select * from {{ source('hr_ops', 'raw_payroll') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as payroll_id,
+        cast(employee_id as varchar) as employee_id,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'pay_period_start') }} as pay_period_start,
+        {{ dbt.date_trunc('day', 'pay_period_end') }} as pay_period_end,
+        {{ dbt.date_trunc('day', 'pay_date') }} as pay_date,
+
+        ---------- numerics
+        hours_worked as payroll_hours,
+        overtime_hours as payroll_overtime_hours,
+        {{ cents_to_dollars('gross_pay') }} as gross_pay,
+        {{ cents_to_dollars('deductions') }} as deductions,
+        {{ cents_to_dollars('net_pay') }} as net_pay
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_performance_reviews.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_performance_reviews.sql
@@ -1,0 +1,35 @@
+with
+
+source as (
+
+    select * from {{ source('hr_ops', 'raw_performance_reviews') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as review_id,
+        cast(employee_id as varchar) as employee_id,
+        cast(reviewer_id as varchar) as reviewer_id,
+
+        ---------- text
+        review_period,
+        comments as review_comments,
+
+        ---------- numerics
+        overall_score,
+        attendance_score,
+        quality_score,
+        teamwork_score,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'review_date') }} as review_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_positions.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_positions.sql
@@ -1,0 +1,32 @@
+with
+
+source as (
+
+    select * from {{ source('hr_ops', 'raw_positions') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as position_id,
+        cast(department_id as varchar) as department_id,
+
+        ---------- text
+        title as position_title,
+        pay_grade,
+
+        ---------- numerics
+        {{ cents_to_dollars('min_pay_rate') }} as min_hourly_rate,
+        {{ cents_to_dollars('max_pay_rate') }} as max_hourly_rate,
+
+        ---------- booleans
+        is_management
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_shifts.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_shifts.sql
@@ -1,0 +1,36 @@
+with
+
+source as (
+
+    select * from {{ source('hr_ops', 'raw_shifts') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as shift_id,
+        cast(employee_id as varchar) as employee_id,
+        cast(store_id as varchar) as location_id,
+
+        ---------- text
+        shift_type,
+        status as shift_status,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'shift_date') }} as shift_date,
+        scheduled_start,
+        scheduled_end,
+        actual_start,
+        actual_end,
+
+        ---------- numerics
+        {{ dbt.datediff('scheduled_start', 'scheduled_end', 'hour') }} as scheduled_hours
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_store_hours.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_store_hours.sql
@@ -1,0 +1,42 @@
+with
+
+source as (
+
+    select * from {{ source('hr_ops', 'raw_store_hours') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as store_hours_id,
+        cast(store_id as varchar) as location_id,
+
+        ---------- numerics
+        day_of_week,
+
+        ---------- text
+        case day_of_week
+            when 0 then 'Sunday'
+            when 1 then 'Monday'
+            when 2 then 'Tuesday'
+            when 3 then 'Wednesday'
+            when 4 then 'Thursday'
+            when 5 then 'Friday'
+            when 6 then 'Saturday'
+        end as day_name,
+
+        ---------- timestamps
+        open_time,
+        close_time,
+
+        ---------- booleans
+        is_closed
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_timecards.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_timecards.sql
@@ -1,0 +1,34 @@
+with
+
+source as (
+
+    select * from {{ source('hr_ops', 'raw_timecards') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as timecard_id,
+        cast(employee_id as varchar) as employee_id,
+        cast(store_id as varchar) as location_id,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'work_date') }} as work_date,
+        clock_in,
+        clock_out,
+
+        ---------- numerics
+        hours_worked,
+        break_minutes,
+
+        ---------- text
+        status as timecard_status
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_training_completions.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_training_completions.sql
@@ -1,0 +1,32 @@
+with
+
+source as (
+
+    select * from {{ source('hr_ops', 'raw_training_completions') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as training_completion_id,
+        cast(employee_id as varchar) as employee_id,
+        cast(course_id as varchar) as training_course_id,
+
+        ---------- text
+        status as completion_status,
+
+        ---------- numerics
+        score as completion_score,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'started_at') }} as started_date,
+        {{ dbt.date_trunc('day', 'completed_at') }} as completed_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_training_courses.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/hr_ops/stg_training_courses.sql
@@ -1,0 +1,32 @@
+with
+
+source as (
+
+    select * from {{ source('hr_ops', 'raw_training_courses') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as training_course_id,
+
+        ---------- text
+        name as course_name,
+        description as course_description,
+        category as course_category,
+
+        ---------- numerics
+        duration_hours,
+
+        ---------- booleans
+        is_required,
+        is_active
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/__sources.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/__sources.yml
@@ -1,0 +1,35 @@
+version: 2
+
+sources:
+  - name: marketing
+    schema: "{{ target.schema }}_raw"
+    description: Marketing and loyalty program data for the Jaffle Shop
+    tables:
+      - name: raw_campaigns
+        description: Marketing campaigns across email, social, and in-store channels
+      - name: raw_campaign_spend
+        description: Daily spend per campaign per channel
+      - name: raw_coupons
+        description: Coupon definitions including code, discount type, amount, and validity
+      - name: raw_coupon_redemptions
+        description: Each time a coupon is used on an order
+      - name: raw_loyalty_members
+        description: Loyalty program membership records
+      - name: raw_loyalty_transactions
+        description: Points earned and redeemed by loyalty members
+        loaded_at_field: transacted_at
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
+      - name: raw_loyalty_tiers
+        description: Tier definitions for the loyalty program (Bronze, Silver, Gold, Platinum)
+      - name: raw_email_events
+        description: Email interaction events including sends, opens, clicks, and unsubscribes
+        loaded_at_field: event_at
+        freshness:
+          warn_after: {count: 12, period: hour}
+          error_after: {count: 24, period: hour}
+      - name: raw_social_media_posts
+        description: Social media content and engagement metrics
+      - name: raw_referrals
+        description: Customer referral tracking records

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/_marketing__models.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/_marketing__models.yml
@@ -1,0 +1,204 @@
+models:
+  - name: stg_campaigns
+    description: Cleaned marketing campaigns with renamed columns, one row per campaign.
+    columns:
+      - name: campaign_id
+        description: The unique key for each campaign.
+        data_tests:
+          - not_null
+          - unique
+      - name: campaign_name
+        description: Human-readable campaign name.
+      - name: campaign_channel
+        description: The channel used for the campaign (email, social, in-store).
+      - name: campaign_status
+        description: Current status of the campaign (draft, active, paused, completed).
+      - name: budget
+        description: Total campaign budget in dollars.
+      - name: campaign_start_date
+        description: Date the campaign starts.
+      - name: campaign_end_date
+        description: Date the campaign ends.
+
+  - name: stg_campaign_spend
+    description: Daily campaign spend records by channel, one row per spend entry.
+    columns:
+      - name: campaign_spend_id
+        description: The unique key for each spend record.
+        data_tests:
+          - not_null
+          - unique
+      - name: campaign_id
+        description: Foreign key to campaigns.
+        data_tests:
+          - not_null
+      - name: spend_amount
+        description: Amount spent in dollars.
+      - name: spend_date
+        description: Date the spend occurred.
+
+  - name: stg_coupons
+    description: Coupon definitions with discount details and validity windows, one row per coupon.
+    columns:
+      - name: coupon_id
+        description: The unique key for each coupon.
+        data_tests:
+          - not_null
+          - unique
+      - name: coupon_code
+        description: The code customers enter to redeem the coupon.
+      - name: discount_type
+        description: Type of discount (percentage, fixed_amount).
+      - name: discount_amount
+        description: Fixed discount amount in dollars (null for percentage discounts).
+      - name: discount_percent
+        description: Percentage discount (null for fixed amount discounts).
+      - name: valid_from
+        description: Date the coupon becomes active.
+      - name: valid_until
+        description: Date the coupon expires.
+
+  - name: stg_coupon_redemptions
+    description: Coupon redemption events, one row per redemption.
+    columns:
+      - name: redemption_id
+        description: The unique key for each redemption.
+        data_tests:
+          - not_null
+          - unique
+      - name: coupon_id
+        description: Foreign key to coupons.
+        data_tests:
+          - not_null
+      - name: order_id
+        description: Foreign key to orders.
+        data_tests:
+          - not_null
+      - name: discount_applied
+        description: Actual discount amount applied in dollars.
+      - name: redeemed_at
+        description: Date the coupon was redeemed.
+
+  - name: stg_loyalty_members
+    description: Loyalty program membership records, one row per member.
+    columns:
+      - name: loyalty_member_id
+        description: The unique key for each loyalty member.
+        data_tests:
+          - not_null
+          - unique
+      - name: customer_id
+        description: Foreign key to customers.
+        data_tests:
+          - not_null
+      - name: current_tier_id
+        description: Foreign key to the member's current loyalty tier.
+      - name: membership_status
+        description: Current membership status (active, inactive, suspended).
+      - name: lifetime_points
+        description: Total points earned over the lifetime of membership.
+      - name: enrolled_at
+        description: Date the customer enrolled in the loyalty program.
+
+  - name: stg_loyalty_transactions
+    description: Points earned and redeemed by loyalty members, one row per transaction.
+    columns:
+      - name: loyalty_transaction_id
+        description: The unique key for each loyalty transaction.
+        data_tests:
+          - not_null
+          - unique
+      - name: loyalty_member_id
+        description: Foreign key to loyalty members.
+        data_tests:
+          - not_null
+      - name: transaction_type
+        description: Type of transaction (earn, redeem, expire, bonus).
+      - name: points
+        description: Number of points (positive for earn, negative for redeem/expire).
+      - name: transacted_at
+        description: Date the transaction occurred.
+
+  - name: stg_loyalty_tiers
+    description: Loyalty tier definitions, one row per tier.
+    columns:
+      - name: tier_id
+        description: The unique key for each tier.
+        data_tests:
+          - not_null
+          - unique
+      - name: tier_name
+        description: Name of the tier (Bronze, Silver, Gold, Platinum).
+      - name: minimum_points
+        description: Minimum points required to reach this tier.
+      - name: maximum_points
+        description: Maximum points for this tier (null for top tier).
+      - name: points_multiplier
+        description: Points earning multiplier for this tier.
+      - name: annual_reward
+        description: Annual reward value in dollars for this tier.
+
+  - name: stg_email_events
+    description: Email interaction events, one row per event.
+    columns:
+      - name: email_event_id
+        description: The unique key for each email event.
+        data_tests:
+          - not_null
+          - unique
+      - name: campaign_id
+        description: Foreign key to campaigns.
+      - name: customer_id
+        description: Foreign key to customers.
+      - name: email_event_type
+        description: Type of email event (sent, opened, clicked, unsubscribed, bounced).
+      - name: event_date
+        description: Date the event occurred.
+
+  - name: stg_social_media_posts
+    description: Social media posts and engagement metrics, one row per post.
+    columns:
+      - name: post_id
+        description: The unique key for each social media post.
+        data_tests:
+          - not_null
+          - unique
+      - name: campaign_id
+        description: Foreign key to campaigns (null for organic posts).
+      - name: platform
+        description: Social media platform (instagram, twitter, facebook, tiktok).
+      - name: impressions
+        description: Number of times the post was displayed.
+      - name: reach
+        description: Number of unique users who saw the post.
+      - name: likes
+        description: Number of likes on the post.
+      - name: shares
+        description: Number of shares/retweets.
+      - name: posted_at
+        description: Date the post was published.
+
+  - name: stg_referrals
+    description: Customer referral records, one row per referral.
+    columns:
+      - name: referral_id
+        description: The unique key for each referral.
+        data_tests:
+          - not_null
+          - unique
+      - name: referrer_customer_id
+        description: Foreign key to the customer who made the referral.
+        data_tests:
+          - not_null
+      - name: referee_customer_id
+        description: Foreign key to the customer who was referred.
+        data_tests:
+          - not_null
+      - name: referral_status
+        description: Status of the referral (pending, converted, expired).
+      - name: reward_amount
+        description: Reward amount in dollars for a successful referral.
+      - name: referred_at
+        description: Date the referral was created.
+      - name: converted_at
+        description: Date the referral was converted (referee made a purchase).

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_campaign_spend.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_campaign_spend.sql
@@ -1,0 +1,30 @@
+with
+
+source as (
+
+    select * from {{ source('marketing', 'raw_campaign_spend') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as campaign_spend_id,
+        cast(campaign_id as varchar) as campaign_id,
+
+        ---------- text
+        channel as spend_channel,
+
+        ---------- numerics
+        {{ cents_to_dollars('amount') }} as spend_amount,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'spend_date') }} as spend_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_campaigns.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_campaigns.sql
@@ -1,0 +1,34 @@
+with
+
+source as (
+
+    select * from {{ source('marketing', 'raw_campaigns') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as campaign_id,
+
+        ---------- text
+        name as campaign_name,
+        channel as campaign_channel,
+        status as campaign_status,
+        description as campaign_description,
+
+        ---------- numerics
+        {{ cents_to_dollars('budget') }} as budget,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'start_date') }} as campaign_start_date,
+        {{ dbt.date_trunc('day', 'end_date') }} as campaign_end_date,
+        {{ dbt.date_trunc('day', 'created_at') }} as created_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_coupon_redemptions.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_coupon_redemptions.sql
@@ -1,0 +1,29 @@
+with
+
+source as (
+
+    select * from {{ source('marketing', 'raw_coupon_redemptions') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as redemption_id,
+        cast(coupon_id as varchar) as coupon_id,
+        cast(order_id as varchar) as order_id,
+        cast(customer_id as varchar) as customer_id,
+
+        ---------- numerics
+        {{ cents_to_dollars('discount_applied') }} as discount_applied,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'redeemed_at') }} as redeemed_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_coupons.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_coupons.sql
@@ -1,0 +1,37 @@
+with
+
+source as (
+
+    select * from {{ source('marketing', 'raw_coupons') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as coupon_id,
+        cast(campaign_id as varchar) as campaign_id,
+
+        ---------- text
+        code as coupon_code,
+        discount_type,
+        status as coupon_status,
+
+        ---------- numerics
+        {{ cents_to_dollars('discount_amount') }} as discount_amount,
+        discount_percent,
+        {{ cents_to_dollars('minimum_order_amount') }} as minimum_order_amount,
+        max_redemptions,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'valid_from') }} as valid_from,
+        {{ dbt.date_trunc('day', 'valid_until') }} as valid_until,
+        {{ dbt.date_trunc('day', 'created_at') }} as created_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_email_events.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_email_events.sql
@@ -1,0 +1,30 @@
+with
+
+source as (
+
+    select * from {{ source('marketing', 'raw_email_events') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as email_event_id,
+        cast(campaign_id as varchar) as campaign_id,
+        cast(customer_id as varchar) as customer_id,
+
+        ---------- text
+        event_type as email_event_type,
+        email_subject,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'event_at') }} as event_date,
+        event_at as event_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_loyalty_members.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_loyalty_members.sql
@@ -1,0 +1,32 @@
+with
+
+source as (
+
+    select * from {{ source('marketing', 'raw_loyalty_members') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as loyalty_member_id,
+        cast(customer_id as varchar) as customer_id,
+        cast(tier_id as varchar) as current_tier_id,
+
+        ---------- text
+        status as membership_status,
+
+        ---------- numerics
+        lifetime_points,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'enrolled_at') }} as enrolled_at,
+        {{ dbt.date_trunc('day', 'last_activity_at') }} as last_activity_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_loyalty_tiers.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_loyalty_tiers.sql
@@ -1,0 +1,30 @@
+with
+
+source as (
+
+    select * from {{ source('marketing', 'raw_loyalty_tiers') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as tier_id,
+
+        ---------- text
+        name as tier_name,
+        description as tier_description,
+
+        ---------- numerics
+        min_points as minimum_points,
+        max_points as maximum_points,
+        points_multiplier,
+        {{ cents_to_dollars('annual_reward') }} as annual_reward
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_loyalty_transactions.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_loyalty_transactions.sql
@@ -1,0 +1,32 @@
+with
+
+source as (
+
+    select * from {{ source('marketing', 'raw_loyalty_transactions') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as loyalty_transaction_id,
+        cast(loyalty_member_id as varchar) as loyalty_member_id,
+        cast(order_id as varchar) as order_id,
+
+        ---------- text
+        transaction_type,
+        description as transaction_description,
+
+        ---------- numerics
+        points,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'transacted_at') }} as transacted_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_referrals.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_referrals.sql
@@ -1,0 +1,34 @@
+with
+
+source as (
+
+    select * from {{ source('marketing', 'raw_referrals') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as referral_id,
+        cast(referrer_customer_id as varchar) as referrer_customer_id,
+        cast(referee_customer_id as varchar) as referee_customer_id,
+        cast(campaign_id as varchar) as campaign_id,
+
+        ---------- text
+        status as referral_status,
+        referral_code,
+
+        ---------- numerics
+        {{ cents_to_dollars('reward_amount') }} as reward_amount,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'referred_at') }} as referred_at,
+        {{ dbt.date_trunc('day', 'converted_at') }} as converted_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_social_media_posts.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/marketing/stg_social_media_posts.sql
@@ -1,0 +1,38 @@
+with
+
+source as (
+
+    select * from {{ source('marketing', 'raw_social_media_posts') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as post_id,
+        cast(campaign_id as varchar) as campaign_id,
+
+        ---------- text
+        platform,
+        post_type,
+        content as post_content,
+        url as post_url,
+
+        ---------- numerics
+        impressions,
+        reach,
+        likes,
+        shares,
+        comments as comment_count,
+        clicks as click_count,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'posted_at') }} as posted_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/__sources.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/__sources.yml
@@ -1,0 +1,35 @@
+version: 2
+
+sources:
+  - name: product
+    schema: "{{ target.schema }}_raw"
+    description: Product and menu analytics data for the Jaffle Shop
+    tables:
+      - name: raw_recipes
+        description: Recipe definitions linking menu items to required ingredients
+      - name: raw_recipe_ingredients
+        description: Ingredient quantities per recipe
+      - name: raw_ingredients
+        description: Master ingredient list (flour, coffee beans, milk, etc.)
+      - name: raw_ingredient_prices
+        description: Historical price records for each ingredient from suppliers
+      - name: raw_menu_items
+        description: Menu items (may differ from products — includes combos, seasonal)
+      - name: raw_menu_categories
+        description: Menu category hierarchy (hot drinks, cold drinks, food, pastries)
+      - name: raw_seasonal_menus
+        description: Seasonal and limited-time menu configurations
+      - name: raw_nutritional_info
+        description: Nutritional data per menu item (calories, fat, protein, etc.)
+      - name: raw_pricing_history
+        description: Historical price changes for products
+        loaded_at_field: changed_at
+        freshness:
+          warn_after: {count: 48, period: hour}
+          error_after: {count: 168, period: hour}
+      - name: raw_product_reviews
+        description: Customer reviews and ratings per product
+        loaded_at_field: reviewed_at
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/_product__models.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/_product__models.yml
@@ -1,0 +1,230 @@
+models:
+  - name: stg_recipes
+    description: Recipe definitions linking menu items to required ingredients, one row per recipe.
+    columns:
+      - name: recipe_id
+        description: The unique key for each recipe.
+        data_tests:
+          - not_null
+          - unique
+      - name: menu_item_id
+        description: Foreign key to the menu item this recipe produces.
+      - name: recipe_name
+        description: Name of the recipe.
+      - name: recipe_description
+        description: Description of the recipe.
+      - name: serving_size
+        description: Number of servings the recipe produces.
+      - name: is_active_recipe
+        description: Whether this recipe is currently in use.
+      - name: created_date
+        description: Date the recipe was created.
+      - name: updated_date
+        description: Date the recipe was last updated.
+
+  - name: stg_recipe_ingredients
+    description: Ingredient quantities per recipe, one row per recipe-ingredient combination.
+    columns:
+      - name: recipe_ingredient_id
+        description: The unique key for each recipe ingredient entry.
+        data_tests:
+          - not_null
+          - unique
+      - name: recipe_id
+        description: Foreign key to the recipe.
+      - name: ingredient_id
+        description: Foreign key to the ingredient.
+      - name: quantity
+        description: Quantity of the ingredient required.
+      - name: quantity_unit
+        description: Unit of measure for the quantity (e.g., grams, ml, units).
+
+  - name: stg_ingredients
+    description: Master ingredient list, one row per ingredient.
+    columns:
+      - name: ingredient_id
+        description: The unique key for each ingredient.
+        data_tests:
+          - not_null
+          - unique
+      - name: ingredient_name
+        description: Name of the ingredient.
+      - name: ingredient_category
+        description: Category of the ingredient (e.g., dairy, grain, produce).
+      - name: default_unit
+        description: Default unit of measure for this ingredient.
+      - name: is_perishable
+        description: Whether the ingredient is perishable.
+      - name: is_allergen
+        description: Whether the ingredient is a common allergen.
+
+  - name: stg_ingredient_prices
+    description: Historical price records for each ingredient from suppliers, one row per price record.
+    columns:
+      - name: ingredient_price_id
+        description: The unique key for each ingredient price record.
+        data_tests:
+          - not_null
+          - unique
+      - name: ingredient_id
+        description: Foreign key to the ingredient.
+      - name: supplier_id
+        description: Foreign key to the supplier providing this price.
+      - name: unit_cost
+        description: Cost per unit of the ingredient in USD.
+      - name: minimum_order_quantity
+        description: Minimum order quantity for this price tier.
+      - name: effective_from_date
+        description: Date this price became effective.
+      - name: effective_to_date
+        description: Date this price expires (null if currently active).
+
+  - name: stg_menu_items
+    description: Menu items including combos and seasonal offerings, one row per menu item.
+    columns:
+      - name: menu_item_id
+        description: The unique key for each menu item.
+        data_tests:
+          - not_null
+          - unique
+      - name: product_id
+        description: Foreign key to the base product (null for combos).
+      - name: menu_category_id
+        description: Foreign key to the menu category.
+      - name: menu_item_name
+        description: Display name of the menu item.
+      - name: menu_item_description
+        description: Description shown on the menu.
+      - name: menu_item_size
+        description: Size variant (e.g., small, medium, large).
+      - name: menu_item_price
+        description: Current menu price in USD.
+      - name: display_order
+        description: Sort order for menu display.
+      - name: is_available
+        description: Whether the item is currently available.
+      - name: is_combo
+        description: Whether this is a combo/bundle item.
+      - name: is_seasonal
+        description: Whether this is a seasonal item.
+
+  - name: stg_menu_categories
+    description: Menu category hierarchy, one row per category.
+    columns:
+      - name: menu_category_id
+        description: The unique key for each menu category.
+        data_tests:
+          - not_null
+          - unique
+      - name: parent_category_id
+        description: Foreign key to the parent category (null for top-level).
+      - name: category_name
+        description: Name of the menu category.
+      - name: category_description
+        description: Description of the menu category.
+      - name: category_display_order
+        description: Sort order for category display.
+      - name: category_depth
+        description: Depth in the category hierarchy (0 for top-level).
+      - name: is_active_category
+        description: Whether this category is currently active.
+
+  - name: stg_seasonal_menus
+    description: Seasonal and limited-time menu configurations, one row per seasonal menu entry.
+    columns:
+      - name: seasonal_menu_id
+        description: The unique key for each seasonal menu entry.
+        data_tests:
+          - not_null
+          - unique
+      - name: menu_item_id
+        description: Foreign key to the menu item included in the seasonal menu.
+      - name: season_name
+        description: Name of the season (e.g., summer, holiday, spring).
+      - name: promotion_name
+        description: Name of the seasonal promotion.
+      - name: promotion_start_date
+        description: Start date of the seasonal promotion.
+      - name: promotion_end_date
+        description: End date of the seasonal promotion.
+      - name: is_active_promotion
+        description: Whether this seasonal promotion is currently active.
+
+  - name: stg_nutritional_info
+    description: Nutritional data per menu item, one row per menu item.
+    columns:
+      - name: nutritional_info_id
+        description: The unique key for each nutritional info record.
+        data_tests:
+          - not_null
+          - unique
+      - name: menu_item_id
+        description: Foreign key to the menu item.
+      - name: calories
+        description: Total calories per serving.
+      - name: total_fat_g
+        description: Total fat in grams per serving.
+      - name: saturated_fat_g
+        description: Saturated fat in grams per serving.
+      - name: trans_fat_g
+        description: Trans fat in grams per serving.
+      - name: cholesterol_mg
+        description: Cholesterol in milligrams per serving.
+      - name: sodium_mg
+        description: Sodium in milligrams per serving.
+      - name: total_carbs_g
+        description: Total carbohydrates in grams per serving.
+      - name: dietary_fiber_g
+        description: Dietary fiber in grams per serving.
+      - name: total_sugars_g
+        description: Total sugars in grams per serving.
+      - name: protein_g
+        description: Protein in grams per serving.
+      - name: caffeine_mg
+        description: Caffeine in milligrams per serving.
+      - name: serving_size_description
+        description: Description of the serving size.
+      - name: updated_date
+        description: Date the nutritional info was last updated.
+
+  - name: stg_pricing_history
+    description: Historical price changes for products, one row per price change.
+    columns:
+      - name: pricing_history_id
+        description: The unique key for each pricing history record.
+        data_tests:
+          - not_null
+          - unique
+      - name: product_id
+        description: Foreign key to the product.
+      - name: old_price
+        description: Previous price in USD.
+      - name: new_price
+        description: New price in USD.
+      - name: change_reason
+        description: Reason for the price change.
+      - name: price_changed_date
+        description: Date the price change took effect.
+
+  - name: stg_product_reviews
+    description: Customer reviews and ratings per product, one row per review.
+    columns:
+      - name: review_id
+        description: The unique key for each review.
+        data_tests:
+          - not_null
+          - unique
+      - name: product_id
+        description: Foreign key to the product being reviewed.
+      - name: customer_id
+        description: Foreign key to the customer who wrote the review.
+      - name: order_id
+        description: Foreign key to the order associated with the review.
+      - name: rating
+        description: Numeric rating (1-5 scale).
+      - name: review_title
+        description: Title of the review.
+      - name: review_body
+        description: Full text of the review.
+      - name: reviewed_date
+        description: Date the review was submitted.

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_ingredient_prices.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_ingredient_prices.sql
@@ -1,0 +1,30 @@
+with
+
+source as (
+
+    select * from {{ source('product', 'raw_ingredient_prices') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as ingredient_price_id,
+        cast(ingredient_id as varchar) as ingredient_id,
+        cast(supplier_id as varchar) as supplier_id,
+
+        ---------- numerics
+        {{ cents_to_dollars('unit_cost') }} as unit_cost,
+        quantity as minimum_order_quantity,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'effective_from') }} as effective_from_date,
+        {{ dbt.date_trunc('day', 'effective_to') }} as effective_to_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_ingredients.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_ingredients.sql
@@ -1,0 +1,29 @@
+with
+
+source as (
+
+    select * from {{ source('product', 'raw_ingredients') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as ingredient_id,
+
+        ---------- text
+        name as ingredient_name,
+        category as ingredient_category,
+        unit as default_unit,
+
+        ---------- booleans
+        coalesce(is_perishable, false) as is_perishable,
+        coalesce(is_allergen, false) as is_allergen
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_menu_categories.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_menu_categories.sql
@@ -1,0 +1,32 @@
+with
+
+source as (
+
+    select * from {{ source('product', 'raw_menu_categories') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as menu_category_id,
+        cast(parent_category_id as varchar) as parent_category_id,
+
+        ---------- text
+        name as category_name,
+        description as category_description,
+
+        ---------- numerics
+        display_order as category_display_order,
+        depth as category_depth,
+
+        ---------- booleans
+        coalesce(is_active, false) as is_active_category
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_menu_items.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_menu_items.sql
@@ -1,0 +1,36 @@
+with
+
+source as (
+
+    select * from {{ source('product', 'raw_menu_items') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as menu_item_id,
+        cast(product_id as varchar) as product_id,
+        cast(category_id as varchar) as menu_category_id,
+
+        ---------- text
+        name as menu_item_name,
+        description as menu_item_description,
+        size as menu_item_size,
+
+        ---------- numerics
+        {{ cents_to_dollars('price') }} as menu_item_price,
+        display_order,
+
+        ---------- booleans
+        coalesce(is_available, false) as is_available,
+        coalesce(is_combo, false) as is_combo,
+        coalesce(is_seasonal, false) as is_seasonal
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_nutritional_info.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_nutritional_info.sql
@@ -1,0 +1,40 @@
+with
+
+source as (
+
+    select * from {{ source('product', 'raw_nutritional_info') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as nutritional_info_id,
+        cast(menu_item_id as varchar) as menu_item_id,
+
+        ---------- numerics
+        calories,
+        total_fat_g,
+        saturated_fat_g,
+        trans_fat_g,
+        cholesterol_mg,
+        sodium_mg,
+        total_carbs_g,
+        dietary_fiber_g,
+        total_sugars_g,
+        protein_g,
+        caffeine_mg,
+
+        ---------- text
+        serving_size_description,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'updated_at') }} as updated_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_pricing_history.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_pricing_history.sql
@@ -1,0 +1,31 @@
+with
+
+source as (
+
+    select * from {{ source('product', 'raw_pricing_history') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as pricing_history_id,
+        cast(product_id as varchar) as product_id,
+
+        ---------- numerics
+        {{ cents_to_dollars('old_price') }} as old_price,
+        {{ cents_to_dollars('new_price') }} as new_price,
+
+        ---------- text
+        change_reason,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'changed_at') }} as price_changed_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_product_reviews.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_product_reviews.sql
@@ -1,0 +1,33 @@
+with
+
+source as (
+
+    select * from {{ source('product', 'raw_product_reviews') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as review_id,
+        cast(product_id as varchar) as product_id,
+        cast(customer_id as varchar) as customer_id,
+        cast(order_id as varchar) as order_id,
+
+        ---------- numerics
+        rating,
+
+        ---------- text
+        review_title,
+        review_body,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'reviewed_at') }} as reviewed_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_recipe_ingredients.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_recipe_ingredients.sql
@@ -1,0 +1,26 @@
+with
+
+source as (
+
+    select * from {{ source('product', 'raw_recipe_ingredients') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as recipe_ingredient_id,
+        cast(recipe_id as varchar) as recipe_id,
+        cast(ingredient_id as varchar) as ingredient_id,
+
+        ---------- numerics
+        quantity,
+        unit as quantity_unit
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_recipes.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_recipes.sql
@@ -1,0 +1,35 @@
+with
+
+source as (
+
+    select * from {{ source('product', 'raw_recipes') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as recipe_id,
+        cast(menu_item_id as varchar) as menu_item_id,
+
+        ---------- text
+        name as recipe_name,
+        description as recipe_description,
+
+        ---------- numerics
+        serving_size,
+
+        ---------- booleans
+        coalesce(is_active, false) as is_active_recipe,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'created_at') }} as created_date,
+        {{ dbt.date_trunc('day', 'updated_at') }} as updated_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_seasonal_menus.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/product/stg_seasonal_menus.sql
@@ -1,0 +1,32 @@
+with
+
+source as (
+
+    select * from {{ source('product', 'raw_seasonal_menus') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as seasonal_menu_id,
+        cast(menu_item_id as varchar) as menu_item_id,
+
+        ---------- text
+        season_name,
+        promotion_name,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'start_date') }} as promotion_start_date,
+        {{ dbt.date_trunc('day', 'end_date') }} as promotion_end_date,
+
+        ---------- booleans
+        coalesce(is_active, false) as is_active_promotion
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_customers.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_customers.sql
@@ -1,0 +1,23 @@
+with
+
+source as (
+
+    select * from {{ source('ecom', 'raw_customers') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as customer_id,
+
+        ---------- text
+        name as customer_name
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_customers.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_customers.yml
@@ -1,0 +1,9 @@
+models:
+  - name: stg_customers
+    description: Customer data with basic cleaning and transformation applied, one row per customer.
+    columns:
+      - name: customer_id
+        description: The unique key for each customer.
+        data_tests:
+          - not_null
+          - unique

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_locations.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_locations.sql
@@ -1,0 +1,29 @@
+with
+
+source as (
+
+    select * from {{ source('ecom', 'raw_stores') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as location_id,
+
+        ---------- text
+        name as location_name,
+
+        ---------- numerics
+        tax_rate,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'opened_at') }} as opened_date
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_locations.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_locations.yml
@@ -1,0 +1,43 @@
+models:
+  - name: stg_locations
+    description: List of open locations with basic cleaning and transformation applied, one row per location.
+    columns:
+      - name: location_id
+        description: The unique key for each location.
+        data_tests:
+          - not_null
+          - unique
+
+unit_tests:
+  - name: test_does_location_opened_at_trunc_to_date
+    description: "Check that opened_at timestamp is properly truncated to a date."
+    model: stg_locations
+    given:
+      - input: source('ecom', 'raw_stores')
+        rows:
+          - {
+              id: 1,
+              name: "Vice City",
+              tax_rate: 0.2,
+              opened_at: "2016-09-01T00:00:00",
+            }
+          - {
+              id: 2,
+              name: "San Andreas",
+              tax_rate: 0.1,
+              opened_at: "2079-10-27T23:59:59.9999",
+            }
+    expect:
+      rows:
+        - {
+            location_id: 1,
+            location_name: "Vice City",
+            tax_rate: 0.2,
+            opened_date: "2016-09-01",
+          }
+        - {
+            location_id: 2,
+            location_name: "San Andreas",
+            tax_rate: 0.1,
+            opened_date: "2079-10-27",
+          }

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_order_items.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_order_items.sql
@@ -1,0 +1,22 @@
+with
+
+source as (
+
+    select * from {{ source('ecom', 'raw_items') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as order_item_id,
+        cast(order_id as varchar) as order_id,
+        cast(sku as varchar) as product_id
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_order_items.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_order_items.yml
@@ -1,0 +1,17 @@
+models:
+  - name: stg_order_items
+    description: Individual food and drink items that make up our orders, one row per item.
+    columns:
+      - name: order_item_id
+        description: The unique key for each order item.
+        data_tests:
+          - not_null
+          - unique
+      - name: order_id
+        description: The corresponding order each order item belongs to
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_orders')
+                field: order_id

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_orders.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_orders.sql
@@ -1,0 +1,33 @@
+with
+
+source as (
+
+    select * from {{ source('ecom', 'raw_orders') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as order_id,
+        cast(store_id as varchar) as location_id,
+        cast(customer as varchar) as customer_id,
+
+        ---------- numerics
+        subtotal as subtotal_cents,
+        tax_paid as tax_paid_cents,
+        order_total as order_total_cents,
+        {{ cents_to_dollars('subtotal') }} as subtotal,
+        {{ cents_to_dollars('tax_paid') }} as tax_paid,
+        {{ cents_to_dollars('order_total') }} as order_total,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day','ordered_at') }} as ordered_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_orders.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_orders.yml
@@ -1,0 +1,13 @@
+models:
+  - name: stg_orders
+    description: Order data with basic cleaning and transformation applied, one row per order.
+    data_tests:
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "order_total - tax_paid = subtotal"
+    columns:
+      - name: order_id
+        description: The unique key for each order.
+        data_tests:
+          - not_null
+          - unique

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_products.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_products.sql
@@ -1,0 +1,34 @@
+with
+
+source as (
+
+    select * from {{ source('ecom', 'raw_products') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(sku as varchar) as product_id,
+
+        ---------- text
+        name as product_name,
+        type as product_type,
+        description as product_description,
+
+
+        ---------- numerics
+        {{ cents_to_dollars('price') }} as product_price,
+
+        ---------- booleans
+        coalesce(type = 'jaffle', false) as is_food_item,
+
+        coalesce(type = 'beverage', false) as is_drink_item
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_products.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_products.yml
@@ -1,0 +1,9 @@
+models:
+  - name: stg_products
+    description: Product (food and drink items that can be ordered) data with basic cleaning and transformation applied, one row per product.
+    columns:
+      - name: product_id
+        description: The unique key for each product.
+        data_tests:
+          - not_null
+          - unique

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_supplies.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_supplies.sql
@@ -1,0 +1,31 @@
+with
+
+source as (
+
+    select * from {{ source('ecom', 'raw_supplies') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        {{ dbt_utils.generate_surrogate_key(['id', 'sku']) }} as supply_uuid,
+        cast(id as varchar) as supply_id,
+        cast(sku as varchar) as product_id,
+
+        ---------- text
+        name as supply_name,
+
+        ---------- numerics
+        {{ cents_to_dollars('cost') }} as supply_cost,
+
+        ---------- booleans
+        perishable as is_perishable_supply
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_supplies.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/stg_supplies.yml
@@ -1,0 +1,12 @@
+models:
+  - name: stg_supplies
+    description: >
+      List of our supply expenses data with basic cleaning and transformation applied.
+
+      One row per supply cost, not per supply. As supply costs fluctuate they receive a new row with a new UUID. Thus there can be multiple rows per supply_id.
+    columns:
+      - name: supply_uuid
+        description: The unique key of our supplies per cost.
+        data_tests:
+          - not_null
+          - unique

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/__sources.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/__sources.yml
@@ -1,0 +1,35 @@
+version: 2
+
+sources:
+  - name: supply_chain
+    schema: "{{ target.schema }}_raw"
+    description: Supply chain and inventory data for the Jaffle Shop
+    tables:
+      - name: raw_suppliers
+        description: Supplier companies that provide ingredients and supplies
+      - name: raw_supplier_contracts
+        description: Contract terms with each supplier
+      - name: raw_purchase_orders
+        description: Purchase orders placed with suppliers
+        loaded_at_field: ordered_at
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
+      - name: raw_po_line_items
+        description: Individual items on each purchase order
+      - name: raw_po_receipts
+        description: Goods received against purchase orders
+      - name: raw_warehouses
+        description: Warehouse and distribution center locations
+      - name: raw_inventory_counts
+        description: Periodic physical inventory counts by location
+      - name: raw_inventory_movements
+        description: Inbound and outbound inventory transactions
+        loaded_at_field: moved_at
+        freshness:
+          warn_after: {count: 12, period: hour}
+          error_after: {count: 24, period: hour}
+      - name: raw_waste_logs
+        description: Records of spoiled or wasted inventory
+      - name: raw_delivery_shipments
+        description: Shipments from suppliers to stores and warehouses

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/_supply_chain__models.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/_supply_chain__models.yml
@@ -1,0 +1,240 @@
+models:
+  - name: stg_suppliers
+    description: Supplier companies that provide ingredients and supplies to Jaffle Shop, one row per supplier.
+    columns:
+      - name: supplier_id
+        description: The unique key for each supplier.
+        data_tests:
+          - not_null
+          - unique
+      - name: supplier_name
+        description: The name of the supplier company.
+      - name: contact_name
+        description: Primary contact person at the supplier.
+      - name: contact_email
+        description: Email address of the primary contact.
+      - name: is_active
+        description: Whether the supplier is currently active.
+      - name: created_at
+        description: The date the supplier record was created.
+
+  - name: stg_supplier_contracts
+    description: Contract terms negotiated with each supplier, one row per contract.
+    columns:
+      - name: contract_id
+        description: The unique key for each contract.
+        data_tests:
+          - not_null
+          - unique
+      - name: supplier_id
+        description: The foreign key to the supplier.
+        data_tests:
+          - not_null
+      - name: contract_type
+        description: The type of contract (e.g. fixed-price, volume-based).
+      - name: minimum_order_amount
+        description: The minimum order amount in USD required by the contract.
+      - name: lead_time_days
+        description: Contracted lead time in days from order to delivery.
+      - name: effective_date
+        description: The date the contract becomes effective.
+      - name: expiration_date
+        description: The date the contract expires.
+
+  - name: stg_purchase_orders
+    description: Purchase orders placed with suppliers, one row per purchase order.
+    columns:
+      - name: purchase_order_id
+        description: The unique key for each purchase order.
+        data_tests:
+          - not_null
+          - unique
+      - name: supplier_id
+        description: The foreign key to the supplier.
+        data_tests:
+          - not_null
+      - name: warehouse_id
+        description: The foreign key to the destination warehouse.
+      - name: po_status
+        description: Current status of the purchase order (e.g. draft, submitted, received, cancelled).
+      - name: total_amount
+        description: The total amount of the purchase order in USD.
+      - name: ordered_at
+        description: The date the purchase order was placed.
+      - name: expected_delivery_at
+        description: The expected delivery date.
+
+  - name: stg_po_line_items
+    description: Individual line items on each purchase order, one row per line item.
+    columns:
+      - name: po_line_item_id
+        description: The unique key for each purchase order line item.
+        data_tests:
+          - not_null
+          - unique
+      - name: purchase_order_id
+        description: The foreign key to the purchase order.
+        data_tests:
+          - not_null
+      - name: product_id
+        description: The foreign key to the product being ordered.
+        data_tests:
+          - not_null
+      - name: quantity_ordered
+        description: The quantity of the product ordered.
+      - name: unit_cost
+        description: The cost per unit in USD.
+      - name: line_total
+        description: The total cost for this line item in USD.
+
+  - name: stg_po_receipts
+    description: Goods received against purchase orders, one row per receipt.
+    columns:
+      - name: receipt_id
+        description: The unique key for each receipt.
+        data_tests:
+          - not_null
+          - unique
+      - name: purchase_order_id
+        description: The foreign key to the purchase order.
+        data_tests:
+          - not_null
+      - name: po_line_item_id
+        description: The foreign key to the purchase order line item.
+        data_tests:
+          - not_null
+      - name: quantity_received
+        description: The quantity of goods received.
+      - name: quality_status
+        description: Quality inspection result (e.g. accepted, rejected, partial).
+      - name: received_at
+        description: The date the goods were received.
+
+  - name: stg_warehouses
+    description: Warehouse and distribution center locations, one row per warehouse.
+    columns:
+      - name: warehouse_id
+        description: The unique key for each warehouse.
+        data_tests:
+          - not_null
+          - unique
+      - name: warehouse_name
+        description: The name of the warehouse.
+      - name: warehouse_type
+        description: The type of warehouse (e.g. distribution center, cold storage).
+      - name: capacity_units
+        description: The total storage capacity in standard units.
+      - name: is_active
+        description: Whether the warehouse is currently operational.
+      - name: opened_at
+        description: The date the warehouse opened.
+
+  - name: stg_inventory_counts
+    description: Periodic physical inventory counts by product and location, one row per count event.
+    columns:
+      - name: inventory_count_id
+        description: The unique key for each inventory count record.
+        data_tests:
+          - not_null
+          - unique
+      - name: product_id
+        description: The foreign key to the product.
+        data_tests:
+          - not_null
+      - name: location_id
+        description: The foreign key to the location (store or warehouse).
+        data_tests:
+          - not_null
+      - name: quantity_on_hand
+        description: Total quantity physically present.
+      - name: quantity_reserved
+        description: Quantity reserved for pending orders.
+      - name: quantity_available
+        description: Quantity available for new orders.
+      - name: counted_at
+        description: The date the physical count was performed.
+
+  - name: stg_inventory_movements
+    description: Inbound and outbound inventory transactions, one row per movement.
+    columns:
+      - name: movement_id
+        description: The unique key for each inventory movement.
+        data_tests:
+          - not_null
+          - unique
+      - name: product_id
+        description: The foreign key to the product.
+        data_tests:
+          - not_null
+      - name: location_id
+        description: The foreign key to the location (store or warehouse).
+        data_tests:
+          - not_null
+      - name: movement_type
+        description: The type of movement (e.g. inbound, outbound, transfer, adjustment).
+      - name: quantity
+        description: The quantity moved (positive for inbound, negative for outbound).
+      - name: reference_type
+        description: The type of source document (e.g. purchase_order, sale, transfer).
+      - name: reference_id
+        description: The ID of the source document.
+      - name: moved_at
+        description: The date the inventory movement occurred.
+
+  - name: stg_waste_logs
+    description: Records of spoiled or wasted inventory, one row per waste event.
+    columns:
+      - name: waste_log_id
+        description: The unique key for each waste log entry.
+        data_tests:
+          - not_null
+          - unique
+      - name: product_id
+        description: The foreign key to the product.
+        data_tests:
+          - not_null
+      - name: location_id
+        description: The foreign key to the location.
+        data_tests:
+          - not_null
+      - name: waste_reason
+        description: The reason for waste (e.g. expired, damaged, quality).
+      - name: quantity_wasted
+        description: The quantity of product wasted.
+      - name: cost_of_waste
+        description: The cost of the wasted inventory in USD.
+      - name: wasted_at
+        description: The date the waste was recorded.
+
+  - name: stg_delivery_shipments
+    description: Shipments from suppliers to stores and warehouses, one row per shipment.
+    columns:
+      - name: shipment_id
+        description: The unique key for each shipment.
+        data_tests:
+          - not_null
+          - unique
+      - name: purchase_order_id
+        description: The foreign key to the purchase order.
+        data_tests:
+          - not_null
+      - name: supplier_id
+        description: The foreign key to the supplier.
+        data_tests:
+          - not_null
+      - name: destination_id
+        description: The ID of the destination (store or warehouse).
+      - name: destination_type
+        description: The type of destination (e.g. store, warehouse).
+      - name: carrier
+        description: The shipping carrier.
+      - name: tracking_number
+        description: The shipment tracking number.
+      - name: shipment_status
+        description: Current status of the shipment (e.g. in_transit, delivered, delayed).
+      - name: shipped_at
+        description: The date the shipment was dispatched.
+      - name: estimated_arrival_at
+        description: The estimated arrival date.
+      - name: actual_arrival_at
+        description: The actual arrival date, null if not yet delivered.

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_delivery_shipments.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_delivery_shipments.sql
@@ -1,0 +1,34 @@
+with
+
+source as (
+
+    select * from {{ source('supply_chain', 'raw_delivery_shipments') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as shipment_id,
+        cast(purchase_order_id as varchar) as purchase_order_id,
+        cast(supplier_id as varchar) as supplier_id,
+        cast(destination_id as varchar) as destination_id,
+
+        ---------- text
+        destination_type,
+        carrier,
+        tracking_number,
+        shipment_status,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'shipped_at') }} as shipped_at,
+        {{ dbt.date_trunc('day', 'estimated_arrival_at') }} as estimated_arrival_at,
+        {{ dbt.date_trunc('day', 'actual_arrival_at') }} as actual_arrival_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_inventory_counts.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_inventory_counts.sql
@@ -1,0 +1,30 @@
+with
+
+source as (
+
+    select * from {{ source('supply_chain', 'raw_inventory_counts') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as inventory_count_id,
+        cast(product_id as varchar) as product_id,
+        cast(location_id as varchar) as location_id,
+
+        ---------- numerics
+        quantity_on_hand,
+        quantity_reserved,
+        quantity_available,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'counted_at') }} as counted_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_inventory_movements.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_inventory_movements.sql
@@ -1,0 +1,33 @@
+with
+
+source as (
+
+    select * from {{ source('supply_chain', 'raw_inventory_movements') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as movement_id,
+        cast(product_id as varchar) as product_id,
+        cast(location_id as varchar) as location_id,
+
+        ---------- text
+        movement_type,
+        reference_type,
+        cast(reference_id as varchar) as reference_id,
+
+        ---------- numerics
+        quantity,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'moved_at') }} as moved_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_po_line_items.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_po_line_items.sql
@@ -1,0 +1,27 @@
+with
+
+source as (
+
+    select * from {{ source('supply_chain', 'raw_po_line_items') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as po_line_item_id,
+        cast(purchase_order_id as varchar) as purchase_order_id,
+        cast(product_id as varchar) as product_id,
+
+        ---------- numerics
+        quantity_ordered,
+        {{ cents_to_dollars('unit_cost') }} as unit_cost,
+        {{ cents_to_dollars('line_total') }} as line_total
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_po_receipts.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_po_receipts.sql
@@ -1,0 +1,31 @@
+with
+
+source as (
+
+    select * from {{ source('supply_chain', 'raw_po_receipts') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as receipt_id,
+        cast(purchase_order_id as varchar) as purchase_order_id,
+        cast(po_line_item_id as varchar) as po_line_item_id,
+
+        ---------- numerics
+        quantity_received,
+
+        ---------- text
+        quality_status,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'received_at') }} as received_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_purchase_orders.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_purchase_orders.sql
@@ -1,0 +1,33 @@
+with
+
+source as (
+
+    select * from {{ source('supply_chain', 'raw_purchase_orders') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as purchase_order_id,
+        cast(supplier_id as varchar) as supplier_id,
+        cast(warehouse_id as varchar) as warehouse_id,
+
+        ---------- text
+        status as po_status,
+
+        ---------- numerics
+        {{ cents_to_dollars('total_amount') }} as total_amount,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'ordered_at') }} as ordered_at,
+        {{ dbt.date_trunc('day', 'expected_delivery_at') }} as expected_delivery_at,
+        {{ dbt.date_trunc('day', 'created_at') }} as created_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_supplier_contracts.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_supplier_contracts.sql
@@ -1,0 +1,34 @@
+with
+
+source as (
+
+    select * from {{ source('supply_chain', 'raw_supplier_contracts') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as contract_id,
+        cast(supplier_id as varchar) as supplier_id,
+
+        ---------- text
+        contract_type,
+        payment_terms,
+
+        ---------- numerics
+        {{ cents_to_dollars('minimum_order_amount') }} as minimum_order_amount,
+        lead_time_days,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'effective_date') }} as effective_date,
+        {{ dbt.date_trunc('day', 'expiration_date') }} as expiration_date,
+        {{ dbt.date_trunc('day', 'created_at') }} as created_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_suppliers.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_suppliers.sql
@@ -1,0 +1,36 @@
+with
+
+source as (
+
+    select * from {{ source('supply_chain', 'raw_suppliers') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as supplier_id,
+
+        ---------- text
+        name as supplier_name,
+        contact_name,
+        contact_email,
+        phone,
+        address,
+        city,
+        state,
+        country,
+
+        ---------- booleans
+        is_active,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'created_at') }} as created_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_warehouses.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_warehouses.sql
@@ -1,0 +1,36 @@
+with
+
+source as (
+
+    select * from {{ source('supply_chain', 'raw_warehouses') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as warehouse_id,
+
+        ---------- text
+        name as warehouse_name,
+        address,
+        city,
+        state,
+        warehouse_type,
+
+        ---------- numerics
+        capacity_units,
+
+        ---------- booleans
+        is_active,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'opened_at') }} as opened_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_waste_logs.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/staging/supply_chain/stg_waste_logs.sql
@@ -1,0 +1,32 @@
+with
+
+source as (
+
+    select * from {{ source('supply_chain', 'raw_waste_logs') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        cast(id as varchar) as waste_log_id,
+        cast(product_id as varchar) as product_id,
+        cast(location_id as varchar) as location_id,
+
+        ---------- text
+        waste_reason,
+
+        ---------- numerics
+        quantity_wasted,
+        {{ cents_to_dollars('cost_of_waste') }} as cost_of_waste,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'wasted_at') }} as wasted_at
+
+    from source
+
+)
+
+select * from renamed

--- a/groups/jaffle/projects/jaffle-shop/transform/models/utils/_utilities__models.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/utils/_utilities__models.yml
@@ -1,0 +1,81 @@
+models:
+  - name: util_date_spine
+    description: >
+      Date spine from ~2017 to ~2027 (3650 days from today, going backwards).
+      Provides calendar attributes for each day including day of week, week start,
+      month start, quarter start, and weekend flag.
+    columns:
+      - name: date_day
+        description: The calendar date.
+        data_tests:
+          - unique
+          - not_null
+      - name: day_of_week
+        description: "Day of week as integer (0=Sunday, 6=Saturday)."
+      - name: day_name
+        description: "Day name (e.g., Monday, Tuesday)."
+      - name: week_start
+        description: The start of the ISO week containing this date.
+      - name: month_start
+        description: The first day of the month.
+      - name: quarter_start
+        description: The first day of the calendar quarter.
+      - name: year
+        description: The calendar year.
+      - name: is_weekend
+        description: Whether the date falls on Saturday or Sunday.
+
+  - name: util_fiscal_periods
+    description: >
+      Fiscal calendar mapping. Maps each calendar date to a fiscal year,
+      fiscal quarter, and fiscal month assuming a February 1 fiscal year start.
+    columns:
+      - name: date_day
+        description: The calendar date.
+        data_tests:
+          - unique
+          - not_null
+      - name: fiscal_year
+        description: "Fiscal year (e.g., FY starting Feb 1 2024 = fiscal year 2024)."
+      - name: fiscal_quarter
+        description: "Fiscal quarter (1-4)."
+      - name: fiscal_month
+        description: "Fiscal month (1-12, where Feb=1, Jan=12)."
+
+  - name: util_store_calendar
+    description: >
+      Cross join of the date spine with locations. Provides one row per store
+      per day starting from each store's opening date, useful for gap-filling
+      sparse event data.
+    columns:
+      - name: date_day
+        description: The calendar date.
+      - name: location_id
+        description: The store/location identifier.
+      - name: location_name
+        description: The name of the store.
+      - name: days_since_opening
+        description: Number of days since the store opened.
+      - name: is_weekend
+        description: Whether the date is a weekend day.
+
+  - name: util_product_active_dates
+    description: >
+      Date range when each product was actively sold. Derived from first and
+      last order dates per product in stg_order_items.
+    columns:
+      - name: product_id
+        description: The product identifier.
+        data_tests:
+          - unique
+          - not_null
+      - name: product_name
+        description: The name of the product.
+      - name: active_from
+        description: Date of the first order containing this product.
+      - name: last_seen_at
+        description: Date of the most recent order containing this product.
+      - name: active_days
+        description: Number of days between first and last order.
+      - name: is_currently_active
+        description: Whether the product was ordered within the last 30 days.

--- a/groups/jaffle/projects/jaffle-shop/transform/models/utils/util_date_spine.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/utils/util_date_spine.sql
@@ -1,0 +1,36 @@
+with
+
+days as (
+
+    {{ dbt_date.get_base_dates(n_dateparts=3650, datepart="day") }}
+
+),
+
+date_spine as (
+
+    select
+        cast(date_day as date) as date_day,
+        {{ dbt.date_trunc('week', 'date_day') }} as week_start,
+        {{ dbt.date_trunc('month', 'date_day') }} as month_start,
+        {{ dbt.date_trunc('quarter', 'date_day') }} as quarter_start,
+        extract(year from date_day) as year,
+        {{ day_of_week_number('date_day') }} as day_of_week,
+        case {{ day_of_week_number('date_day') }}
+            when 0 then 'Sunday'
+            when 1 then 'Monday'
+            when 2 then 'Tuesday'
+            when 3 then 'Wednesday'
+            when 4 then 'Thursday'
+            when 5 then 'Friday'
+            when 6 then 'Saturday'
+        end as day_name,
+        case
+            when {{ day_of_week_number('date_day') }} in (0, 6) then true
+            else false
+        end as is_weekend
+
+    from days
+
+)
+
+select * from date_spine

--- a/groups/jaffle/projects/jaffle-shop/transform/models/utils/util_fiscal_periods.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/utils/util_fiscal_periods.sql
@@ -1,0 +1,49 @@
+with
+
+date_spine as (
+
+    select * from {{ ref('util_date_spine') }}
+
+),
+
+-- Fiscal year starts February 1
+fiscal_mapping as (
+
+    select
+        date_day,
+        week_start,
+        month_start,
+        quarter_start,
+        year,
+        day_of_week,
+        day_name,
+        is_weekend,
+
+        -- Fiscal year: if month >= Feb, fiscal year = calendar year
+        -- if month = Jan, fiscal year = calendar year - 1
+        case
+            when extract(month from date_day) >= 2
+                then extract(year from date_day)
+            else extract(year from date_day) - 1
+        end as fiscal_year,
+
+        -- Fiscal month: Feb=1, Mar=2, ..., Jan=12
+        case
+            when extract(month from date_day) >= 2
+                then extract(month from date_day) - 1
+            else 12
+        end as fiscal_month,
+
+        -- Fiscal quarter: FM 1-3 = FQ1, FM 4-6 = FQ2, FM 7-9 = FQ3, FM 10-12 = FQ4
+        case
+            when extract(month from date_day) between 2 and 4 then 1
+            when extract(month from date_day) between 5 and 7 then 2
+            when extract(month from date_day) between 8 and 10 then 3
+            else 4
+        end as fiscal_quarter
+
+    from date_spine
+
+)
+
+select * from fiscal_mapping

--- a/groups/jaffle/projects/jaffle-shop/transform/models/utils/util_product_active_dates.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/utils/util_product_active_dates.sql
@@ -1,0 +1,63 @@
+with
+
+order_items as (
+
+    select * from {{ ref('stg_order_items') }}
+
+),
+
+orders as (
+
+    select * from {{ ref('stg_orders') }}
+
+),
+
+products as (
+
+    select * from {{ ref('stg_products') }}
+
+),
+
+-- Find first and last order date per product
+product_order_range as (
+
+    select
+        oi.product_id,
+        min(o.ordered_at) as first_ordered_at,
+        max(o.ordered_at) as last_ordered_at,
+        count(distinct oi.order_id) as total_orders,
+        count(oi.order_item_id) as total_units_sold
+
+    from order_items as oi
+
+    inner join orders as o
+        on oi.order_id = o.order_id
+
+    group by 1
+
+),
+
+final as (
+
+    select
+        p.product_id,
+        p.product_name,
+        p.product_type,
+        por.first_ordered_at as active_from,
+        por.last_ordered_at as last_seen_at,
+        {{ sf_datediff('day', "por.first_ordered_at", "por.last_ordered_at") }} as active_days,
+        por.total_orders,
+        por.total_units_sold,
+        case
+            when {{ sf_datediff('day', "por.last_ordered_at", "current_date") }} <= 30 then true
+            else false
+        end as is_currently_active
+
+    from products as p
+
+    left join product_order_range as por
+        on p.product_id = por.product_id
+
+)
+
+select * from final

--- a/groups/jaffle/projects/jaffle-shop/transform/models/utils/util_store_calendar.sql
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/utils/util_store_calendar.sql
@@ -1,0 +1,37 @@
+with
+
+date_spine as (
+
+    select * from {{ ref('util_date_spine') }}
+
+),
+
+locations as (
+
+    select * from {{ ref('stg_locations') }}
+
+),
+
+-- One row per store per day, starting from each store's opening date
+store_calendar as (
+
+    select
+        ds.date_day,
+        ds.day_of_week,
+        ds.day_name,
+        ds.week_start,
+        ds.month_start,
+        ds.is_weekend,
+        l.location_id,
+        l.location_name,
+        {{ sf_datediff('day', "l.opened_date", "ds.date_day") }} as days_since_opening
+
+    from date_spine as ds
+
+    cross join locations as l
+
+    where ds.date_day >= l.opened_date
+
+)
+
+select * from store_calendar


### PR DESCRIPTION
----
## Summary by Gitar

- **New Jaffle Marts core & finance project:**
    - Added complete dbt project scaffold, seeds, staging models, marts (core, finance, executive, KPIs, summaries), and snapshots for `jaffle-shop`
- **Platform onboarding and tooling:**
    - Added onboarding ladder, survey/audit/apply capabilities, and the `onboard-project` skill
    - Added `dbt-snowflake` toolkit with `sf_*` SQL portability macros and porting skill
- **Engine & platform improvements:**
    - Enhanced capabilities, ontology governance validation, proposal workflows, and gate checking in `platform/src/pf/`


<sub>This will update automatically on new commits.</sub>