### PR TITLE
Give the jaffle group the tools its sisters already run

### DIFF
--- a/gate.capabilities.yaml
+++ b/gate.capabilities.yaml
@@ -12,6 +12,7 @@ denylist:
 - '**/mdl/connection.json'
 - '**/catalog/ingestion.yaml'
 - '**/catalog/openmetadata.json'
+- '**/.github/workflows/**'
 impact_required:
 - '**/reporting/pages/**'
 - '**/transform/recce.yml'

--- a/groups/jaffle/evals/README.md
+++ b/groups/jaffle/evals/README.md
@@ -1,0 +1,32 @@
+# Evals for jaffle
+
+Prompts are code; these are their tests. Cases here cover what the sisters
+**share and only share** — the group's ontology instance, its conformed
+dimensions, its group-level metrics.
+
+Three tiers run together, and each owns what only it can know:
+
+| Tier | Lives in | Owns |
+|---|---|---|
+| platform | `platform/toolkits/<toolkit>/evals/` | health checks, and templates |
+| **group** | **here** | what every sister in jaffle agrees on |
+| project | `projects/<project>/evals/cases/` | one entity's business logic |
+
+A case belongs here when it would be *wrong for a sister to disagree with it*.
+If one sister could legitimately answer differently, it is a project case.
+
+```json
+{
+  "name": "conformed_customer_grain_is_respected",
+  "agent": "metric_gap_proposer",
+  "why": "Why this case exists — what breaks without it.",
+  "tags": ["conformed"],
+  "input": {"gaps": ["..."], "mart_detail": "..."},
+  "expect": {"proposals[].metric_type": {"any": {"equals": "ratio"}}}
+}
+```
+
+    pf evals jaffle <project>          # contract tier + load every case
+    pf evals jaffle <project> --live   # grade against the real models
+
+Any change to an agent prompt must keep these green.

--- a/groups/jaffle/kg/group_card.md
+++ b/groups/jaffle/kg/group_card.md
@@ -1,4 +1,4 @@
-## jaffle — group index (generated 2026-08-15)
+## jaffle — group index (generated 2026-08-16)
 
 **Sister projects (1):** `jaffle-shop`
 **Ontology classes in scope:** Customer, Order, Payment, Refund, Product, Location

--- a/groups/jaffle/tools.yaml
+++ b/groups/jaffle/tools.yaml
@@ -1,0 +1,15 @@
+# Which platform tools this group runs.
+#
+# Managed by `pf tool enable/disable`, but hand-editing is fine — it is read, not
+# generated. A tool enabled here is scaffolded and bootstrapped by
+# `pf bootstrap`, and contributes its assets to Dagster.
+# Enabled here means enabled for every sister project in this group. A project
+# can override any key in its own tools.yaml, including `enabled: false`.
+version: 1
+tools:
+  recce:
+    enabled: true
+  wren:
+    enabled: true
+  openmetadata:
+    enabled: true


### PR DESCRIPTION
**Layer 6 of 8** · base: #46

The `jaffle` group had **no `tools.yaml` at all**, so `recce`, `wren` and `openmetadata` were off for the whole family while acme, globex and zenith ran all three. That is why jaffle-shop had no recce workflow — nothing was disabled, the decision had simply never been recorded.

Enabled through `pf tool enable` so the capability half, the gate rules and the bootstrap all run the way they would for any other group, rather than by hand-writing the files.

`groups/jaffle/evals/README.md` is rendered from the scaffolder's own `GROUP_EVALS` template — verified identical to acme's modulo the group name — so it matches what `pf new-group` emits today.

All four groups now have the same structure: `CLAUDE.md evals kg ontology projects shared tools.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


