### PR TITLE
Add the power-tools toolkit: commands, subagents, hooks, MCP

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,0 +1,50 @@
+# SQL formatting for dbt models. Read by the power-tools PostToolUse hook and by
+# `just fmt`; both no-op when sqlfluff is not installed.
+#
+# Why the `jinja` templater and not `dbt`: the dbt templater needs a working
+# profile and a parsed manifest, so it turns a 200 ms format into a multi-second
+# one that fails on any project whose warehouse is not up. `apply_dbt_builtins`
+# gives us stubbed `ref`, `source`, `config`, `var` and `is_incremental`, which is
+# all that is needed to *parse* a model. It cannot resolve a custom macro — those
+# files fail to template and the hook skips them silently rather than mangling
+# them.
+#
+# Dialect is duckdb because that is what every project runs locally. Models that
+# must also run on Snowflake go through the cross-database macros in
+# platform/toolkits/dbt-snowflake, so they parse under duckdb too.
+[sqlfluff]
+dialect = duckdb
+templater = jinja
+max_line_length = 120
+# Layout-only rules are what we want the hook to enforce. Rules about naming and
+# structure belong in review, where a human can disagree with them — a formatter
+# that silently renames a column is a formatter nobody trusts.
+exclude_rules = RF01, RF02, RF03, RF04, ST06, AM05, CV02
+
+[sqlfluff:indentation]
+tab_space_size = 4
+indent_unit = space
+indented_joins = False
+indented_ctes = False
+implicit_indents = allow
+
+[sqlfluff:templater:jinja]
+apply_dbt_builtins = True
+
+[sqlfluff:rules:capitalisation.keywords]
+capitalisation_policy = lower
+
+[sqlfluff:rules:capitalisation.functions]
+extended_capitalisation_policy = lower
+
+[sqlfluff:rules:capitalisation.literals]
+capitalisation_policy = lower
+
+[sqlfluff:rules:capitalisation.types]
+extended_capitalisation_policy = lower
+
+[sqlfluff:rules:aliasing.table]
+aliasing = explicit
+
+[sqlfluff:rules:aliasing.column]
+aliasing = explicit

--- a/platform/.claude-plugin/marketplace.json
+++ b/platform/.claude-plugin/marketplace.json
@@ -1,87 +1,96 @@
 {
   "name": "platform",
-  "owner": {
-    "name": "data-platform"
-  },
+  "owner": { "name": "data-platform" },
+  "description": "Shared toolkits for the agentic data platform: ingestion, modelling, semantics, orchestration, review and the power-user command layer.",
   "plugins": [
     {
       "name": "platform-init",
-      "source": "../platform/toolkits/platform-init",
+      "source": "./toolkits/platform-init",
       "description": "Workspace rules, secrets handling, routing"
     },
     {
       "name": "dlt-ingest",
-      "source": "../platform/toolkits/dlt-ingest",
+      "source": "./toolkits/dlt-ingest",
       "description": "Find sources and build dlt pipelines"
     },
     {
       "name": "dlt-quality",
-      "source": "../platform/toolkits/dlt-quality",
+      "source": "./toolkits/dlt-quality",
       "description": "Schema contracts and data quality checks"
     },
     {
       "name": "dlt-performance",
-      "source": "../platform/toolkits/dlt-performance",
+      "source": "./toolkits/dlt-performance",
       "description": "Pipeline tuning"
     },
     {
       "name": "dlt-explore",
-      "source": "../platform/toolkits/dlt-explore",
+      "source": "./toolkits/dlt-explore",
       "description": "Explore loaded data, build marimo dashboards"
     },
     {
       "name": "dbt-modeling",
-      "source": "../platform/toolkits/dbt-modeling",
+      "source": "./toolkits/dbt-modeling",
       "description": "Build and debug dbt models"
     },
     {
       "name": "dbt-semantic",
-      "source": "../platform/toolkits/dbt-semantic",
+      "source": "./toolkits/dbt-semantic",
       "description": "MetricFlow semantic models and metrics"
     },
     {
       "name": "dbt-testing",
-      "source": "../platform/toolkits/dbt-testing",
+      "source": "./toolkits/dbt-testing",
       "description": "Data tests and unit tests"
     },
     {
       "name": "dbt-govern",
-      "source": "../platform/toolkits/dbt-govern",
+      "source": "./toolkits/dbt-govern",
       "description": "Contracts, access, versions, run troubleshooting"
     },
     {
       "name": "dbt-migrate",
-      "source": "../platform/toolkits/dbt-migrate",
+      "source": "./toolkits/dbt-migrate",
       "description": "Version and platform migrations"
     },
     {
+      "name": "dbt-snowflake",
+      "source": "./toolkits/dbt-snowflake",
+      "description": "Cross-database macros so one model runs on DuckDB and Snowflake"
+    },
+    {
       "name": "duckdb-ops",
-      "source": "../platform/toolkits/duckdb-ops",
+      "source": "./toolkits/duckdb-ops",
       "description": "Attach, query, read files, docs, memories, extensions"
     },
     {
       "name": "dagster-orchestrate",
-      "source": "../platform/toolkits/dagster-orchestrate",
+      "source": "./toolkits/dagster-orchestrate",
       "description": "Assets, schedules, sensors, partitions (factory-constrained)"
     },
     {
-      "name": "python-standards",
-      "source": "../platform/toolkits/python-standards",
-      "description": "Production Python conventions"
+      "name": "recce-review",
+      "source": "./toolkits/recce-review",
+      "description": "Review what a dbt change did to the data, using Recce"
     },
     {
       "name": "evidence-bi",
-      "source": "../platform/toolkits/evidence-bi",
+      "source": "./toolkits/evidence-bi",
       "description": "Evidence BI reporting layer, metric-first"
     },
     {
-      "name": "dbt-snowflake",
-      "source": "../platform/toolkits/dbt-snowflake",
-      "description": "Cross-database macros so one model runs on DuckDB and Snowflake"
+      "name": "forge-ui",
+      "source": "./toolkits/forge-ui",
+      "description": "Control-plane React UI under platform/src/pf/ui/web"
+    },
+    {
+      "name": "python-standards",
+      "source": "./toolkits/python-standards",
+      "description": "Production Python conventions"
     },
     {
       "name": "project-onboarding",
-      "source": "../platform/toolkits/project-onboarding",
+      "source": "./toolkits/project-onboarding",
       "description": "Adopt a repository and align it with the platform, stage by stage"
     }
   ]

--- a/platform/.claude-plugin/marketplace.json
+++ b/platform/.claude-plugin/marketplace.json
@@ -9,6 +9,11 @@
       "description": "Workspace rules, secrets handling, routing"
     },
     {
+      "name": "power-tools",
+      "source": "./toolkits/power-tools",
+      "description": "Audit and shipping commands, verification subagents, format/notify hooks, and the pf MCP server"
+    },
+    {
       "name": "dlt-ingest",
       "source": "./toolkits/dlt-ingest",
       "description": "Find sources and build dlt pipelines"

--- a/platform/pyproject.toml
+++ b/platform/pyproject.toml
@@ -20,6 +20,11 @@ dependencies = [
 data = ["dlt[duckdb]>=1.4", "dbt-core>=1.9", "dbt-duckdb>=1.9"]
 orchestration = ["dagster>=1.9", "dagster-webserver>=1.9", "dagster-dbt>=0.25"]
 agents = ["anthropic>=0.40"]
+# `pf mcp` imports FastMCP lazily inside main(), so the package still installs
+# and every other command still works without it. Without the extra, `pf mcp`
+# fails at startup with a plain ImportError rather than the server silently
+# serving nothing.
+mcp = ["mcp>=1.2"]
 
 [project.scripts]
 pf = "pf.cli:app"

--- a/platform/toolkits/power-tools/.claude-plugin/plugin.json
+++ b/platform/toolkits/power-tools/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "power-tools",
+  "displayName": "Platform power tools",
+  "version": "0.1.0",
+  "description": "Audit and shipping commands, verification subagents, format/notify hooks, and the pf MCP server",
+  "author": { "name": "data-platform" },
+  "keywords": ["audit", "review", "impact", "mcp", "hooks"]
+}

--- a/platform/toolkits/power-tools/.mcp.json
+++ b/platform/toolkits/power-tools/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "pf": {
+      "command": "uv",
+      "args": ["run", "pf", "mcp"],
+      "env": {
+        "PF_PROJECT_DIR": "${CLAUDE_PROJECT_DIR}"
+      }
+    }
+  }
+}

--- a/platform/toolkits/power-tools/RULES.md
+++ b/platform/toolkits/power-tools/RULES.md
@@ -1,0 +1,37 @@
+# power-tools
+
+The session layer: what a Claude Code session in this repo is *given* (tools,
+context, formatting, notifications) as opposed to what it knows how to do. Every
+other toolkit teaches a craft; this one wires the workbench.
+
+## What it ships
+
+| Component | Effect |
+|---|---|
+| `.mcp.json` | Starts `pf mcp` as the `pf` stdio server. This is what makes `kg_search`, `kg_neighbors`, `kg_path` and `impact_analysis` exist — the tools every project `CLAUDE.md` already tells the agent to call. |
+| `commands/` | User-invoked audits (`/security-audit`, `/performance-audit`, `/architecture-review`, `/tech-debt`), shipping (`/ship`, `/blast-radius`), context control (`/context-budget`), and the two external-tool protocols (`/gemini-analyze`, `/ast-grep`). |
+| `agents/` | Four verification subagents. They read and report; none of them may write. |
+| `hooks/hooks.json` | Formats what the agent edits, injects session context at start, notifies on stop and on permission prompts. |
+
+## Rules
+
+**The MCP server is scoped to one project.** `pf mcp` resolves group/project from
+`PF_PROJECT_DIR`, falling back to cwd. In a root session there is no active
+project, so warehouse and graph tools return "not inside a project" — that is the
+isolation working, not a fault. Use `pf work <group> <project>` to get a session
+where they answer.
+
+**Ask the graph before reading files.** `kg_search` costs a few hundred tokens;
+reading four models to find the same edge costs thousands and is likelier to be
+wrong. `impact_analysis` before changing any column, model or metric.
+
+**The subagents in `agents/` are read-only by construction.** A verifier that can
+edit stops being a second opinion and becomes a second author. If one of them
+finds a fault, it reports; the main session fixes.
+
+**Formatting is not review.** The PostToolUse hook normalises whitespace and
+import order. It does not vouch for the SQL. `/blast-radius` and `pf check` do.
+
+**These commands never cross an entity boundary.** An audit runs against the
+active project. If you need the same audit for a sister, open a session there —
+carrying a finding across is the bug the gate exists to stop.

--- a/platform/toolkits/power-tools/agents/impact-verifier.md
+++ b/platform/toolkits/power-tools/agents/impact-verifier.md
@@ -1,0 +1,53 @@
+---
+name: impact-verifier
+description: Independently verifies that a proposed or completed change to a model, column or metric is safe — checks the blast radius against the actual downstream SQL rather than trusting the dependency list. Use before merging any change the graph reaches.
+disallowedTools: Write, Edit, MultiEdit, NotebookEdit
+effort: high
+maxTurns: 25
+---
+
+You verify blast radius claims. You do not make changes, and you do not agree
+out of politeness — your value is entirely in catching what the author missed.
+
+## Method
+
+1. Get the mechanical reach first: `impact_analysis("<node>")`, or
+   `uv run pf impact <group> <project> <node>`. This is the *candidate* set, not
+   the answer.
+2. For each downstream node, read the SQL that actually consumes the changed
+   thing. A dependency edge means "recompiles". You are deciding "breaks", which
+   is a different question and needs the code.
+3. Classify each consumer:
+   - **breaks** — references a removed or renamed column, relies on a type that
+     changed, or joins on a key whose grain moved.
+   - **silently wrong** — still compiles, different value. Column redefinitions,
+     filter changes, grain changes. This is the class you exist to find.
+   - **unaffected** — recompiles, same result. Say so explicitly; a verifier that
+     only reports problems cannot be trusted about their absence.
+4. Check the classes the dependency list under-reports:
+   - **metrics** — a metric over a changed column changes value with no error.
+     `list_metrics`, `get_dimensions`, and `query_metrics` before/after where you
+     can run it.
+   - **published contracts** — `mdl/mdl.json`, `catalog/openmetadata.json`. If
+     the change reaches these, an external consumer is affected.
+   - **Evidence pages** under `reporting/pages/` — a redefined column renders a
+     wrong number rather than failing.
+   - **tests and contracts** — does an existing test still assert the right thing
+     after the change, or does it now pass vacuously?
+
+## When the graph is empty or stale
+
+Say so, loudly, and stop treating the result as evidence. An empty blast radius
+from a project with no `kg/graph.duckdb` means *nothing was checked*, not that
+nothing is affected. Compare the graph's mtime against the newest file under
+`transform/models/`; if the graph is older, the report is stale and you should
+say the verification could not be completed until `pf kg build` runs.
+
+## Output
+
+- **Verdict**: safe / safe-with-conditions / unsafe.
+- **Breaks**: node, the line that breaks, why.
+- **Silently wrong**: node, what the number becomes, how to confirm.
+- **Unverified**: anything you could not check, and what would be needed.
+
+Never say "no impact" when what you mean is "I found none". State which one it is.

--- a/platform/toolkits/power-tools/agents/secrets-auditor.md
+++ b/platform/toolkits/power-tools/agents/secrets-auditor.md
@@ -1,0 +1,59 @@
+---
+name: secrets-auditor
+description: Hunts for credentials, tokens and PII that have leaked into tracked files, committed review artefacts or logs. Use before a first push, before making a repo visible, and after adding any capability that writes an artefact.
+disallowedTools: Write, Edit, MultiEdit, NotebookEdit
+effort: high
+maxTurns: 20
+---
+
+You look for secrets and personal data that have escaped into places they are
+read from. You never print a secret you find — report its location and shape, so
+the report itself is safe to paste into a ticket.
+
+## Where to look, in order of likelihood
+
+1. **Tracked files that the gate denies.** `uv run pf check` reports every denied
+   path git is tracking. Each is either a mistake or a documented exception in
+   `denylist_except`. Anything not in that list is a finding.
+2. **Committed review artefacts.** This repo deliberately tracks
+   `transform/recce_state.json`, and recce `value_diff` checks write **compared
+   row values** into it. That is only safe while PII columns are excluded from
+   those checks. Open the file, list the columns each `value_diff` compares, and
+   flag any matching email / phone / name / address / dob / ssn / iban / card /
+   passport. A hit here is critical: the values are already in git history.
+3. **Published contracts.** `mdl/mdl.json`, `catalog/openmetadata.json`,
+   `catalog/ingestion.yaml`. These should carry names and types only. The
+   ingestion workflow should reference a credential by environment variable and
+   never contain the token itself.
+4. **Config that shipped.** `.dlt/secrets.toml` — inspect via
+   `secrets_view_redacted`, never by reading the file. `.env` and `.env.*` should
+   be untracked; `.env.example` is the tracked template and must contain
+   placeholders only.
+5. **History, not just the working tree.** A rotated key still in history is
+   still exposed:
+   `git log --oneline -S 'BEGIN PRIVATE KEY' -- . | head`
+   and the same for any token prefix the project uses.
+6. **Logs and observability.** `pf.obs` should record counts and verdicts.
+   Anything that writes a row value into a log or a ledger entry is a leak into a
+   place people paste freely.
+7. **Fixtures and seeds.** Test data copied from production is the quiet one.
+   Check `seeds/` and `evals/cases/` for real-looking personal data.
+
+## Judgement
+
+Distinguish clearly, because the remediation differs:
+
+- **Exposed** — a live credential or real personal data is readable now. Critical.
+  The fix is **rotate**, then remove; deleting the file does not un-expose it.
+- **Exposable** — a path that will collect secrets on the next run but has none
+  yet, e.g. a generated artefact missing from the denylist. High. Fix the rule.
+- **Placeholder** — looks like a secret, is not. Say so, so nobody re-audits it.
+
+## Output
+
+Per finding: severity, file and line, **what kind** of secret (never the value),
+whether it is in history, blast radius (who can already read it), and the fix in
+the right order — rotate, then remove, then close the gate hole that let it in.
+
+End with what you checked and found clean. An audit without stated coverage
+cannot be relied on the second time.

--- a/platform/toolkits/power-tools/agents/semantic-conformance.md
+++ b/platform/toolkits/power-tools/agents/semantic-conformance.md
@@ -1,0 +1,60 @@
+---
+name: semantic-conformance
+description: Checks that the project's models, annotations and metrics still agree with the platform ontology — declared joins, concept coverage, grain, and metric definitions. Use before approving an ontology proposal or shipping a semantic-layer change.
+disallowedTools: Write, Edit, MultiEdit, NotebookEdit
+effort: high
+maxTurns: 25
+---
+
+You check one thing: that the semantic claims this project makes are still true.
+Not whether the SQL runs — whether what it *says it means* holds.
+
+## The chain, checked link by link
+
+The platform's claim is that meaning flows: ontology class → annotated source →
+model → metric → published contract. Break any link and everything downstream is
+decoration. Check each:
+
+1. **Ontology.** `ontology_classes` — what concepts exist, and does the project's
+   domain actually map onto them? A concept that had to be stretched to fit is a
+   finding, and usually the trigger for an ontology proposal
+   (`pf semantic scan`, `pf semantic proposals`).
+2. **Annotation.** `validate_annotations`. Every dlt resource annotated *before*
+   any model was written on it. A resource annotated afterwards, retrofitted to
+   match models that already exist, has the causality backwards — the models were
+   not derived from meaning, the meaning was reverse-engineered from the models.
+3. **Links and topology.** Every `links={"col": "SomeClass"}` must name a class
+   the topology already relates (`pf semantic topology`). Annotation without
+   relation is the common half-failure: the binding exists, the join condition
+   is still guessable rather than derivable. `pf check` fails on undeclared joins
+   — confirm it was actually run, not just present.
+4. **Grain.** Every mart declares `meta.grain` and is unique at it. Test it:
+   `select <grain>, count(*) from <mart> group by all having count(*) > 1 limit 5`
+5. **Metrics.** `list_metrics` and `get_dimensions`. Does each metric's definition
+   still match what the mart contains? Two metrics that answer the same question
+   differently is a finding; so is a mart that pre-aggregates what a metric also
+   aggregates, because the two will disagree.
+6. **Policy.** `pf semantic policy` — intent → constraint → artifact → evidence.
+   Any constraint with no artifact enforcing it is a stated rule that nothing
+   checks, which is worse than an unstated one because people rely on it.
+7. **Projection.** `mdl/mdl.json` regenerated from the current graph, not stale.
+   It is the contract an external consumer reads; if it disagrees with the models
+   the consumers are wrong and do not know it.
+
+## Group boundaries
+
+Conformed dimensions belong to the group. If this project re-implements one
+locally, that is a finding — two sisters with private definitions of the same
+dimension will eventually disagree about a customer, and neither will be
+obviously wrong. Check the group's shared ontology instance, not a sister project.
+
+Never read a sister project's models to compare. Compare against the group.
+
+## Output
+
+Per link in the chain: holds / broken / unverifiable, with evidence. For each
+break: what becomes underivable because of it, and the specific repair
+(`pf kg build`, `pf semantic annotate`, a topology relation, a regenerated MDL).
+
+Say explicitly which links you could not check and why. "Unverifiable" is a
+legitimate result; silence about it is not.

--- a/platform/toolkits/power-tools/agents/sql-reviewer.md
+++ b/platform/toolkits/power-tools/agents/sql-reviewer.md
@@ -1,0 +1,56 @@
+---
+name: sql-reviewer
+description: Reviews dbt model SQL for correctness faults — fanout, grain violations, null-swallowing joins, broken incremental predicates, timezone and type traps. Use after writing or changing a model, before it is built into a mart.
+disallowedTools: Write, Edit, MultiEdit, NotebookEdit
+effort: high
+maxTurns: 25
+---
+
+You review dbt SQL for faults that produce **wrong numbers without erroring**.
+Style is not your concern; a formatter already handles it. You report, you do not
+edit.
+
+## What to check, in order of how often it is actually wrong
+
+1. **Grain.** What is one row of this model? Does it match `meta.grain`? Verify
+   rather than assume:
+   `select <grain>, count(*) c from <model> group by all having count(*) > 1 limit 5`
+   A mart whose declared grain is not unique is the single most common cause of
+   double-counted metrics downstream.
+2. **Fanout.** Every join: can the right side produce more than one match? If so
+   the row count multiplies before any aggregate, and every additive measure is
+   now wrong. Check the join key's uniqueness on both sides, not just intent.
+3. **Join type and nulls.** An `inner join` that should be `left` silently drops
+   rows — the count looks plausible, so nobody notices. A `left join` followed by
+   a `where` on the right table's column is an inner join wearing a costume.
+4. **Incremental logic.** Is the `is_incremental()` predicate actually selective?
+   Does it handle late-arriving rows and updates, or only appends? Does the
+   `unique_key` match the model's real grain? A wrong `unique_key` corrupts data
+   over time rather than failing once.
+5. **Types and casts.** Joins across mismatched types, implicit casts, decimal
+   precision lost in an aggregate, integer division.
+6. **Time.** Timezone handling, date truncation boundaries, and any comparison
+   between a timestamp and a date. Ask which timezone the source is in, and
+   whether the model assumes the same one.
+7. **Null semantics.** `not in` with a nullable subquery returns no rows —
+   quietly. Aggregates skip nulls; `count(*)` and `count(col)` differ.
+8. **Declared joins.** Every foreign key used in a join should be declared via
+   `links={"col": "SomeClass"}` with the topology relating the two classes. An
+   undeclared join is a guessed join condition; `pf check` fails on it.
+
+## Reading the model
+
+`get_model_details("<model>")` for the compiled SQL — review what actually runs,
+not the Jinja. Where a claim is testable, test it with `execute_sql_query` rather
+than reasoning about it.
+
+## Output
+
+Findings ranked by consequence, each with:
+- the fault, and the specific line,
+- **the wrong answer it produces** — a concrete scenario, not "may cause issues",
+- the fix,
+- a query that demonstrates the fault now and passes after the fix.
+
+If the SQL is correct, say so plainly and name what you checked. An empty review
+that lists its coverage is useful; one that just says "looks good" is not.

--- a/platform/toolkits/power-tools/commands/architecture-review.md
+++ b/platform/toolkits/power-tools/commands/architecture-review.md
@@ -1,0 +1,88 @@
+---
+name: architecture-review
+description: Check the active project against the platform's architecture — ontology conformance, declared joins, grain, layering and the semantic contract.
+disable-model-invocation: "yes"
+---
+
+# Architecture review
+
+In this platform "architecture" is not a diagram, it is a set of claims the graph
+can check. Review = find the claims that are no longer true.
+
+Scope: `$ARGUMENTS` (a subtree, a layer, a concept), else the whole project.
+
+## 1. Conformance, mechanically
+
+```bash
+uv run pf check                     # ontology conformance + blast radius of your changes
+uv run pf semantic topology         # the named relations between classes
+uv run pf semantic policy           # intent → constraint → artifact → evidence
+```
+
+`validate_annotations` (MCP) for the source layer. `pf check` fails on an
+undeclared join — that failure is the single highest-value signal here, because a
+join that is not declared is a join whose condition was *guessed*.
+
+## 2. The four claims worth checking by hand
+
+1. **Every dlt resource is annotated before any model exists.** A model built on
+   an unannotated resource has no concept behind its columns; the semantic layer
+   downstream is then decoration. `ontology_classes` + `validate_annotations`.
+2. **Every foreign key is declared** as `links={"col": "SomeClass"}` *and* the
+   topology already relates the two classes. One without the other is the common
+   failure: the annotation exists, the relation does not, so nothing is derivable.
+3. **Every mart declares `meta.grain`,** and is actually unique at it. Test the
+   claim rather than trusting it:
+   ```sql
+   select <grain cols>, count(*) c from <mart> group by all having count(*) > 1 limit 5
+   ```
+4. **Aggregation lives in the semantic layer, not in marts.** A mart that
+   pre-aggregates what a metric also aggregates gives two answers to one question.
+   `list_metrics` / `get_dimensions` to see what the semantic layer already owns.
+
+## 3. Layering
+
+staging → intermediate → marts, and sources only entering at staging. Ask the
+graph rather than reading files:
+
+```
+kg_search "<concept>"          # what exists
+kg_neighbors "<node>" depth=2  # what it touches
+kg_path "<src>" "<dst>"        # how two things are actually connected
+```
+
+Findings: a mart selecting straight from a source, a staging model with business
+logic in it, a cycle, or an orphan (a model nothing consumes — dead weight that
+still costs build time).
+
+## 4. Boundaries
+
+- Nothing in the project reads `platform/` internals; shared infra is used
+  through `pf`, not imported around.
+- Nothing references a sister project. Ever.
+- Group-level conformed dimensions are used, not re-implemented per sister —
+  a re-implementation is how two sisters start disagreeing about a customer.
+
+## 5. Report
+
+For each finding: the claim that is false, the evidence, what breaks because of
+it, and the fix. Separate **structural** faults (wrong layering, undeclared join
+— fix now) from **drift** (stale annotation, missing grain — schedule). Where a
+fix changes a model, give its blast radius from `impact_analysis`.
+
+If a decision is worth keeping, write it to `decisions/ADR-NNNN-*.md` rather than
+leaving it in the transcript.
+
+---
+
+## Generic checklist (retained from the source guide)
+
+**Structure** — separation of concerns, circular dependencies, violations of
+clean-architecture boundaries, feature-based vs type-based organisation.
+**Patterns** — consistency of the patterns in use, composition over inheritance,
+error handling at boundaries, state management.
+**Evolution** — what will be expensive to change later, what is over-abstracted
+now, which decisions deserve an ADR.
+
+**Output format** — analysis, prioritised recommendations, and the trade-offs of
+each; note explicitly where the current design is fine and should be left alone.

--- a/platform/toolkits/power-tools/commands/ast-grep.md
+++ b/platform/toolkits/power-tools/commands/ast-grep.md
@@ -1,0 +1,94 @@
+---
+name: ast-grep
+description: Structural, syntax-aware code search and rewriting with ast-grep, for when regex would match the wrong thing.
+---
+
+# Structural search with ast-grep
+
+Ported from the source guide. Use instead of plain text search when the pattern
+is **structural** rather than textual.
+
+Pattern / task: `$ARGUMENTS`.
+
+## Availability — check before promising results
+
+`ast-grep` is **not installed** in this environment as of writing:
+
+```bash
+command -v ast-grep >/dev/null 2>&1 || echo "ast-grep not installed"
+# install: brew install ast-grep   (or: cargo install ast-grep --locked)
+```
+
+If it is absent, say so once and fall back to Grep with a pattern narrowed by
+path and file type. Do not silently degrade — a structural question answered
+textually gives a different, usually longer, answer.
+
+## When it is the right tool
+
+- structural patterns: every call site of a function, every class definition,
+  every decorator usage,
+- language-aware refactors: renaming a symbol, changing a signature, rewriting
+  imports — where regex would also hit strings, comments and unrelated names,
+- finding a pattern across several syntactic contexts at once,
+- cross-language sweeps in this monorepo (Python pipelines, TypeScript in
+  `platform/src/pf/ui/web`, YAML config).
+
+## Syntax
+
+```sh
+ast-grep --pattern '$PATTERN' --lang $LANGUAGE $PATH
+```
+
+| Token | Meaning |
+|---|---|
+| `$VAR` | matches one node, captures it |
+| `$$$` | matches zero or more nodes |
+| `$$` | matches one or more nodes |
+| literal code | matches exactly |
+
+Languages: python, typescript, javascript, go, rust, java, c, cpp, html, css,
+yaml, json, and more.
+
+## Patterns that pay off in this repo
+
+```sh
+# every annotated dlt resource
+ast-grep --pattern '@annotate($$$)' --lang python groups/<g>/projects/<p>/src/
+
+# every dlt resource declaration, annotated or not — the diff is the debt
+ast-grep --pattern '@dlt.resource($$$)' --lang python groups/<g>/projects/<p>/src/
+
+# direct warehouse construction outside the runtime factory
+ast-grep --pattern 'Warehouse($$$)' --lang python .
+
+# React hooks in the control-plane UI
+ast-grep --pattern 'const [$S, $SET] = useState($$$)' --lang typescript platform/src/pf/ui/web/
+```
+
+Scope every invocation to one project or to `platform/`. A bare `.` from the repo
+root walks `vendor/` (fourteen submodules) and `.venv`, and crosses entity
+boundaries.
+
+## Advanced
+
+```sh
+ast-grep --pattern '$P' --lang $LANG $PATH --json        # machine-readable
+ast-grep --pattern '$OLD' --rewrite '$NEW' --lang $LANG $PATH
+```
+
+Rewrites go through the same gate as any other edit — check `/blast-radius`
+before rewriting anything the graph knows about, and never rewrite under
+`vendor/`, which is read-only always.
+
+## Tool choice
+
+| Task | Tool |
+|---|---|
+| find a literal string | Grep |
+| find a code structure | ast-grep |
+| find what depends on what | `kg_neighbors` / `impact_analysis` |
+| understand a concept's meaning | `kg_search`, the ontology |
+| precise edits | Edit, after the search |
+
+The graph outranks both search tools for dependency questions: it knows edges
+that no amount of syntax matching will recover.

--- a/platform/toolkits/power-tools/commands/blast-radius.md
+++ b/platform/toolkits/power-tools/commands/blast-radius.md
@@ -1,0 +1,58 @@
+---
+name: blast-radius
+description: Report what breaks if a model, column or metric changes. Run this before editing anything in the graph, not after.
+---
+
+# Blast radius
+
+Target: `$ARGUMENTS` — a node (`model:stg_orders`, `column:orders.status`,
+`metric:revenue`), or nothing, in which case use what you have already changed.
+
+## Fastest path
+
+```bash
+uv run pf impact <group> <project> <node>
+```
+
+or, in a session where the `pf` MCP server is up, `impact_analysis("<node>")` —
+same answer, no shell round-trip.
+
+For everything currently modified, without naming nodes:
+
+```bash
+uv run pf check          # ontology conformance + blast radius of your changes
+```
+
+## Reading the result
+
+The report is downstream reach, not a verdict. Judge it:
+
+- **models** — each one recompiles; any whose SQL depends on the *shape* you are
+  changing (a renamed or retyped column, a changed grain) breaks rather than
+  merely rebuilds.
+- **metrics** — a metric depending on a changed column changes value silently.
+  This is the dangerous class: nothing errors, the number is just different.
+  `query_metrics` before and after and compare.
+- **Evidence pages** — a page referencing a removed column fails at build, which
+  is CI's problem; a page referencing a *redefined* one renders a wrong number,
+  which is nobody's problem until someone acts on it.
+- **contracts** — `mdl/mdl.json` and `catalog/openmetadata.json` are published
+  contracts. If the change reaches them, an external consumer is affected and the
+  change needs to be announced, not just merged.
+
+## When the answer is empty
+
+An empty blast radius means one of three things, and they are not equivalent:
+
+1. Nothing depends on it. Fine — proceed.
+2. The graph does not have this node. Usually a brand-new model:
+   `pf kg build <group> <project>`, then ask again.
+3. **There is no graph.** Then the gate is inert and every edit in this project
+   is unverified. The PreToolUse hook says so explicitly when this happens. Build
+   the graph before continuing; do not treat silence as safety.
+
+## After a change with real reach
+
+Run the data-level diff, not just the dependency list — `pf tool recce run
+<group> <project>` shows whether the numbers actually moved. Dependencies tell
+you what recompiles; recce tells you what changed.

--- a/platform/toolkits/power-tools/commands/context-budget.md
+++ b/platform/toolkits/power-tools/commands/context-budget.md
@@ -1,0 +1,72 @@
+---
+name: context-budget
+description: Report and repair what this project spends on always-on context — cards, CLAUDE.md, routing, plugins, MCP tools.
+disable-model-invocation: "yes"
+---
+
+# Context budget
+
+The guide's advice for large codebases is "limit scope". This platform does it
+structurally instead: a fixed always-on preamble, budgeted and enforced, plus
+graph queries in place of file reads. This command audits that machinery.
+
+## 1. The enforced budget
+
+```bash
+uv run pf tokens          # exits non-zero if any card is over
+```
+
+Reports every project's `kg/context_card.md` and `CLAUDE.md`, each group card,
+`ROUTING.md` and `VENDOR-CARD.md` against its budget, and the worst-case session
+preamble total. **Over budget is a build failure, not a warning** — every session
+pays it for the whole life of the project.
+
+To repair an over-budget card, regenerate rather than trim by hand:
+
+```bash
+uv run pf kg build <group> <project>
+uv run pf kg card  <group> <project>
+```
+
+If it is still over after regeneration, the project has genuinely outgrown the
+card and the fix is fewer, better entries — not a bigger budget.
+
+## 2. What the session loads beyond the cards
+
+```bash
+claude plugin list
+claude plugin details <plugin>     # component inventory + projected token cost
+```
+
+Every enabled plugin contributes skill descriptions to every request. A toolkit
+that this project will never use (Snowflake macros in a DuckDB-only project) is
+pure overhead — disable it in `.claude/settings.json` rather than tolerating it.
+
+Same question for MCP: the `pf` server registers 23 tools. Their schemas ride in
+context unless the client defers them.
+
+## 3. Spend it on the graph, not on files
+
+The cheapest large-context strategy here is not to load the context:
+
+| Instead of | Do |
+|---|---|
+| reading four models to find a dependency | `kg_neighbors` |
+| grepping for where a concept is used | `kg_search` |
+| reading downstream models to judge a change | `impact_analysis` |
+| reading a whole sister project | never — it is a gate violation |
+
+## 4. When a session is already too full
+
+- `/clear` between unrelated tasks. Context carried across two tasks makes the
+  second one worse, not better.
+- Prefer one project per session: `pf work <group> <project>` sets cwd so the
+  gate, the MCP server and the card all resolve to the same entity.
+- For a genuinely repo-sized question, hand it to a bigger window rather than
+  compacting this one: `/gemini-analyze`.
+
+## 5. Report
+
+Current preamble total, each artefact against its budget, plugins enabled versus
+plugins used, and one recommendation per overspend. Say what to remove; do not
+remove it as part of this command.

--- a/platform/toolkits/power-tools/commands/gemini-analyze.md
+++ b/platform/toolkits/power-tools/commands/gemini-analyze.md
@@ -1,0 +1,70 @@
+---
+name: gemini-analyze
+description: Hand a repo-sized question to Gemini's large context window instead of compacting this session. Read-only analysis.
+disable-model-invocation: "yes"
+---
+
+# Large-context analysis with the Gemini CLI
+
+When a question needs more files than this session should hold, shell out to
+`gemini -p` rather than reading everything in. Ported from the source guide;
+`gemini` is installed on this machine, so it works as written.
+
+Question: `$ARGUMENTS`.
+
+## Scope rule for this repo — read first
+
+Run `gemini` **from the active project directory**, and never pass `@` paths that
+reach into another group or sister project. `--all_files` from the repo root
+would sweep every entity in the monorepo, which is exactly the cross-entity read
+the gate exists to prevent. It also drags `vendor/` (fourteen upstreams) and
+`.venv` into the prompt.
+
+Safe:
+
+```bash
+cd groups/<group>/projects/<project>
+gemini -p "@transform/models/ @src/ Where does customer status get derived, and by which model?"
+```
+
+Not safe: `gemini --all_files -p …` from the repo root.
+
+For a platform-wide question, scope it to shared infra only:
+
+```bash
+gemini -p "@platform/src/pf/ Summarise how the gate, the graph and the MCP server relate"
+```
+
+## Syntax
+
+`@` includes files and directories, resolved relative to the directory you run
+`gemini` in.
+
+```bash
+gemini -p "@transform/models/marts/ Summarise the grain of each mart"
+gemini -p "@src/ @transform/ Which sources feed which marts?"
+gemini -p "@transform/models/ Is there any model that selects straight from a source?"
+```
+
+## When to reach for it
+
+- the file set exceeds what this session should carry (roughly >100 KB),
+- a whole-project sweep: "is X implemented anywhere", "list every place Y appears",
+- comparing many large files at once,
+- verifying a *negative* — "nothing in this project references a sister" — where
+  missing one file makes the answer wrong.
+
+## When not to
+
+- **Anything the knowledge graph already answers.** `kg_search`, `kg_neighbors`,
+  `kg_path` and `impact_analysis` are cheaper, faster and structurally correct.
+  Gemini reads text; the graph knows the edges. Use the graph first, and reach
+  for Gemini only when the question is not a graph question.
+- Anything that needs to write. This is read-only analysis; no `--yolo`.
+- Anything touching secrets — `@` inlines file contents into a third-party
+  request. Never include `.env`, `.dlt/secrets.toml`, or `credentials/`.
+
+## After
+
+Treat the output as a lead, not a finding. Verify each claim against the file it
+names before acting on it, and cite `path:line` in your own report.

--- a/platform/toolkits/power-tools/commands/performance-audit.md
+++ b/platform/toolkits/power-tools/commands/performance-audit.md
@@ -1,0 +1,89 @@
+---
+name: performance-audit
+description: Find the slow parts of the active project — dbt model timing, DuckDB plans, dlt pipeline throughput — and rank fixes by payoff.
+disable-model-invocation: "yes"
+---
+
+# Performance audit
+
+Scope: `$ARGUMENTS` (a model, a pipeline, `dbt` / `dlt` / `bi`), else the whole
+active project. Measure before recommending; a plausible optimisation that
+targets the wrong stage is worse than none.
+
+## 1. Where the time actually goes
+
+dbt already recorded it. Read, don't re-run:
+
+```bash
+uv run python - <<'PY'
+import json, pathlib
+rr = pathlib.Path('transform/target/run_results.json')
+if not rr.exists():
+    print('no run_results.json — run `dbt build` first'); raise SystemExit
+res = json.loads(rr.read_text())['results']
+for r in sorted(res, key=lambda r: -r['execution_time'])[:15]:
+    print(f"{r['execution_time']:8.2f}s  {r['status']:8}  {r['unique_id']}")
+PY
+```
+
+The top three rows are the audit. Everything below them is noise until those are
+addressed.
+
+## 2. Why the slow ones are slow
+
+For each, `get_model_details` (MCP) for the compiled SQL and materialisation,
+then get the plan from DuckDB:
+
+```sql
+EXPLAIN ANALYZE <the compiled query>
+```
+
+via `execute_sql_query`. Look for, in payoff order:
+- a **full scan** feeding a join that could have been filtered first,
+- a `view` materialisation that is recomputed by several downstream models —
+  each consumer pays the whole cost again,
+- an **incremental** model with no usable predicate, so every run is a full
+  refresh wearing an incremental's name,
+- a join whose keys differ in type (silent cast, no index use),
+- fanout: a join that multiplies rows before an aggregate that removes them.
+
+Check the grain claim too — `meta.grain` on a mart that is not actually unique at
+that grain both misleads readers and hides a duplicate-row cost.
+
+## 3. Ingestion
+
+```bash
+uv run python -c "import json,pathlib;print(pathlib.Path('.dlt').exists())"
+```
+
+Then `get_local_pipeline_state` (MCP). Look for: full loads where the source
+supports incremental, a write disposition of `replace` on a large resource,
+per-row normalisation that could be batched, and resources with no primary key
+(which forces the loader into the slow path).
+
+## 4. Reporting layer
+
+Evidence queries run at build. A page that issues a broad scan against a mart is
+paying dbt's cost again at render time. Prefer a mart that already aggregates.
+
+## 5. Report
+
+For each finding: measured cost now, the change, the expected cost after, and
+how to verify. Rank by **seconds saved per unit of risk**, and say plainly when
+a fix is not worth making. If a change touches a model, run `/blast-radius` on it
+before recommending it — a faster model that breaks four downstream ones is not
+an optimisation.
+
+---
+
+## Generic checklist (retained from the source guide)
+
+**Frontend** — lazy load route components, memoise expensive components, debounce
+search inputs and API calls, analyse bundle size, CDN for static assets.
+**Backend** — database query optimisation, API response times, caching strategy,
+memory leaks.
+**Process** — set performance budgets, track Core Web Vitals, add alerts for
+regressions, monitor query performance continuously.
+
+**Output format** — analysis, implementation plan, and success metrics: how the
+improvement will be measured, and how to roll back if it regresses.

--- a/platform/toolkits/power-tools/commands/security-audit.md
+++ b/platform/toolkits/power-tools/commands/security-audit.md
@@ -1,0 +1,96 @@
+---
+name: security-audit
+description: Audit the active project for exposed secrets, gate holes and PII leaking into committed review artefacts.
+disable-model-invocation: "yes"
+---
+
+# Security audit
+
+Scope: `$ARGUMENTS` if given (e.g. `secrets`, `gate`, `pii`, a path), otherwise
+the whole active project. Never leave the active project — a sister's exposure
+is a finding for a session opened there.
+
+## 1. Secrets at rest
+
+```bash
+uv run pf check                     # flags any denied path git is tracking
+git ls-files | grep -E '\.env|secrets\.toml|credentials|_key|_secret' || echo "clean"
+```
+
+Then call `secrets_view_redacted` (MCP) rather than reading `.dlt/secrets.toml`
+yourself — it returns the shape without the values, which is all an audit needs.
+
+A finding here is: a value committed, **or** a key present in `.dlt/secrets.toml`
+that has no counterpart in `.env.example`, which means a fresh clone silently
+runs without it.
+
+## 2. Gate coverage — the holes, not the rules
+
+`gate.yaml` plus the generated `gate.capabilities.yaml` are the policy. The
+question is not "what does it deny" but "what does it fail to deny".
+
+```bash
+uv run pf gate --paths "$(git diff --cached --name-only | tr '\n' ',')"
+```
+
+Check each in turn, and report the ones that fail:
+- every artefact a generator writes is on the `denylist` (drift otherwise
+  re-appears as a hand edit that the next regeneration discards silently),
+- every entry in `denylist_except` is a deliberate, still-true exception,
+- `platform_denylist` still covers shared infra a project session must not touch.
+
+## 3. PII in committed review artefacts
+
+This repo deliberately commits `transform/recce_state.json` — and `value_diff`
+checks write **compared rows** into it. That is only safe while PII columns stay
+excluded from those checks (`pf.tools.recce`). Verify it, every time:
+
+```bash
+uv run python - <<'PY'
+import json, pathlib
+for p in pathlib.Path('.').rglob('transform/recce_state.json'):
+    d = json.loads(p.read_text())
+    print(p, '→ checks:', len(d.get('checks', [])))
+PY
+```
+
+For any `value_diff` check, confirm its column list contains no name matching
+email / phone / name / address / dob / ssn / iban / card. One that does is a
+**critical** finding: the data is already in git history.
+
+Same question for `mdl/mdl.json` and `catalog/openmetadata.json` — both are
+committed contracts. They should carry column *names and types*, never values,
+and never a credential (the ingestion workflow holds an env-var reference only).
+
+## 4. Query surface
+
+- `execute_sql_query` and `dbt_build` reach the warehouse. Confirm the project's
+  `.claude/settings.json` `permissions.deny` blocks reads of `.env*`,
+  `**/secrets.toml` and `**/credentials/**`.
+- Confirm no model or Evidence page interpolates a value that arrived from an
+  untrusted source into raw SQL.
+- Confirm logging never writes a row value — `pf.obs` records counts and
+  verdicts, not data.
+
+## 5. Report
+
+Prioritised list. For each finding: **severity** (Critical / High / Medium /
+Low), what is exposed, the blast radius (who can already see it — is it in git
+history?), and the concrete remediation. Lead with anything already committed:
+rotation, not deletion, is the fix for that class.
+
+---
+
+## Generic checklist (retained from the source guide)
+
+Where the sections above do not apply, fall back to these:
+
+**Authentication & authorization** — JWT handling, session management, RBAC.
+**Input validation** — SQL injection, XSS, API input sanitisation.
+**Data protection** — hardcoded secrets and API keys, PII handling, encryption
+at rest, secure logging (no sensitive data in logs), environment variable usage,
+CORS and CSP headers.
+
+**Output format** — a prioritised list of findings, each with severity level,
+description of the vulnerability, potential impact, recommended remediation, and
+a code example where applicable.

--- a/platform/toolkits/power-tools/commands/ship.md
+++ b/platform/toolkits/power-tools/commands/ship.md
@@ -1,0 +1,79 @@
+---
+name: ship
+description: Take the current change from working tree to a reviewable commit — gate, conformance, blast radius, data diff, then one conventional commit.
+disable-model-invocation: "yes"
+---
+
+# Ship
+
+Ordered. Each step produces the input for the next; a failure stops the sequence
+rather than being noted and passed over. `$ARGUMENTS` may carry a commit subject.
+
+## 1. See what is actually changing
+
+```bash
+git status --short
+git diff --stat
+```
+
+If the change spans more than one concern, stop and split it. A commit that does
+two things cannot be reverted for one of them.
+
+## 2. Gate
+
+```bash
+uv run pf gate --paths "$(git diff --name-only HEAD | tr '\n' ',')"
+```
+
+A denied path is not a thing to argue with. Either the file is generated (then
+regenerate it properly) or the rule is wrong (then change `gate.yaml`
+deliberately, in its own commit, with the reason in the comment beside it).
+
+## 3. Conformance and reach
+
+```bash
+uv run pf check
+```
+
+Ontology conformance plus the blast radius of everything modified. Undeclared
+joins fail here. If the reach includes metrics or a published contract
+(`mdl/mdl.json`, `catalog/openmetadata.json`), say so in the commit body — that
+is what makes the change reviewable rather than merely correct.
+
+## 4. Build and test what you touched
+
+```bash
+uv run dbt build --select state:modified+ --defer --state transform/target-base
+```
+
+Falling back to `dbt build --select <the models> ` when no base state exists.
+Tests are part of this step, not a later one.
+
+## 5. Data diff, when models changed
+
+```bash
+uv run pf tool recce run <group> <project>
+```
+
+Read `transform/recce_summary.md`. Numbers that moved unexpectedly are a finding,
+not a formality — resolve before committing, and reference the summary in the
+commit body when they moved for a good reason.
+
+## 6. Commit
+
+Conventional commit. Subject in the imperative, under ~70 characters, saying what
+changed and for whom. Body: why, and the blast radius if it was non-trivial.
+
+```bash
+git add <the specific paths>        # never `git add -A`
+git commit
+```
+
+The pre-commit hook re-runs the gate over the staged set. If it blocks, it is
+right; fix rather than bypass. `--no-verify` is not part of this workflow.
+
+## 7. Stop
+
+Do **not** push and do **not** open a PR unless that was explicitly asked for.
+Report: what was committed, what the blast radius was, what recce said, and what
+remains. Pushing is the user's call — the branch is theirs to place.

--- a/platform/toolkits/power-tools/commands/tech-debt.md
+++ b/platform/toolkits/power-tools/commands/tech-debt.md
@@ -1,0 +1,86 @@
+---
+name: tech-debt
+description: Inventory the active project's debt — ungoverned models, unannotated sources, stale decisions, inert gates — and rank it by what it actually costs.
+disable-model-invocation: "yes"
+---
+
+# Tech debt
+
+Debt in a data platform is mostly **governance that went inert**: a gate that
+cannot fire, a graph that no longer matches the models, a contract nobody
+regenerated. Those are cheap to find and expensive to leave.
+
+Scope: `$ARGUMENTS` (`governance`, `models`, `docs`, `tools`), else all.
+
+## 1. Inert governance — check first, it is the costliest kind
+
+```bash
+uv run pf loop audit                # scored: gate, hooks, graph, cards, ledger
+uv run pf tool doctor <group> <project>
+uv run pf tokens                    # always-on context budget
+```
+
+Each of these is a specific class of debt:
+- **no `kg/graph.duckdb`** → the PreToolUse gate warns instead of reporting a
+  blast radius. The project is ungoverned; edits land unverified. `pf kg build`.
+- **stale graph** → worse than none, because it reports a blast radius that is
+  wrong. Compare graph mtime against the newest file under `transform/models/`.
+- **`pf tool doctor` gaps** → a tool is enabled in `tools.yaml` but its package
+  is not installed, so its gate rules exist and never run.
+- **card over budget** → every session pays it, forever.
+
+## 2. Model debt
+
+```bash
+uv run dbt ls --select "resource_type:model" | wc -l
+```
+
+Then, via the graph:
+- models absent from the graph (built after the last `pf kg build`),
+- models nothing consumes — dead, but still built and tested every run,
+- models with no test and no contract, especially any that a metric depends on,
+- `select *` in staging, which makes every upstream schema change a silent one,
+- duplicated logic across models that should be one intermediate.
+
+## 3. Source debt
+
+Resources without `@annotate`; annotations whose concept no longer exists in the
+ontology; `links` pointing at a class the topology does not relate. Each one is a
+join that will be guessed later.
+
+## 4. Documentation and decisions
+
+- `decisions/ADR-*.md` that describe a state no longer true — an ADR that lies is
+  worse than a missing one.
+- `CLAUDE.md` "Business rules the graph cannot encode" still empty on a project
+  that plainly has some.
+- `evals/cases/` that no longer match the models they assert on.
+
+## 5. Rank and report
+
+One table. For each item: **cost now** (what it makes slow, risky or wrong),
+**cost of the fix**, **trigger** (what event makes it urgent — a new sister, a
+schema change, an audit). Then three buckets:
+
+- **Fix now** — anything that makes a gate inert. It is silently disabling a
+  control, which is the only kind of debt that gets worse without being touched.
+- **Fix next** — real cost, bounded work.
+- **Accept** — with the reason written down, so it is a decision and not an
+  oversight. Put these in an ADR.
+
+Do not open the fixes as part of this command. Inventory first.
+
+---
+
+## Generic checklist (retained from the source guide)
+
+**Code** — duplicated logic, dead code, TODO/FIXME/HACK markers, missing error
+handling, weak typing (`any`/`unknown` without a reason), inconsistent patterns.
+**Dependencies** — outdated or unmaintained packages, known vulnerabilities,
+dependencies added without discussion, heavy libraries where a small one works.
+**Tests** — coverage gaps on critical paths, flaky tests, tests asserting
+implementation rather than behaviour.
+**Docs** — stale README, undocumented public functions, missing ADRs.
+
+**Output format** — a prioritised assessment: what to fix now, what to schedule,
+what to accept and why.

--- a/platform/toolkits/power-tools/hooks/hooks.json
+++ b/platform/toolkits/power-tools/hooks/hooks.json
@@ -1,0 +1,51 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/scripts/format_edit.py",
+            "timeout": 60,
+            "statusMessage": "Formatting"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/scripts/session_start.sh",
+            "timeout": 20
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/scripts/notify.sh stop",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "permission_prompt|idle_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/scripts/notify.sh permission",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/platform/toolkits/power-tools/scripts/format_edit.py
+++ b/platform/toolkits/power-tools/scripts/format_edit.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""PostToolUse hook — normalise what the agent just wrote.
+
+Formatting is the one class of review nobody should spend a turn on. This runs
+after every successful Edit/Write and leaves the file in repo style.
+
+Three properties it must have, in order:
+
+1. **It never mangles.** It refuses to touch anything the gate denies, anything
+   generated, and anything under vendor/ or a virtualenv. For SQL it relies on
+   sqlfluff's own refusal to rewrite a file it could not parse — models using
+   project macros template to an unparsable tree under the stubbed `jinja`
+   templater, and are silently left alone rather than half-formatted.
+2. **It is quiet.** A hook that prints on success trains everyone to ignore it.
+   The only thing it ever says is that the file it was handed is not valid
+   source, which is worth a turn.
+3. **It never breaks the session.** Any unexpected failure exits 0.
+
+exit 0 = silent (the normal case)
+exit 2 = stderr is shown to the agent (file does not parse)
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+WRITE_TOOLS = {"Edit", "Write", "MultiEdit", "NotebookEdit"}
+
+# Directories whose contents are not ours to reformat: pinned upstreams, build
+# output, installed packages. `target` and `dbt_packages` are dbt artefacts and
+# are already on the gate denylist; they are repeated here so the hook is still
+# safe if it ever runs somewhere the gate cannot be imported.
+SKIP_PARTS = {
+    ".git", ".venv", "venv", "site-packages", "node_modules",
+    "vendor", "target", "target-base", "dbt_packages", "__pycache__",
+    ".evidence", "build", "dist",
+}
+
+TIMEOUT = 45
+
+
+def repo_root(start: Path) -> Path:
+    for p in [start, *start.parents]:
+        if (p / "platform").is_dir() and (p / "groups").is_dir():
+            return p
+    return start
+
+
+def tool(root: Path, name: str) -> list[str] | None:
+    """Prefer the workspace venv over PATH.
+
+    `uv run <tool>` would also work but re-resolves the environment on every
+    invocation, which is a few hundred milliseconds on a hook that fires after
+    every single edit.
+    """
+    venv = root / ".venv" / "bin" / name
+    if venv.exists():
+        return [str(venv)]
+    found = shutil.which(name)
+    return [found] if found else None
+
+
+def run(cmd: list[str]) -> subprocess.CompletedProcess | None:
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=TIMEOUT)
+    except Exception:
+        return None
+
+
+def gate_blocks(rel: str, root: Path, cwd: Path) -> bool:
+    """Ask the same policy the PreToolUse gate asks.
+
+    A denied path reaching this hook means the write happened outside the gate
+    (a generator, a capability). Formatting it would create drift against the
+    template it came from.
+    """
+    sys.path.insert(0, str(root / "platform" / "src"))
+    try:
+        from pf.loops.gate import check_path, project_for
+    except Exception:
+        return False
+    try:
+        return bool(check_path(rel, root, in_project=project_for(str(cwd), root) is not None).blocked)
+    except Exception:
+        return False
+
+
+def format_python(root: Path, path: Path) -> str | None:
+    ruff = tool(root, "ruff")
+    if not ruff:
+        return None
+    fmt = run([*ruff, "format", "--quiet", str(path)])
+    if fmt is not None and fmt.returncode != 0:
+        # ruff format only fails when it cannot parse the file. That is a real
+        # fault in what was just written, and the agent should hear about it.
+        return (fmt.stderr or fmt.stdout or "ruff format failed").strip()
+    # Import sorting only (`I`), deliberately not a bare `--fix-only`. The full
+    # default rule set includes F401, whose fix *deletes* unused imports — and
+    # halfway through writing a function the import above it is legitimately
+    # still unused. A hook that removes code the agent is about to use is worse
+    # than no hook. Everything semantic stays with `ruff check` in review.
+    run([*ruff, "check", "--fix-only", "--select", "I", "--quiet", str(path)])
+    return None
+
+
+def format_sql(root: Path, path: Path) -> None:
+    # Only dbt model/macro/test SQL. Loose .sql elsewhere (a scratch query, a
+    # fixture) is not ours to restyle.
+    if "transform" not in path.parts:
+        return
+    sqlfluff = tool(root, "sqlfluff")
+    cfg = root / ".sqlfluff"
+    if not sqlfluff or not cfg.exists():
+        return
+    # --ignore-local-config stops sqlfluff walking to the filesystem root looking
+    # for config, which both costs time and crashes outright on a directory the
+    # process cannot list.
+    run([*sqlfluff, "fix", "--disable-progress-bar", "--ignore-local-config",
+         "--config", str(cfg), str(path)])
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+
+    if payload.get("tool_name") not in WRITE_TOOLS:
+        return 0
+
+    raw = (payload.get("tool_input") or {}).get("file_path") or ""
+    if not raw:
+        return 0
+
+    path = Path(raw)
+    if not path.is_absolute():
+        path = Path(payload.get("cwd") or Path.cwd()) / path
+    try:
+        path = path.resolve()
+    except Exception:
+        return 0
+    if not path.is_file():
+        return 0
+    if SKIP_PARTS & set(path.parts):
+        return 0
+
+    cwd = Path(payload.get("cwd") or Path.cwd()).resolve()
+    root = repo_root(cwd)
+    try:
+        rel = str(path.relative_to(root))
+    except ValueError:
+        return 0  # outside the repo entirely
+
+    if gate_blocks(rel, root, cwd):
+        return 0
+
+    if path.suffix == ".py":
+        problem = format_python(root, path)
+        if problem:
+            print(f"{rel} does not parse — formatting skipped:\n{problem}", file=sys.stderr)
+            return 2
+    elif path.suffix == ".sql":
+        format_sql(root, path)
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        sys.exit(0)  # a formatter is never a reason to interrupt the session

--- a/platform/toolkits/power-tools/scripts/notify.sh
+++ b/platform/toolkits/power-tools/scripts/notify.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Stop / Notification hook — tell the human, who is not watching the terminal.
+#
+# The point of a long agent turn is that you go and do something else. This is
+# what brings you back: a desktop notification, a short spoken line, and an
+# append-only log so a session left running overnight is still readable.
+#
+# Off switches, because taste varies and open-plan offices exist:
+#   PF_NOTIFY=0        no notifications at all
+#   PF_NOTIFY_VOICE=0  desktop only, stay silent
+#   PF_NOTIFY_LOG      log path (default ~/.claude/pf-task-log.txt)
+#
+# Always exits 0. On a Stop hook a non-zero exit means "do not stop", which
+# would turn a notifier into an infinite loop.
+set -uo pipefail
+
+[ "${PF_NOTIFY:-1}" = "0" ] && exit 0
+
+kind="${1:-stop}"
+payload="$(cat 2>/dev/null || true)"
+log="${PF_NOTIFY_LOG:-$HOME/.claude/pf-task-log.txt}"
+
+field() { printf '%s' "$payload" | jq -r "$1 // empty" 2>/dev/null; }
+
+cwd="$(field '.cwd')"
+where="$(basename "${cwd:-$PWD}")"
+
+case "$kind" in
+  permission)
+    title="Claude Code · needs you"
+    body="$(field '.message')"
+    body="${body:-Waiting for approval in ${where}}"
+    spoken="I need your confirmation"
+    ;;
+  *)
+    title="Claude Code · done"
+    last="$(field '.last_assistant_message')"
+    # One line, trimmed. The notification is a summons, not a transcript.
+    body="$(printf '%s' "${last:-Task finished}" | tr '\n' ' ' | cut -c1-140)"
+    spoken="Task completed"
+    ;;
+esac
+
+mkdir -p "$(dirname "$log")" 2>/dev/null
+printf '%s  [%s]  %s  %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$kind" "$where" "$body" >> "$log" 2>/dev/null
+
+# macOS only. Elsewhere the log above is the whole feature.
+if [ "$(uname)" = "Darwin" ]; then
+  if command -v osascript >/dev/null 2>&1; then
+    osascript -e "display notification \"${body//\"/\\\"}\" with title \"${title}\" subtitle \"${where}\"" >/dev/null 2>&1 || true
+  fi
+  if [ "${PF_NOTIFY_VOICE:-1}" != "0" ] && command -v say >/dev/null 2>&1; then
+    # Backgrounded: `say` blocks for as long as it speaks, and a Stop hook that
+    # blocks is a Stop hook that delays the next prompt.
+    ( say "$spoken" >/dev/null 2>&1 & ) || true
+  fi
+fi
+
+exit 0

--- a/platform/toolkits/power-tools/scripts/session_start.sh
+++ b/platform/toolkits/power-tools/scripts/session_start.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# SessionStart hook — the four facts a session needs before its first turn.
+#
+# stdout is injected into the model's initial context, so this is charged to
+# every session for its whole life. It is deliberately short and says only what
+# cannot be derived from the files already loaded: which entity is active,
+# whether the gate can actually fire, and where the tree stands right now.
+#
+# The important line is the graph one. A project with no kg/graph.duckdb gets
+# warnings instead of blast radii — the gate is present and inert. That is worth
+# knowing on turn one, not on the turn an edit lands.
+set -uo pipefail
+
+cd "${CLAUDE_PROJECT_DIR:-$PWD}" 2>/dev/null || exit 0
+
+root="$PWD"
+while [ "$root" != "/" ] && ! { [ -d "$root/platform" ] && [ -d "$root/groups" ]; }; do
+  root="$(dirname "$root")"
+done
+[ "$root" = "/" ] && exit 0
+
+rel="${PWD#"$root"/}"
+echo "## Session context"
+echo "- repo: $(basename "$root") · branch: $(git -C "$root" branch --show-current 2>/dev/null || echo '?')"
+
+# Active entity, resolved the same way pf.mcp.server.active_project does.
+if [[ "$rel" == groups/*/projects/* ]]; then
+  group="$(echo "$rel" | cut -d/ -f2)"
+  project="$(echo "$rel" | cut -d/ -f4)"
+  echo "- scope: project ${group}/${project} — never read another group or sister"
+
+  graph="$root/$rel/kg/graph.duckdb"
+  if [ ! -f "$graph" ]; then
+    echo "- ⚠ NO KNOWLEDGE GRAPH (kg/graph.duckdb missing). The impact gate is inert:"
+    echo "  edits are allowed but nothing verifies what they break."
+    echo "  Build it before changing a model: \`pf kg build ${group} ${project}\`"
+  else
+    newest="$(find "$root/$rel/transform/models" -name '*.sql' -newer "$graph" 2>/dev/null | head -1)"
+    if [ -n "$newest" ]; then
+      echo "- ⚠ graph is STALE (models changed since it was built). A blast radius"
+      echo "  computed now may be wrong. Refresh: \`pf kg build ${group} ${project}\`"
+    else
+      echo "- graph: current · ask it before reading files (kg_search, kg_neighbors, impact_analysis)"
+    fi
+  fi
+else
+  echo "- scope: platform/root — shared infra. Changes here affect every project."
+fi
+
+# Uncommitted work, capped: the point is "there is state here", not a file list.
+dirty="$(git -C "$root" status --porcelain 2>/dev/null | wc -l | tr -d ' ')"
+[ "${dirty:-0}" -gt 0 ] && echo "- working tree: ${dirty} uncommitted path(s) — \`git status\` before assuming a clean base"
+
+exit 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,4 +66,7 @@ dev = [
   # project CLAUDE.md tells the agent to call `kg_search` and `impact_analysis`
   # before touching a model, and those are MCP tools.
   "mcp>=1.2",
+  # Formats dbt SQL after an agent edit (power-tools PostToolUse hook). The hook
+  # skips silently when it is absent, so this is what turns SQL formatting on.
+  "sqlfluff>=3.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,4 +60,10 @@ dev = [
   "dagster-dbt>=0.26",
   "anthropic>=0.40",
   "dbt-metricflow[duckdb]>=0.13.0",
+  # Runs `pf-mcp`, the stdio server every project session talks to. In the dev
+  # group rather than a base dependency: a CI job that only builds dbt has no
+  # reason to carry it, but a developer session is useless without it — the
+  # project CLAUDE.md tells the agent to call `kg_search` and `impact_analysis`
+  # before touching a model, and those are MCP tools.
+  "mcp>=1.2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -658,6 +658,7 @@ dev = [
     { name = "mcp" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "sqlfluff" },
 ]
 
 [package.metadata]
@@ -682,6 +683,7 @@ dev = [
     { name = "mcp", specifier = ">=1.2" },
     { name = "pytest", specifier = ">=8" },
     { name = "ruff", specifier = ">=0.6" },
+    { name = "sqlfluff", specifier = ">=3.2" },
 ]
 
 [[package]]
@@ -3433,6 +3435,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/20/5c2b4583904af4173076dda1c9e53c9e2ffc7a702d2efde0216bbacbf7cb/sqlalchemy-2.0.52-cp312-cp312-win32.whl", hash = "sha256:afda3ec521d0517d0de783fc70030775841900896d832de5bbd066549290470e", size = 2129366, upload-time = "2026-08-11T21:14:50.991Z" },
     { url = "https://files.pythonhosted.org/packages/ed/06/543dab8ef62d4e9fb96fb31a30c2b8b14a8763bccf48d428294d6b3041c0/sqlalchemy-2.0.52-cp312-cp312-win_amd64.whl", hash = "sha256:2d5e53e36e37129fe0be8b9d08b6e4052c10a963ee6cda56c8c10dcc194b99ca", size = 2157344, upload-time = "2026-08-11T21:14:52.453Z" },
     { url = "https://files.pythonhosted.org/packages/b3/3f/3582293d1e185e71d19d7c731c3e2ee20ba21981c4a1115c0806c1f62120/sqlalchemy-2.0.52-py3-none-any.whl", hash = "sha256:3b81b8363a919ce53453591cdb93702e6bd54ade6c4fa2f468fc053baee5ed89", size = 1950700, upload-time = "2026-08-11T20:47:21.603Z" },
+]
+
+[[package]]
+name = "sqlfluff"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chardet" },
+    { name = "click" },
+    { name = "colorama" },
+    { name = "diff-cover" },
+    { name = "jinja2" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "tblib" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/06/c675066797f91a77d456bc15375a0a8c9b4765f1e66db639655772a928da/sqlfluff-4.3.0.tar.gz", hash = "sha256:aa647b3721112f1aca581efe8eaa815a332ae214610a0946592f98a19ef1e8cb", size = 1068771, upload-time = "2026-08-07T09:01:19.317Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/be/0be38ce154b9d798bb00b5ce65a3ad0e1ae2bc9419fcd8e3c773c2b80c70/sqlfluff-4.3.0-py3-none-any.whl", hash = "sha256:582e12af5101bd1c5bc120cb4a6942dadcfe5e5b1e01406f220dd08f5b3f31dd", size = 1051485, upload-time = "2026-08-07T09:01:17.139Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -655,6 +655,7 @@ dev = [
     { name = "dbt-duckdb" },
     { name = "dbt-metricflow" },
     { name = "dlt", extra = ["duckdb"] },
+    { name = "mcp" },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -678,6 +679,7 @@ dev = [
     { name = "dbt-duckdb", specifier = ">=1.9" },
     { name = "dbt-metricflow", extras = ["duckdb"], specifier = ">=0.13.0" },
     { name = "dlt", extras = ["duckdb"], specifier = ">=1.4" },
+    { name = "mcp", specifier = ">=1.2" },
     { name = "pytest", specifier = ">=8" },
     { name = "ruff", specifier = ">=0.6" },
 ]
@@ -1403,6 +1405,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "humanfriendly"
 version = "10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1838,6 +1849,31 @@ wheels = [
 [package.optional-dependencies]
 msgpack = [
     { name = "msgpack" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/d3/f9acc21dfc886e4f78e2add1a47db46ce16884346afde53f8a064c02c891/mcp-1.29.0.tar.gz", hash = "sha256:52d01f334de1868cc3bb2d6604931126a67631f99a6c5d3b82ba47290315ec36", size = 643148, upload-time = "2026-07-28T13:41:41.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/c8/248b201f6d753d69fd5d6506011abbb35a946d9142b2ae311a948fd0be3d/mcp-1.29.0-py3-none-any.whl", hash = "sha256:f5a075bb611f23d6f4d080c6a1699fa62772eebc562ba9e66b306ddde1c755f7", size = 223436, upload-time = "2026-07-28T13:41:40.337Z" },
 ]
 
 [[package]]
@@ -2378,6 +2414,9 @@ data = [
     { name = "dbt-duckdb" },
     { name = "dlt", extra = ["duckdb"] },
 ]
+mcp = [
+    { name = "mcp" },
+]
 orchestration = [
     { name = "dagster" },
     { name = "dagster-dbt" },
@@ -2396,13 +2435,14 @@ requires-dist = [
     { name = "duckdb", specifier = ">=1.1" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "jsonschema", specifier = ">=4.20" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.2" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pyyaml", specifier = ">=6" },
     { name = "rich", specifier = ">=13" },
     { name = "typer", specifier = ">=0.12" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
 ]
-provides-extras = ["data", "orchestration", "agents"]
+provides-extras = ["data", "orchestration", "agents", "mcp"]
 
 [[package]]
 name = "platformdirs"
@@ -3411,6 +3451,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/67/701f86b28d63b2086de47c942eccf8ca2208b3be69715a1119a4e384415a/sqlparse-0.5.4.tar.gz", hash = "sha256:4396a7d3cf1cd679c1be976cf3dc6e0a51d0111e87787e7a8d780e7d5a998f9e", size = 120112, upload-time = "2025-11-28T07:10:18.377Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/70/001ee337f7aa888fb2e3f5fd7592a6afc5283adb1ed44ce8df5764070f22/sqlparse-0.5.4-py3-none-any.whl", hash = "sha256:99a9f0314977b76d776a0fcb8554de91b9bb8a18560631d6bc48721d07023dcb", size = 45933, upload-time = "2025-11-28T07:10:19.73Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/00/b42a44342a054d58cb1115d7c8aa9cb4290dd9442f9c1b91a4b8173dba22/sse_starlette-3.4.8.tar.gz", hash = "sha256:ed89ffbb75cbf78a5fe2f2109cd584792ee7f9dfac96f791db546df8f15f3f9c", size = 32548, upload-time = "2026-08-05T11:19:49.982Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/3a/764912c58293d95b6dcdf4cc255f9d10de310580ced547b082eb9d72018c/sse_starlette-3.4.8-py3-none-any.whl", hash = "sha256:6e82314c786709a3cd9520f2285cf9fff90e181e598e8a357b0cf80f66afba0d", size = 16516, upload-time = "2026-08-05T11:19:48.748Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Layer 2 of 8** · base: #54

The session layer, shipped as a plugin rather than loose `.claude/` files. `pf work` chdirs into a project and execs `claude`, so a plugin is the only unit that carries commands, agents, hooks *and* `.mcp.json` into that session — and it is the extension seam this repo already committed to.

Four commits, one per component:

| Commit | Contents |
|---|---|
| core | `plugin.json`, `RULES.md`, and the `.mcp.json` that starts `pf mcp` scoped by `PF_PROJECT_DIR` |
| commands | 9 slash commands |
| agents | 4 read-only verification subagents |
| hooks | format-on-edit, session context, notifications |

**Commands** — the six from the power-users guide, each rewritten to drive this platform (`/security-audit` reads the committed recce state for PII; `/performance-audit` reads `run_results.json`; `/architecture-review` checks declared joins and grain), with the guide's generic checklist kept below as fallback. Plus `/blast-radius`, `/ship` and `/context-budget`.

**Agents** — all four declare `disallowedTools: Write, Edit, MultiEdit, NotebookEdit`. A verifier that can edit stops being a second opinion and becomes a second author.

**Hooks** — one decision worth flagging in review: autofix is restricted to import sorting (`--select I`). A bare `ruff check --fix-only` deletes unused imports, and an import added moments before the code that uses it is legitimately unused. Caught in testing when it silently removed two imports from a probe file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


