### PR TITLE
feat(vendor): pin the public-sector AI playbook, and stop CI cloning every upstream

### DIFF
--- a/.github/workflows/pr-report.yml
+++ b/.github/workflows/pr-report.yml
@@ -25,12 +25,34 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Submodules are the vendored upstreams; without them the drift
-          # section is silently empty, which reads as "no drift".
-          submodules: recursive
           # Blast radius is computed against the merge base, so a shallow
           # checkout would report every file in the repo as changed.
           fetch-depth: 0
+          # Submodules are deliberately *not* fetched here, and `fetch-depth` is
+          # why: actions/checkout applies it to submodules too, so
+          # `submodules: recursive` alongside `fetch-depth: 0` means a
+          # full-history clone of every pinned upstream. One of them is
+          # `vendor/openmetadata`, the OpenMetadata product monorepo, and the
+          # registry adopts exactly one file from it.
+          #
+          # That is not a theoretical cost. It wedged this workflow: the run for
+          # PR #201 sat in `actions/checkout` for twelve hours, could not be
+          # cancelled (the API returned 500), and held the `pr-report-<n>`
+          # concurrency group the whole time. The other pull requests in that
+          # stack only escaped it by finishing in four to five minutes each,
+          # nearly all of which was this clone.
+
+      # The drift section does need the pinned upstreams — but only their pinned
+      # *trees*. `pf vendor drift` resolves blob OIDs with
+      # `git rev-parse <commit>:<path>`, and the pinned commit is HEAD, so one
+      # commit with no blob content is enough for every comparison it makes.
+      #
+      # Best-effort on purpose. `pf vendor drift` prints "<id> not checked out"
+      # for an upstream it cannot read, which is a different line in the report
+      # from "no drift" — so a partial fetch degrades visibly rather than
+      # silently, which is what the comment this replaces was worried about.
+      - name: Vendored upstreams
+        run: git submodule update --init --jobs 4 --depth 1 --filter=blob:none || true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/.gitmodules
+++ b/.gitmodules
@@ -79,3 +79,7 @@
 	url = https://github.com/jagmarques/asqav-compliance
 	branch = main
 	shallow = true
+[submodule "vendor/public-sector-ai-playbook"]
+	path = vendor/public-sector-ai-playbook
+	url = https://github.com/PackMaaan/public-sector-ai-playbook
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -74,6 +74,7 @@
 [submodule "vendor/openmetadata"]
 	path = vendor/openmetadata
 	url = https://github.com/open-metadata/OpenMetadata
+	shallow = true
 [submodule "vendor/asqav-compliance"]
 	path = vendor/asqav-compliance
 	url = https://github.com/jagmarques/asqav-compliance

--- a/platform/src/pf/vendor/registry.yaml
+++ b/platform/src/pf/vendor/registry.yaml
@@ -946,3 +946,74 @@ upstreams:
           it `disable_agent` scores as missing it. Useful as a prompt to go and
           look; wrong as a merge gate. `pf provenance verify` blocks instead,
           because it tests behaviour.
+
+  - id: public-sector-ai-playbook
+    summary: "the governance artefacts a regulated deployment has to produce"
+    name: Public Sector AI Playbook
+    url: https://github.com/PackMaaan/public-sector-ai-playbook
+    path: vendor/public-sector-ai-playbook
+    branch: main
+    licence: CC BY 4.0
+    licence_review: >
+      Creative Commons Attribution 4.0 — the most permissive licence in this
+      registry. Use, adaptation and redistribution are all allowed, commercially
+      included, on one condition: attribution. Any template we derive from must
+      credit the author (Linda Oraegbunam) and state that changes were made.
+      That obligation travels with the *derived artefact*, not with this
+      repository, so a model card or risk register generated for a company and
+      handed to its regulator carries the credit line — which is why nothing
+      here is copied into the platform silently.
+    role: reference
+    why: >
+      It closes the third side of the governance question. `pf.provenance` is
+      runtime evidence — what an agent actually did, hash-linked and anchored.
+      `asqav-compliance` is static analysis — whether the controls exist in the
+      code. Neither says what the controls should *be*, and for a regulated
+      deployment that is the part someone external judges: a model card, a bias
+      audit, a risk register, a supplier due-diligence trail, mapped to the UK
+      AI Playbook (2025) and the EU AI Act.
+
+      Carried rather than copied because these are templates for a *deployment*,
+      and this platform is multi-tenant: the risk register belongs to a company,
+      not to the shared infra. The submodule is the reference a project fills in
+      from, pinned so the version a regulator was shown is the version we still
+      have.
+    adopted:
+      - upstream: 05-deployment/model-card-template.md
+        kind: shape
+        ours: [platform/src/pf/provenance/audit.py]
+        note: >
+          The audit's four questions — integrity, completeness, coverage,
+          oversight — are the evidence half of what a model card asks for. Ours
+          answers them from the ledger rather than from a form, which is the
+          difference between a document that asserts human oversight and a chain
+          that shows the approval.
+      - upstream: 04-governance/ai-risk-register-template.md
+        kind: shape
+        ours: [gate.yaml]
+        note: >
+          A risk register names the controls; gate.yaml is the subset that is
+          machine-enforced. Drift between the two is the thing to watch — a
+          register entry with no gate rule is a control that exists only on
+          paper, and that comparison is the reason to carry the template at all.
+    declined:
+      - what: tools/readiness_scorer.py
+        why: >
+          It is an interactive CLI that prompts for 25 answers and crashes on a
+          non-TTY (no `--help`, no flags), so it cannot run in CI or from a
+          loop. `pf.loops.audit` already scores readiness from the repository
+          itself — hook present, graph built, card current — which is a measure
+          nobody can talk up in an interview with themselves.
+      - what: tools/governance_report_generator.py
+        why: >
+          Verified working (it generates a governance pack from a project JSON),
+          and still not adopted: it reads a hand-written config, so the report
+          says whatever the config claims. Ours would have to read the ontology
+          and the ledger, and at that point it shares no code with this — only
+          the output shape, which is what `adopted` above records.
+      - what: the sector playbooks (healthcare, local government)
+        why: >
+          NHS DSPT, DCB0129 and MHRA/SaMD classification are real obligations
+          for a healthcare deployment and noise for every other tenant. They
+          belong to a project that has that regulator, not to shared infra —
+          the same reason business logic never lives in platform/.


### PR DESCRIPTION
> **Rebased onto a base PR — the diff below is now 4 files, not 20.**
> This PR was opened against `main` while carrying `668cdd1` and `2bdd97d`,
> both of which #165 was also carrying. Those are now #289 and #290, and this
> PR is based on them. Nothing was rewritten; only the base moved.

## What this PR changes

Two things, both about what the repository pulls in from outside.

**A vendored reference.** `vendor/public-sector-ai-playbook` is pinned as a
submodule and recorded in `platform/src/pf/vendor/registry.yaml` (+71) — so
`pf vendor why` can answer for it like it answers for the other fourteen.

**A CI fix.** `.github/workflows/pr-report.yml` stopped full-cloning every
vendored upstream on every PR. Fifteen submodules, most of them large, cloned
in full to produce a report that reads none of them.

## Reviewing this

The registry entry is the load-bearing part: it is what makes the new pin
explainable later. Check that what it claims we took matches what the pin
actually contains.

Depends on #290.

---

<sub>Everything below was written by the review bots **before** the base split, and
describes the provenance ledger — which now lives in #290.</sub>

----
## Summary by Gitar

- **Provenance ledger system:**
    - Added comprehensive ledger implementation tracking `intent`, `decision`, and `execution` stages in `platform/src/pf/provenance/ledger.py`
    - Implemented tamper-evident SHA-256 chain linking and anchor verification in `platform/src/pf/provenance/`
- **Governance and CI integration:**
    - Added AI governance CI workflow in `.github/workflows/ai-governance.yml` incorporating provenance verification and compliance scanning
    - Added documentation detailing agent action provenance in `docs/GOVERNANCE.md`
- **Tool and hook instrumentation:**
    - Updated pre- and post-tool use hooks to integrate provenance logging for agent actions
    - Added comprehensive test suite covering chain integrity and tamper detection in `platform/tests/test_provenance.py`

<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive action provenance tracking for intent, decisions, and execution outcomes.
  * Added commands to inspect, verify, audit, timestamp, approve, revoke, export, and synchronize provenance records.
  * Added external timestamp verification through RFC 3161 and OpenTimestamps.
* **Governance**
  * Added automated provenance integrity and compliance checks.
  * Restricted direct modification of provenance records.
* **Documentation**
  * Added guidance covering provenance, auditing, enforcement, and verification.
* **Tests**
  * Added extensive coverage for integrity, tampering, revocation, auditing, and timestamping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
