### PR TITLE
feat(loops): observability triage and the expectations refresher

### DIFF
--- a/platform/src/pf/loops/registry.py
+++ b/platform/src/pf/loops/registry.py
@@ -58,6 +58,19 @@ SPECS: dict[str, LoopSpec] = {
                     "each movement implicates.",
         autonomy="L1", cadence="weekly", token_budget=0, writes=False,
     ),
+    "observability-triage": LoopSpec(
+        name="observability-triage",
+        description="Read Elementary's recorded test history; report what is "
+                    "failing or anomalous, with how often — recurrence is the "
+                    "difference between an incident and a broken test.",
+        autonomy="L1", cadence="every 6h", token_budget=12_000, writes=False,
+    ),
+    "expectations-refresher": LoopSpec(
+        name="expectations-refresher",
+        description="Regenerate the ontology-derived expectations floor when the "
+                    "knowledge graph has moved past it.",
+        autonomy="L2", cadence="on graph change", token_budget=0, writes=True,
+    ),
 }
 
 
@@ -260,9 +273,112 @@ def vendor_drift(root: Path, group: str, project: str, run: LoopRun) -> list[str
     return out
 
 
+def observability_triage(root: Path, group: str, project: str, run: LoopRun) -> list[str]:
+    """What Elementary's history says is wrong, weighted by recurrence.
+
+    Reads `main_elementary.elementary_test_results` — every framework's tests
+    land there (dbt's own, dbt-expectations, the generated floor, anomaly
+    monitors) — rather than the one run_results.json that happened to survive.
+    The deterministic findings are the fallback; with credentials the existing
+    triage agent classifies them, exactly as `test-failure-triage` does for a
+    single run.
+    """
+    import duckdb
+
+    from pf.runtime.warehouse import Warehouse
+
+    pdir = root / "groups" / group / "projects" / project
+    wh = Warehouse.for_project(pdir, group, project)
+    if not Path(wh.path).exists():
+        return []
+    try:
+        con = duckdb.connect(str(wh.path), read_only=True)
+    except duckdb.Error:
+        return []  # a sister holds the write lock — report nothing, not an error
+    try:
+        if not con.execute(
+                "SELECT 1 FROM information_schema.tables WHERE table_schema = "
+                "'main_elementary' AND table_name = 'elementary_test_results' "
+                "LIMIT 1").fetchone():
+            return [f"elementary tables missing — `pf tool elementary run {group} {project}`"]
+        rows = con.execute("""
+            WITH latest AS (
+                SELECT test_unique_id, table_name, column_name, test_name,
+                       status, test_results_description, detected_at,
+                       row_number() OVER (PARTITION BY test_unique_id
+                                          ORDER BY detected_at DESC) AS rn
+                FROM main_elementary.elementary_test_results
+            ), history AS (
+                SELECT test_unique_id,
+                       count(*) FILTER (WHERE status <> 'pass') AS bad_runs,
+                       count(*) AS runs
+                FROM main_elementary.elementary_test_results GROUP BY 1
+            )
+            SELECT l.table_name, l.column_name, l.test_name, l.status,
+                   l.test_results_description, h.bad_runs, h.runs
+            FROM latest l JOIN history h USING (test_unique_id)
+            WHERE l.rn = 1 AND l.status <> 'pass'
+            ORDER BY h.bad_runs DESC LIMIT 20""").fetchall()
+    except duckdb.Error as exc:
+        return [f"could not read elementary history: {exc}"[:200]]
+    finally:
+        con.close()
+
+    raw = [f"{t or '?'}{'.' + c if c else ''} [{n}] {s} "
+           f"({bad}/{total} runs bad): {(d or '')[:120]}"
+           for t, c, n, s, d, bad, total in rows]
+    if not raw:
+        return []
+
+    from pf.agents import NoCredentials, have_credentials, triage_failures
+    if not have_credentials():
+        return raw
+    failures = [{"unique_id": f"{t or '?'}.{n}", "status": s,
+                 "message": f"{bad}/{total} runs bad — {(d or '')[:160]}"}
+                for t, c, n, s, d, bad, total in rows]
+    try:
+        verdict = triage_failures(root, group, project, failures, "")
+    except NoCredentials:
+        return raw
+    if verdict is None:
+        return raw
+    prefix = "ESCALATE" if verdict.escalate else verdict.confidence.upper()
+    return [(f"[{prefix}] root_cause={verdict.root_cause}: {verdict.summary} "
+            f"→ {verdict.suggested_fix}")]
+
+
+def expectations_refresher(root: Path, group: str, project: str, run: LoopRun) -> list[str]:
+    """Keep the generated quality floor caught up with the graph.
+
+    The mirror of `index-refresher`, one derivation later: the graph is rebuilt
+    from the manifest, and the expectations floor is derived from the graph, so
+    a graph newer than the newest generated test means annotations moved and
+    the floor may be stale. `write_tests` is already idempotent and
+    marker-scoped, so re-deriving over an up-to-date floor writes nothing.
+    """
+    from pf.tools import expectations as ex
+
+    pdir = root / "groups" / group / "projects" / project
+    graph = pdir / "kg" / "graph.duckdb"
+    if not graph.exists():
+        return []
+    tdir = ex.tests_dir(pdir)
+    newest = max((f.stat().st_mtime for f in tdir.glob("*.sql")), default=0.0) \
+        if tdir.exists() else 0.0
+    if newest >= graph.stat().st_mtime:
+        return []
+    written, unchanged, removed = ex.write_tests(pdir)
+    if not (written or removed):
+        return []
+    return [(f"expectations floor refreshed: {written} written, {removed} stale "
+            f"removed ({unchanged} unchanged) — runs on the next `pf seed`")]
+
+
 BODIES = {
     "dashboard-coverage": dashboard_coverage,
     "vendor-drift": vendor_drift,
+    "observability-triage": observability_triage,
+    "expectations-refresher": expectations_refresher,
     "freshness-triage": freshness_triage,
     "test-failure-triage": test_failure_triage,
     "metric-gap-harvester": metric_gap_harvester,

--- a/platform/tests/test_loops_quality.py
+++ b/platform/tests/test_loops_quality.py
@@ -1,0 +1,110 @@
+"""The two quality-stack loops: observability triage and the floor refresher.
+
+What must not regress: the triage loop reads Elementary's *history* and ranks
+by recurrence (that is its whole advantage over run_results.json), degrades to
+silence when the warehouse or the tables are absent, and never mutates
+anything; the refresher rewrites only when the graph has actually moved past
+the generated floor.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+from pf.loops.registry import expectations_refresher, observability_triage
+from pf.tools import expectations as ex
+
+
+def _project(tmp_path: Path) -> Path:
+    d = tmp_path / "groups" / "g" / "projects" / "p"
+    (d / "transform").mkdir(parents=True)
+    (d / "transform" / "dbt_project.yml").write_text("name: demo\n")
+    (d / "data").mkdir()
+    (d / "kg").mkdir()
+    return d
+
+
+def _seed_history(d: Path, rows: list[tuple]) -> None:
+    con = duckdb.connect(str(d / "data" / "p.duckdb"))
+    con.execute("CREATE SCHEMA main_elementary")
+    con.execute("""
+        CREATE TABLE main_elementary.elementary_test_results (
+            test_unique_id VARCHAR, table_name VARCHAR, column_name VARCHAR,
+            test_name VARCHAR, status VARCHAR, test_results_description VARCHAR,
+            detected_at TIMESTAMP)""")
+    con.executemany(
+        "INSERT INTO main_elementary.elementary_test_results VALUES (?,?,?,?,?,?,?)",
+        rows)
+    con.close()
+
+
+# --------------------------------------------------------------- triage ----
+def test_triage_reports_latest_failures_with_recurrence(tmp_path, monkeypatch) -> None:
+    d = _project(tmp_path)
+    _seed_history(d, [
+        # A test that failed twice and last failed — the finding.
+        ("t.flaky", "orders", "order_total", "column_anomalies", "fail",
+         "zero_count spiked", "2026-08-18 01:00"),
+        ("t.flaky", "orders", "order_total", "column_anomalies", "fail",
+         "zero_count spiked again", "2026-08-19 01:00"),
+        # A test that failed once but passes NOW — history, not a finding.
+        ("t.healed", "customers", None, "not_null", "fail",
+         "was broken", "2026-08-18 01:00"),
+        ("t.healed", "customers", None, "not_null", "pass",
+         None, "2026-08-19 01:00"),
+    ])
+    # Deterministic path only — the agent half is someone else's test.
+    monkeypatch.setattr("pf.agents.have_credentials", lambda: False)
+
+    findings = observability_triage(tmp_path, "g", "p", run=None)
+    assert len(findings) == 1
+    assert "orders.order_total" in findings[0]
+    assert "2/2 runs bad" in findings[0]
+    assert "healed" not in findings[0]
+
+
+def test_triage_names_the_missing_tables(tmp_path) -> None:
+    """An enabled tool whose tables were never built is one command away —
+    the loop should say which command rather than reporting silence."""
+    d = _project(tmp_path)
+    duckdb.connect(str(d / "data" / "p.duckdb")).close()
+    findings = observability_triage(tmp_path, "g", "p", run=None)
+    assert findings == ["elementary tables missing — `pf tool elementary run g p`"]
+
+
+def test_triage_is_silent_with_no_warehouse(tmp_path) -> None:
+    _project(tmp_path)
+    assert observability_triage(tmp_path, "g", "p", run=None) == []
+
+
+# ------------------------------------------------------------ refresher ----
+def test_refresher_regenerates_only_when_the_graph_moved(tmp_path, monkeypatch) -> None:
+    import os
+    import time
+
+    d = _project(tmp_path)
+    monkeypatch.setattr(ex, "_annotated_marts", lambda _d: [
+        ex.MartModel(name="fct_orders", grain="one order", key="order_id")])
+    ex.write_tests(d)
+
+    graph = d / "kg" / "graph.duckdb"
+    graph.write_bytes(b"")
+    # Graph older than the floor: nothing to do.
+    old = time.time() - 3600
+    os.utime(graph, (old, old))
+    assert expectations_refresher(tmp_path, "g", "p", run=None) == []
+
+    # Graph moved, and a model left the ontology: the floor follows.
+    monkeypatch.setattr(ex, "_annotated_marts", lambda _d: [
+        ex.MartModel(name="fct_orders", grain="one order", key="")])
+    now = time.time() + 3600
+    os.utime(graph, (now, now))
+    findings = expectations_refresher(tmp_path, "g", "p", run=None)
+    assert len(findings) == 1 and "2 stale removed" in findings[0]
+    assert not (ex.tests_dir(d) / "fct_orders__order_id__unique.sql").exists()
+
+
+def test_refresher_is_silent_without_a_graph(tmp_path) -> None:
+    _project(tmp_path)
+    assert expectations_refresher(tmp_path, "g", "p", run=None) == []


### PR DESCRIPTION
Two catalogue loops that keep the stack true on cadence: observability-triage (L1) reads Elementary's history and ranks findings by recurrence, handing them to the existing triage agent when credentialed; expectations-refresher (L2, writes inside the gate) re-derives the floor when the graph outruns it.

Stack 5/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)