### PR TITLE
feat(governance): name the quality stack's enforcement as policy

### DIFF
--- a/groups/acme/projects/acme-eu/governance/otop.json
+++ b/groups/acme/projects/acme-eu/governance/otop.json
@@ -4,9 +4,9 @@
     "id": "otop.pf.acme.acme-eu",
     "title": "Policy and evidence \u2014 acme/acme-eu",
     "repository": "https://github.com/Atomz-org/data-platform.git",
-    "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+    "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
     "metadata": {
-      "created_at": "2026-08-16T23:53:41Z",
+      "created_at": "2026-08-19T21:36:34Z",
       "actor": "pf.projections.otop"
     }
   },
@@ -17,13 +17,13 @@
       "title": "Agentic Data Platform governance policy",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
         "scope": "acme/acme-eu",
         "source": "platform/src/pf/ontology/policy.yaml",
-        "rules": 10
+        "rules": 22
       }
     },
     {
@@ -32,7 +32,7 @@
       "title": "A monetary amount without its currency is not a number, it is a bug waiting for a second entity to be onboarded.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -45,7 +45,7 @@
       "title": "money-requires-currency",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -61,6 +61,138 @@
         "params": {
           "sibling": "currency_code",
           "scope": "resource"
+        },
+        "controls": [
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -70,8 +202,8 @@
       "title": "pf check for money-requires-currency",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:53:39Z",
-        "observed_at": "2026-08-16T23:53:39Z",
+        "created_at": "2026-08-19T21:36:25Z",
+        "observed_at": "2026-08-19T21:36:25Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -95,7 +227,7 @@
       "title": "A class with no identity property cannot participate in a derived join, so every BI and MDL projection of it is a guess.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -108,7 +240,7 @@
       "title": "entity-requires-identity",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -123,6 +255,138 @@
         },
         "params": {
           "exclude_abstract": true
+        },
+        "controls": [
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -132,8 +396,8 @@
       "title": "pf check for entity-requires-identity",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:53:39Z",
-        "observed_at": "2026-08-16T23:53:39Z",
+        "created_at": "2026-08-19T21:36:26Z",
+        "observed_at": "2026-08-19T21:36:26Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -157,7 +421,7 @@
       "title": "A foreign key pointing at a class the topology does not relate to is an undeclared join. Undeclared joins are how two teams compute different revenue from th...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -170,7 +434,7 @@
       "title": "link-must-be-in-topology",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -183,7 +447,139 @@
         "applies_to": {
           "annotation": "links"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -192,8 +588,8 @@
       "title": "pf check for link-must-be-in-topology",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:53:39Z",
-        "observed_at": "2026-08-16T23:53:39Z",
+        "created_at": "2026-08-19T21:36:26Z",
+        "observed_at": "2026-08-19T21:36:26Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -217,7 +613,7 @@
       "title": "PII may land in raw and staging. It must not reach a mart or an exposure without a masking policy or an explicit, recorded waiver.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -230,7 +626,7 @@
       "title": "pii-not-in-consumption",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -249,6 +645,153 @@
             "semantic",
             "consumption"
           ]
+        },
+        "controls": [
+          "AIR-DET-16",
+          "AIR-PREV-12"
+        ],
+        "control_titles": {
+          "AIR-DET-16": "Preserving Source Data Access Controls in AI Systems",
+          "AIR-PREV-12": "Role-Based Access Control for AI Data"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-3-2",
+              "title": "ISO 42001: AI roles and responsibilities",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-3",
+              "title": "ISO 42001: Acquisition of data",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-9-2",
+              "title": "ISO 42001: Processes for responsible use of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-21",
+              "title": "AC-21 Information Sharing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A238%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C521.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ca-8",
+              "title": "CA-8 Penetration Testing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A351%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "cm-12",
+              "title": "CM-12 Information Location",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ia-2",
+              "title": "IA-2 Identification And Authentication (organizational Users)",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A467%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ia-4",
+              "title": "IA-4 Identifier Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A479%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C422.0%2C0%5D"
+            },
+            {
+              "key": "ia-5",
+              "title": "IA-5 Authenticator Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A485%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -258,8 +801,8 @@
       "title": "pf loop run pii-audit for pii-not-in-consumption",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:53:39Z",
-        "observed_at": "2026-08-16T23:53:39Z",
+        "created_at": "2026-08-19T21:36:26Z",
+        "observed_at": "2026-08-19T21:36:26Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "PII_findings",
@@ -283,8 +826,8 @@
       "title": "STATE.md for pii-not-in-consumption",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "observed_at": "2026-08-15T20:35:53Z",
+        "created_at": "2026-08-18T15:42:57Z",
+        "observed_at": "2026-08-18T15:42:57Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "open_findings",
@@ -308,7 +851,7 @@
       "title": "Grain is the one fact a downstream consumer cannot infer and cannot survive guessing. An undeclared grain is how a join silently fans out.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -321,7 +864,7 @@
       "title": "mart-declares-grain",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "SHOULD",
@@ -336,6 +879,98 @@
         },
         "params": {
           "field": "grain"
+        },
+        "controls": [
+          "AIR-DET-13"
+        ],
+        "control_titles": {
+          "AIR-DET-13": "Providing Citations and Source Traceability for AI-Generated Information"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t5-1",
+              "title": "Table 5.1: Disclosure of AI Use in Products and Services to End-Users",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=49"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-1-2",
+              "title": "ISO 42001: Objectives for responsible development of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-7",
+              "title": "ISO 42001: AI system technical documentation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-2",
+              "title": "ISO 42001: System documentation and information for users",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-10",
+              "title": "AU-10 Non-repudiation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A301%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-8",
+              "title": "SA-8 Security And Privacy Engineering Principles",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A842%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -345,8 +980,8 @@
       "title": "kg/context_card.md for mart-declares-grain",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:53:39Z",
-        "observed_at": "2026-08-16T23:53:39Z",
+        "created_at": "2026-08-19T21:36:25Z",
+        "observed_at": "2026-08-19T21:36:25Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "project_index",
@@ -370,7 +1005,7 @@
       "title": "Aggregation policy \u2014 which statuses count, which timestamp, which filter \u2014 belongs to exactly one metric definition. A mart column named `revenue` is a secon...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -383,7 +1018,7 @@
       "title": "metric-owns-aggregation",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "SHOULD",
@@ -404,6 +1039,98 @@
             "churn_rate",
             "ltv"
           ]
+        },
+        "controls": [
+          "AIR-DET-13"
+        ],
+        "control_titles": {
+          "AIR-DET-13": "Providing Citations and Source Traceability for AI-Generated Information"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t5-1",
+              "title": "Table 5.1: Disclosure of AI Use in Products and Services to End-Users",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=49"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-1-2",
+              "title": "ISO 42001: Objectives for responsible development of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-7",
+              "title": "ISO 42001: AI system technical documentation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-2",
+              "title": "ISO 42001: System documentation and information for users",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-10",
+              "title": "AU-10 Non-repudiation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A301%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-8",
+              "title": "SA-8 Security And Privacy Engineering Principles",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A842%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -413,8 +1140,8 @@
       "title": "pf check for metric-owns-aggregation",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:53:40Z",
-        "observed_at": "2026-08-16T23:53:40Z",
+        "created_at": "2026-08-19T21:36:27Z",
+        "observed_at": "2026-08-19T21:36:27Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -438,7 +1165,7 @@
       "title": "A model or column change must report what it breaks before it lands, including the human who owns each affected exposure.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -451,7 +1178,7 @@
       "title": "change-declares-blast-radius",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -464,7 +1191,158 @@
         "applies_to": {
           "artifact_glob": "**/transform/models/**"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-DET-21",
+          "AIR-PREV-18"
+        ],
+        "control_titles": {
+          "AIR-DET-21": "Agent Decision Audit and Explainability",
+          "AIR-PREV-18": "Agent Authority Least Privilege Framework"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00040",
+              "title": "ATR-2026-00040 Agent Privilege Escalation",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/privilege-escalation/ATR-2026-00040-privilege-escalation.yaml"
+            },
+            {
+              "key": "ATR-2026-00098",
+              "title": "ATR-2026-00098 Unauthorized Financial Action by Agent",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/excessive-autonomy/ATR-2026-00098-unauthorized-financial-action.yaml"
+            }
+          ],
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a12",
+              "title": "III.S2.A12: Record-Keeping",
+              "url": "https://artificialintelligenceact.eu/article/12/"
+            },
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c3-s3-a26",
+              "title": "III.S3.A26: Obligations of Deployers of High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/26/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -473,8 +1351,8 @@
       "title": "impact_reports for change-declares-blast-radius",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:53:40Z",
-        "observed_at": "2026-08-16T23:53:40Z",
+        "created_at": "2026-08-19T21:36:27Z",
+        "observed_at": "2026-08-19T21:36:27Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "blast_radius_history",
@@ -498,8 +1376,8 @@
       "title": "loop-ledger.json for change-declares-blast-radius",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "observed_at": "2026-08-15T20:35:53Z",
+        "created_at": "2026-08-19T20:47:22Z",
+        "observed_at": "2026-08-19T20:47:22Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "run_history",
@@ -523,7 +1401,7 @@
       "title": "A blast radius is a prediction made from lineage. Lineage cannot say whether the numbers actually moved, so a change to a mart must also be compared against ...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -536,7 +1414,7 @@
       "title": "change-verified-against-baseline",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "SHOULD",
@@ -549,7 +1427,94 @@
         "applies_to": {
           "artifact_glob": "**/transform/models/marts/**"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-PREV-5"
+        ],
+        "control_titles": {
+          "AIR-PREV-5": "System Acceptance Testing"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a15",
+              "title": "III.S2.A15: Accuracy, Robustness and Cybersecurity",
+              "url": "https://artificialintelligenceact.eu/article/15/"
+            },
+            {
+              "key": "c3-s2-a9",
+              "title": "III.S2.A9: Risk Management System",
+              "url": "https://artificialintelligenceact.eu/article/9/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-1",
+              "title": "Table 4.1: Assessment of Risk-Proportionate Controls",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=41"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-4",
+              "title": "ISO 42001: AI system verification and validation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-5",
+              "title": "ISO 42001: AI system deployment",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ca-2",
+              "title": "CA-2 Control Assessments",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A324%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C684%2C0%5D"
+            },
+            {
+              "key": "ca-6",
+              "title": "CA-6 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A339%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "cm-4",
+              "title": "CM-4 Impact Analyses",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A375%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C509.0%2C0%5D"
+            },
+            {
+              "key": "sa-11",
+              "title": "SA-11 Developer Testing And Evaluation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A899%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C601.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-2",
+              "title": "SI-2 Flaw Remediation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1070%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-6",
+              "title": "SI-6 Security And Privacy Function Verification",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1103%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C475.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -558,12 +1523,12 @@
       "title": "pf tool recce run for change-verified-against-baseline",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:56:40Z",
-        "observed_at": "2026-08-16T22:56:40Z",
+        "created_at": "2026-08-19T21:36:28Z",
+        "observed_at": "2026-08-19T21:36:28Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "data_diff_against_baseline",
-      "result": "pass",
+      "result": "unknown",
       "subjects": [
         {
           "id": "constraint.pf.change-verified-against-baseline",
@@ -574,7 +1539,7 @@
       "provenance": {
         "actor": "pf.projections.otop",
         "scope": "acme/acme-eu",
-        "detail": "groups/acme/projects/acme-eu/transform/recce_state.json"
+        "detail": "no baseline captured"
       }
     },
     {
@@ -583,7 +1548,7 @@
       "title": "A value-level diff writes the rows it compared into the review tool's state file, which is durable and shared. Diffing a column whose role is PII therefore p...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -596,7 +1561,7 @@
       "title": "review-artifacts-exclude-pii",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -609,7 +1574,194 @@
         "applies_to": {
           "artifact_glob": "**/transform/recce.yml"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-DET-1",
+          "AIR-PREV-12"
+        ],
+        "control_titles": {
+          "AIR-DET-1": "AI Data Leakage Prevention and Detection",
+          "AIR-PREV-12": "Role-Based Access Control for AI Data"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-3-2",
+              "title": "ISO 42001: AI roles and responsibilities",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-5-2",
+              "title": "ISO 42001: AI system impact assessment process",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-20",
+              "title": "AC-20 Use Of External Systems",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A232%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C598.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-13",
+              "title": "AU-13 Monitoring For Information Disclosure",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A310%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C556.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-3",
+              "title": "CA-3 Information Exchange",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A330%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C166.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-12",
+              "title": "CM-12 Information Location",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ia-2",
+              "title": "IA-2 Identification And Authentication (organizational Users)",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A467%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ia-4",
+              "title": "IA-4 Identifier Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A479%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C422.0%2C0%5D"
+            },
+            {
+              "key": "ia-5",
+              "title": "IA-5 Authenticator Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A485%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "ir-4",
+              "title": "IR-4 Incident Handling",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A527%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C626.0%2C0%5D"
+            },
+            {
+              "key": "ir-9",
+              "title": "IR-9 Information Spillage Response",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A548%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C135.0%2C0%5D"
+            },
+            {
+              "key": "mp-6",
+              "title": "MP-6 Media Sanitization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A593%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C314.0%2C0%5D"
+            },
+            {
+              "key": "sa-9",
+              "title": "SA-9 External System Services",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A884%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C665.0%2C0%5D"
+            },
+            {
+              "key": "sc-28",
+              "title": "SC-28 Protection Of Information AT Rest",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1019%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C191.0%2C0%5D"
+            },
+            {
+              "key": "sc-7",
+              "title": "SC-7 Boundary Protection",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A962%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C399.0%2C0%5D"
+            },
+            {
+              "key": "sc-8",
+              "title": "SC-8 Transmission Confidentiality And Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A983%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C223.0%2C0%5D"
+            },
+            {
+              "key": "si-20",
+              "title": "SI-20 Tainting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1151%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C232.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -618,8 +1770,8 @@
       "title": "pf tool recce config for review-artifacts-exclude-pii",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T20:38:47Z",
-        "observed_at": "2026-08-15T20:38:47Z",
+        "created_at": "2026-08-18T15:42:57Z",
+        "observed_at": "2026-08-18T15:42:57Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "derived_review_checks",
@@ -638,12 +1790,580 @@
       }
     },
     {
+      "id": "intent.pf.builds-record-observability",
+      "kind": "intent",
+      "title": "A dbt build that leaves no queryable record cannot be triaged; failures get diagnosed from whichever log happened to survive. Every build must record its run...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A dbt build that leaves no queryable record cannot be triaged; failures get diagnosed from whichever log happened to survive. Every build must record its run and test results into the warehouse with history \u2014 for every test framework at once \u2014 so \"is this new, recurring, or flaky?\" is a query, not an archaeology dig."
+      }
+    },
+    {
+      "id": "constraint.pf.builds-record-observability",
+      "kind": "constraint",
+      "title": "builds-record-observability",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "observability_recorded",
+      "checkability": "automated",
+      "assertion": "observability_recorded on artifact_glob=**/transform/packages.yml",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/transform/packages.yml"
+        },
+        "params": {},
+        "controls": [
+          "AIR-DET-4",
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-DET-4": "AI System Observability",
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t7-adoption",
+              "title": "Table 7: AI Adoption Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=57"
+            },
+            {
+              "key": "t7-nature",
+              "title": "Table 7: Nature and Use Cases of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            },
+            {
+              "key": "t7-performance",
+              "title": "Table 7: AI System Performance Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-8",
+              "title": "ISO 42001: AI system recording of event logs",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "au-11",
+              "title": "AU-11 Audit Record Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C462.0%2C0%5D"
+            },
+            {
+              "key": "au-12",
+              "title": "AU-12 Audit Record Generation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C122.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "ir-4",
+              "title": "IR-4 Incident Handling",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A527%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C626.0%2C0%5D"
+            },
+            {
+              "key": "ir-5",
+              "title": "IR-5 Incident Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A539%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C387%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-10",
+              "title": "RA-10 Threat Hunting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A812%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C110.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.builds-record-observability.pf-tool-elementary-report",
+      "kind": "evidence",
+      "title": "pf tool elementary report for builds-record-observability",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:29Z",
+        "observed_at": "2026-08-19T21:36:29Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "observability_report_over_recorded_history",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.builds-record-observability",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-eu",
+        "detail": "pf tool elementary report not produced yet"
+      }
+    },
+    {
+      "id": "evidence.pf.builds-record-observability.loop-ledger-json",
+      "kind": "evidence",
+      "title": "loop-ledger.json for builds-record-observability",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T20:47:22Z",
+        "observed_at": "2026-08-19T20:47:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "run_history",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.builds-record-observability",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-eu",
+        "detail": "loop-ledger.json"
+      }
+    },
+    {
+      "id": "intent.pf.quality-floor-derived-from-ontology",
+      "kind": "intent",
+      "title": "Hand-written test coverage decays to whichever models someone remembered. The floor \u2014 an annotated mart is never empty, a declared identity identifies \u2014 must...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Hand-written test coverage decays to whichever models someone remembered. The floor \u2014 an annotated mart is never empty, a declared identity identifies \u2014 must be derived from the ontology roles, so coverage is a function of annotation rather than of memory, and a wrong test is a wrong role rather than a stale file."
+      }
+    },
+    {
+      "id": "constraint.pf.quality-floor-derived-from-ontology",
+      "kind": "constraint",
+      "title": "quality-floor-derived-from-ontology",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "tests_derived_from_roles",
+      "checkability": "automated",
+      "assertion": "tests_derived_from_roles on artifact_glob=**/transform/tests/expectations/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/transform/tests/expectations/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-6",
+          "AIR-PREV-5"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity",
+          "AIR-PREV-5": "System Acceptance Testing"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            },
+            {
+              "key": "c3-s2-a15",
+              "title": "III.S2.A15: Accuracy, Robustness and Cybersecurity",
+              "url": "https://artificialintelligenceact.eu/article/15/"
+            },
+            {
+              "key": "c3-s2-a9",
+              "title": "III.S2.A9: Risk Management System",
+              "url": "https://artificialintelligenceact.eu/article/9/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-1",
+              "title": "Table 4.1: Assessment of Risk-Proportionate Controls",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=41"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-4",
+              "title": "ISO 42001: AI system verification and validation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-5",
+              "title": "ISO 42001: AI system deployment",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-2",
+              "title": "CA-2 Control Assessments",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A324%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C684%2C0%5D"
+            },
+            {
+              "key": "ca-6",
+              "title": "CA-6 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A339%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "cm-4",
+              "title": "CM-4 Impact Analyses",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A375%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C509.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-11",
+              "title": "SA-11 Developer Testing And Evaluation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A899%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C601.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-2",
+              "title": "SI-2 Flaw Remediation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1070%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-6",
+              "title": "SI-6 Security And Privacy Function Verification",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1103%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C475.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.quality-floor-derived-from-ontology.pf-tool-expectations-run",
+      "kind": "evidence",
+      "title": "pf tool expectations run for quality-floor-derived-from-ontology",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:29Z",
+        "observed_at": "2026-08-19T21:36:29Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "quality_floor_verdicts",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.quality-floor-derived-from-ontology",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-eu",
+        "detail": "pf tool expectations run not produced yet"
+      }
+    },
+    {
       "id": "intent.pf.secrets-never-in-context",
       "kind": "intent",
       "title": "A credential placed in a prompt, a model file or a committed artefact is durably persisted and replayed into every later session.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -656,7 +2376,7 @@
       "title": "secrets-never-in-context",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -669,7 +2389,131 @@
         "applies_to": {
           "artifact_glob": "**/secrets.toml"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-PREV-23",
+          "AIR-DET-16"
+        ],
+        "control_titles": {
+          "AIR-PREV-23": "Agentic System Credential Protection Framework",
+          "AIR-DET-16": "Preserving Source Data Access Controls in AI Systems"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00113",
+              "title": "ATR-2026-00113 Credential Theft via Agent Channel",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/context-exfiltration/ATR-2026-00113-credential-theft.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-3",
+              "title": "ISO 42001: Acquisition of data",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-9-2",
+              "title": "ISO 42001: Processes for responsible use of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-21",
+              "title": "AC-21 Information Sharing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A238%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C521.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ca-8",
+              "title": "CA-8 Penetration Testing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A351%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ia-5",
+              "title": "IA-5 Authenticator Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A485%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "sc-28",
+              "title": "SC-28 Protection Of Information AT Rest",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1019%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C191.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -678,8 +2522,8 @@
       "title": "pf gate for secrets-never-in-context",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:53:41Z",
-        "observed_at": "2026-08-16T23:53:41Z",
+        "created_at": "2026-08-19T21:36:30Z",
+        "observed_at": "2026-08-19T21:36:30Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "path_verdict",
@@ -698,23 +2542,1498 @@
       }
     },
     {
+      "id": "intent.pf.agent-authority-is-least-privilege",
+      "kind": "intent",
+      "title": "An agent reaches the filesystem through one path gate, and the paths it may never write are declared rather than remembered. Least privilege that lives in a ...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "An agent reaches the filesystem through one path gate, and the paths it may never write are declared rather than remembered. Least privilege that lives in a prompt is a request; in a denylist it is a control."
+      }
+    },
+    {
+      "id": "constraint.pf.agent-authority-is-least-privilege",
+      "kind": "constraint",
+      "title": "agent-authority-is-least-privilege",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "path_denied",
+      "checkability": "automated",
+      "assertion": "path_denied on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-18"
+        ],
+        "control_titles": {
+          "AIR-PREV-18": "Agent Authority Least Privilege Framework"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00040",
+              "title": "ATR-2026-00040 Agent Privilege Escalation",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/privilege-escalation/ATR-2026-00040-privilege-escalation.yaml"
+            },
+            {
+              "key": "ATR-2026-00098",
+              "title": "ATR-2026-00098 Unauthorized Financial Action by Agent",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/excessive-autonomy/ATR-2026-00098-unauthorized-financial-action.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.agent-authority-is-least-privilege.pf-gate",
+      "kind": "evidence",
+      "title": "pf gate for agent-authority-is-least-privilege",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:30Z",
+        "observed_at": "2026-08-19T21:36:30Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "path_verdict",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.agent-authority-is-least-privilege",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-eu",
+        "detail": "denylist present"
+      }
+    },
+    {
+      "id": "intent.pf.tool-contribution-may-only-tighten",
+      "kind": "intent",
+      "title": "A tool contributes gate rules, and a plugin system that can widen the policy judging it is not a policy. `Tool.gate_sections()` rejects a contribution to any...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A tool contributes gate rules, and a plugin system that can widen the policy judging it is not a policy. `Tool.gate_sections()` rejects a contribution to any loosening section at construction, so an unsafe tool fails at import rather than silently permitting more."
+      }
+    },
+    {
+      "id": "constraint.pf.tool-contribution-may-only-tighten",
+      "kind": "constraint",
+      "title": "tool-contribution-may-only-tighten",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "tightening_only",
+      "checkability": "automated",
+      "assertion": "tightening_only (sections=['denylist', 'platform_denylist', 'impact_required']) on artifact_glob=gate.capabilities.yaml",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "gate.capabilities.yaml"
+        },
+        "params": {
+          "sections": [
+            "denylist",
+            "platform_denylist",
+            "impact_required"
+          ]
+        },
+        "controls": [
+          "AIR-PREV-19"
+        ],
+        "control_titles": {
+          "AIR-PREV-19": "Tool Chain Validation and Sanitization"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00011",
+              "title": "ATR-2026-00011 Instruction Injection via Tool Output",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00011-tool-output-injection.yaml"
+            },
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00013",
+              "title": "ATR-2026-00013 Tool-Driven Server-Side Request Forgery",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00013-tool-ssrf.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "sc-4",
+              "title": "SC-4 Information In Shared System Resources",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A956%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-15",
+              "title": "SI-15 Information Output Filtering",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1136%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C355.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.tool-contribution-may-only-tighten.pf-check",
+      "kind": "evidence",
+      "title": "pf check for tool-contribution-may-only-tighten",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:31Z",
+        "observed_at": "2026-08-19T21:36:31Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "conformance_report",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.tool-contribution-may-only-tighten",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-eu",
+        "detail": "0 error(s), 0 issue(s)"
+      }
+    },
+    {
+      "id": "intent.pf.agent-decisions-are-recorded",
+      "kind": "intent",
+      "title": "Every tool call an agent makes is written down before it happens and after it happens, and the gate's verdict is recorded for allows as well as denies. \"No r...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Every tool call an agent makes is written down before it happens and after it happens, and the gate's verdict is recorded for allows as well as denies. \"No rule applied\" and \"a rule allowed it\" are different facts, and only a record that carries both can answer what an agent was permitted to do."
+      }
+    },
+    {
+      "id": "constraint.pf.agent-decisions-are-recorded",
+      "kind": "constraint",
+      "title": "agent-decisions-are-recorded",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "action_recorded",
+      "checkability": "automated",
+      "assertion": "action_recorded (stages=['intent', 'decision', 'execution']) on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {
+          "stages": [
+            "intent",
+            "decision",
+            "execution"
+          ]
+        },
+        "controls": [
+          "AIR-DET-21",
+          "AIR-DET-4"
+        ],
+        "control_titles": {
+          "AIR-DET-21": "Agent Decision Audit and Explainability",
+          "AIR-DET-4": "AI System Observability"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a12",
+              "title": "III.S2.A12: Record-Keeping",
+              "url": "https://artificialintelligenceact.eu/article/12/"
+            },
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c3-s3-a26",
+              "title": "III.S3.A26: Obligations of Deployers of High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/26/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t7-adoption",
+              "title": "Table 7: AI Adoption Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=57"
+            },
+            {
+              "key": "t7-nature",
+              "title": "Table 7: Nature and Use Cases of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            },
+            {
+              "key": "t7-performance",
+              "title": "Table 7: AI System Performance Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-8",
+              "title": "ISO 42001: AI system recording of event logs",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-11",
+              "title": "AU-11 Audit Record Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C462.0%2C0%5D"
+            },
+            {
+              "key": "au-12",
+              "title": "AU-12 Audit Record Generation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C122.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ir-4",
+              "title": "IR-4 Incident Handling",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A527%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C626.0%2C0%5D"
+            },
+            {
+              "key": "ir-5",
+              "title": "IR-5 Incident Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A539%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C387%2C0%5D"
+            },
+            {
+              "key": "ra-10",
+              "title": "RA-10 Threat Hunting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A812%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C110.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.agent-decisions-are-recorded.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for agent-decisions-are-recorded",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:31Z",
+        "observed_at": "2026-08-19T21:36:31Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.agent-decisions-are-recorded",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-eu",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.evidence-chain-is-tamper-evident",
+      "kind": "intent",
+      "title": "A log an agent can edit is not evidence. Each record carries the hash of the one before it, and the head is anchored to a timestamp authority with no stake i...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A log an agent can edit is not evidence. Each record carries the hash of the one before it, and the head is anchored to a timestamp authority with no stake in what it says \u2014 so editing the middle requires editing the end, and the end is countersigned."
+      }
+    },
+    {
+      "id": "constraint.pf.evidence-chain-is-tamper-evident",
+      "kind": "constraint",
+      "title": "evidence-chain-is-tamper-evident",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "hash_chained",
+      "checkability": "automated",
+      "assertion": "hash_chained on artifact_glob=provenance/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "provenance/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-DET-21"
+        ],
+        "control_titles": {
+          "AIR-DET-21": "Agent Decision Audit and Explainability"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a12",
+              "title": "III.S2.A12: Record-Keeping",
+              "url": "https://artificialintelligenceact.eu/article/12/"
+            },
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c3-s3-a26",
+              "title": "III.S3.A26: Obligations of Deployers of High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/26/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.evidence-chain-is-tamper-evident.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for evidence-chain-is-tamper-evident",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:32Z",
+        "observed_at": "2026-08-19T21:36:32Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.evidence-chain-is-tamper-evident",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-eu",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.sister-projects-are-isolated",
+      "kind": "intent",
+      "title": "Business logic does not transfer between entities, so an assumption carried from one sister company into another is a bug by construction. A project session ...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Business logic does not transfer between entities, so an assumption carried from one sister company into another is a bug by construction. A project session may not read or write another project, and may not write shared infra at all."
+      }
+    },
+    {
+      "id": "constraint.pf.sister-projects-are-isolated",
+      "kind": "constraint",
+      "title": "sister-projects-are-isolated",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "cross_tenant_denied",
+      "checkability": "automated",
+      "assertion": "cross_tenant_denied on artifact_glob=groups/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "groups/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-22"
+        ],
+        "control_titles": {
+          "AIR-PREV-22": "Multi-Agent Isolation and Segmentation"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00030",
+              "title": "ATR-2026-00030 Cross-Agent Attack Detection",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/agent-manipulation/ATR-2026-00030-cross-agent-attack.yaml"
+            },
+            {
+              "key": "ATR-2026-00076",
+              "title": "ATR-2026-00076 Insecure Inter-Agent Communication",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/agent-manipulation/ATR-2026-00076-inter-agent-message-spoofing.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "sc-3",
+              "title": "SC-3 Security Function Isolation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A950%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C217.0%2C0%5D"
+            },
+            {
+              "key": "sc-32",
+              "title": "SC-32 System Partitioning",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1031%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C227.0%2C0%5D"
+            },
+            {
+              "key": "sc-7",
+              "title": "SC-7 Boundary Protection",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A962%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C399.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.sister-projects-are-isolated.pf-gate",
+      "kind": "evidence",
+      "title": "pf gate for sister-projects-are-isolated",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:32Z",
+        "observed_at": "2026-08-19T21:36:32Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "path_verdict",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.sister-projects-are-isolated",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-eu",
+        "detail": "denylist present"
+      }
+    },
+    {
+      "id": "intent.pf.agent-authority-is-revocable",
+      "kind": "intent",
+      "title": "A control that cannot be switched off mid-incident is a control you find out about afterwards. Revocation is checked before intent is written, and an unreada...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A control that cannot be switched off mid-incident is a control you find out about afterwards. Revocation is checked before intent is written, and an unreadable revocation file fails closed."
+      }
+    },
+    {
+      "id": "constraint.pf.agent-authority-is-revocable",
+      "kind": "constraint",
+      "title": "agent-authority-is-revocable",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "revocable",
+      "checkability": "automated",
+      "assertion": "revocable on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-18"
+        ],
+        "control_titles": {
+          "AIR-PREV-18": "Agent Authority Least Privilege Framework"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00040",
+              "title": "ATR-2026-00040 Agent Privilege Escalation",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/privilege-escalation/ATR-2026-00040-privilege-escalation.yaml"
+            },
+            {
+              "key": "ATR-2026-00098",
+              "title": "ATR-2026-00098 Unauthorized Financial Action by Agent",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/excessive-autonomy/ATR-2026-00098-unauthorized-financial-action.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.agent-authority-is-revocable.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for agent-authority-is-revocable",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:32Z",
+        "observed_at": "2026-08-19T21:36:32Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.agent-authority-is-revocable",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-eu",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.high-impact-actions-need-a-human",
+      "kind": "intent",
+      "title": "Human oversight is a chain that shows the approval, not a document that asserts it. Approvals are append-only and bound to the action they approve, and an ac...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Human oversight is a chain that shows the approval, not a document that asserts it. Approvals are append-only and bound to the action they approve, and an actor approving their own action is a finding rather than an approval."
+      }
+    },
+    {
+      "id": "constraint.pf.high-impact-actions-need-a-human",
+      "kind": "constraint",
+      "title": "high-impact-actions-need-a-human",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "approval_recorded",
+      "checkability": "automated",
+      "assertion": "approval_recorded on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-DET-11"
+        ],
+        "control_titles": {
+          "AIR-DET-11": "Human Feedback Loop for AI Systems"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a14",
+              "title": "III.S2.A14: Human Oversight",
+              "url": "https://artificialintelligenceact.eu/article/14/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-3-3",
+              "title": "ISO 42001: Reporting of concerns",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-2",
+              "title": "ISO 42001: System documentation and information for users",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ca-2",
+              "title": "CA-2 Control Assessments",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A324%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C684%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ir-6",
+              "title": "IR-6 Incident Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A542%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "pm-26",
+              "title": "PM-26 Complaint Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A722%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C365.0%2C0%5D"
+            },
+            {
+              "key": "ra-5",
+              "title": "RA-5 Vulnerability Monitoring And Scanning",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A797%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C594.0%2C0%5D"
+            },
+            {
+              "key": "si-2",
+              "title": "SI-2 Flaw Remediation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1070%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.high-impact-actions-need-a-human.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for high-impact-actions-need-a-human",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:33Z",
+        "observed_at": "2026-08-19T21:36:33Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.high-impact-actions-need-a-human",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-eu",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.model-routing-is-declared",
+      "kind": "intent",
+      "title": "Which model answers which step is a declared table, not whatever the caller passed. An unregistered step is recorded as such, and the recorded verdict matche...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Which model answers which step is a declared table, not whatever the caller passed. An unregistered step is recorded as such, and the recorded verdict matches what actually happened rather than what policy would have preferred."
+      }
+    },
+    {
+      "id": "constraint.pf.model-routing-is-declared",
+      "kind": "constraint",
+      "title": "model-routing-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "routing_declared",
+      "checkability": "automated",
+      "assertion": "routing_declared on artifact_glob=**/agents/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/agents/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-10"
+        ],
+        "control_titles": {
+          "AIR-PREV-10": "AI Model Version Pinning"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-4",
+              "title": "ISO 42001: Tooling resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-3",
+              "title": "ISO 42001: Documentation of AI system design and development",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-5",
+              "title": "ISO 42001: AI system deployment",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "cm-2",
+              "title": "CM-2 Baseline Configuration",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A363%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "cm-3",
+              "title": "CM-3 Configuration Change Control",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A366%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C205.0%2C0%5D"
+            },
+            {
+              "key": "cm-4",
+              "title": "CM-4 Impact Analyses",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A375%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C509.0%2C0%5D"
+            },
+            {
+              "key": "cm-8",
+              "title": "CM-8 System Component Inventory",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A393%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C197.0%2C0%5D"
+            },
+            {
+              "key": "sa-10",
+              "title": "SA-10 Developer Configuration Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A890%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C211.0%2C0%5D"
+            },
+            {
+              "key": "sa-22",
+              "title": "SA-22 Unsupported System Components",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A941%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C497.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sr-4",
+              "title": "SR-4 Provenance",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1169%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C257.0%2C0%5D"
+            },
+            {
+              "key": "sr-8",
+              "title": "SR-8 Notification Agreements",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1184%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C620.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.model-routing-is-declared.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for model-routing-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:33Z",
+        "observed_at": "2026-08-19T21:36:33Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.model-routing-is-declared",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-eu",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.upstream-licences-are-reviewed",
+      "kind": "intent",
+      "title": "Every upstream this platform borrowed from carries a licence, and some of them constrain what we may ship. The review is written down per upstream and surfac...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Every upstream this platform borrowed from carries a licence, and some of them constrain what we may ship. The review is written down per upstream and surfaced in the listing, so a constraint is a fact in the registry rather than something someone once checked."
+      }
+    },
+    {
+      "id": "constraint.pf.upstream-licences-are-reviewed",
+      "kind": "constraint",
+      "title": "upstream-licences-are-reviewed",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "licence_reviewed",
+      "checkability": "automated",
+      "assertion": "licence_reviewed on artifact_glob=vendor/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "vendor/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-7"
+        ],
+        "control_titles": {
+          "AIR-PREV-7": "Legal and Contractual Frameworks for AI Systems"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t4-1",
+              "title": "Table 4.1: Assessment of Risk-Proportionate Controls",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=41"
+            },
+            {
+              "key": "t4-7",
+              "title": "Table 4.7: Legal Framework and Accountability",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=44"
+            },
+            {
+              "key": "t7-third-party",
+              "title": "Table 7: Third-Party Dependencies and Concentrations",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-10-2",
+              "title": "ISO 42001: Allocating responsibilities",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-10-3",
+              "title": "ISO 42001: Suppliers",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-2-3",
+              "title": "ISO 42001: Alignment with other organizational policies",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-5",
+              "title": "ISO 42001: Information for interested parties",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-20",
+              "title": "AC-20 Use Of External Systems",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A232%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C598.0%2C0%5D"
+            },
+            {
+              "key": "ca-3",
+              "title": "CA-3 Information Exchange",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A330%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C166.0%2C0%5D"
+            },
+            {
+              "key": "ir-6",
+              "title": "IR-6 Incident Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A542%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "pm-30",
+              "title": "PM-30 Supply Chain Risk Management Strategy",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A728%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C427.0%2C0%5D"
+            },
+            {
+              "key": "ps-7",
+              "title": "PS-7 External Personnel Security",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A752%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C623.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-9",
+              "title": "SA-9 External System Services",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A884%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C665.0%2C0%5D"
+            },
+            {
+              "key": "sr-2",
+              "title": "SR-2 Supply Chain Risk Management Plan",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1163%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C684.0%2C0%5D"
+            },
+            {
+              "key": "sr-3",
+              "title": "SR-3 Supply Chain Controls And Processes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1166%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C440.0%2C0%5D"
+            },
+            {
+              "key": "sr-5",
+              "title": "SR-5 Acquisition Strategies, Tools, And Methods",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1175%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C243.0%2C0%5D"
+            },
+            {
+              "key": "sr-8",
+              "title": "SR-8 Notification Agreements",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1184%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C620.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.upstream-licences-are-reviewed.pf-check",
+      "kind": "evidence",
+      "title": "pf check for upstream-licences-are-reviewed",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:34Z",
+        "observed_at": "2026-08-19T21:36:34Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "conformance_report",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.upstream-licences-are-reviewed",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-eu",
+        "detail": "0 error(s), 0 issue(s)"
+      }
+    },
+    {
+      "id": "intent.pf.control-baseline-is-declared",
+      "kind": "intent",
+      "title": "A risk register that names controls nobody enforces is a document. Each entity declares in `air.yaml` which controls it commits to; those are derived from th...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A risk register that names controls nobody enforces is a document. Each entity declares in `air.yaml` which controls it commits to; those are derived from the repository on every run and block the merge when they fail, while everything outside the baseline is reported and does not."
+      }
+    },
+    {
+      "id": "constraint.pf.control-baseline-is-declared",
+      "kind": "constraint",
+      "title": "control-baseline-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "baseline_declared",
+      "checkability": "automated",
+      "assertion": "baseline_declared on artifact_glob=**/air.yaml",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/air.yaml"
+        },
+        "params": {}
+      }
+    },
+    {
+      "id": "evidence.pf.control-baseline-is-declared.pf-air-coverage",
+      "kind": "evidence",
+      "title": "pf air coverage for control-baseline-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:34Z",
+        "observed_at": "2026-08-19T21:36:34Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "control_coverage_verdicts",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.control-baseline-is-declared",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-eu",
+        "detail": "pf air coverage not produced yet"
+      }
+    },
+    {
+      "id": "evidence.pf.control-baseline-is-declared.governance-air-register-md",
+      "kind": "evidence",
+      "title": "governance/air-register.md for control-baseline-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:20Z",
+        "observed_at": "2026-08-19T18:05:20Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "per-entity_risk_register",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.control-baseline-is-declared",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-eu",
+        "detail": "groups/acme/projects/acme-eu/governance/air-register.md"
+      }
+    },
+    {
       "id": "artifact.pf.pf.ontology.validate.money-without-currency",
       "kind": "artifact",
       "title": "pf.ontology.validate:money-without-currency",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "money-without-currency",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -726,18 +4045,18 @@
       "title": "pf.ontology.validate:class-without-identity",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "class-without-identity",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -749,18 +4068,18 @@
       "title": "pf.ontology.validate:illegal-edge",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "illegal-edge",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -772,18 +4091,18 @@
       "title": "pf.loops.registry:pii_audit",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T02:49:37Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "loop",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/loops/registry.py",
         "language": "python",
         "symbol": "pii_audit",
-        "digest": "git:293a23d6448c5fe70cee7c96a01f2690d8af47c2"
+        "digest": "git:e81ff725c18b4ff2a8187f5fb953a9dc003a56f4"
       },
       "extensions": {
         "exists": true
@@ -795,18 +4114,18 @@
       "title": "pf.kg.build:model-grain",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T02:04:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/kg/build.py",
         "language": "python",
         "symbol": "model-grain",
-        "digest": "git:2c8398b8a1246d27395ac2140ceba10eea0d3072"
+        "digest": "git:db169407ccb59827ce7f3c5932b2b4a0d40e1124"
       },
       "extensions": {
         "exists": true
@@ -818,18 +4137,18 @@
       "title": "pf.ontology.validate:metric-shaped-column",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "metric-shaped-column",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -841,17 +4160,17 @@
       "title": "platform/hooks/pre_tool_use.py",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T00:11:17Z",
+        "created_at": "2026-08-18T18:40:22Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "hook",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/hooks/pre_tool_use.py",
         "language": "python",
-        "digest": "git:2cb586ed58222bcb50e9cd0013d536cb2c9e6856"
+        "digest": "git:230bc9d9639eaa71c8c511affccb14881cdfc1f1"
       },
       "extensions": {
         "exists": true
@@ -863,14 +4182,14 @@
       "title": "platform/hooks/pre_commit.sh",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-12T16:06:37Z",
+        "created_at": "2026-08-12T14:06:37Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "hook",
       "language": "bash",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/hooks/pre_commit.sh",
         "language": "bash",
         "digest": "git:ce8e6f322ce15a546c16d2eb25bddf4fab5b6688"
@@ -885,18 +4204,18 @@
       "title": "pf.tools.recce:dagster_assets",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:50:23Z",
+        "created_at": "2026-08-17T23:50:05Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/tools/recce.py",
         "language": "python",
         "symbol": "dagster_assets",
-        "digest": "git:8a560994bb5a994b5a57b37a07f99114656b18a3"
+        "digest": "git:6d6c7a4515c5aa68b9642ca221805c28a15f4fc1"
       },
       "extensions": {
         "exists": true
@@ -908,18 +4227,18 @@
       "title": "pf.tools.recce:register_commands",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:50:23Z",
+        "created_at": "2026-08-17T23:50:05Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/tools/recce.py",
         "language": "python",
         "symbol": "register_commands",
-        "digest": "git:8a560994bb5a994b5a57b37a07f99114656b18a3"
+        "digest": "git:6d6c7a4515c5aa68b9642ca221805c28a15f4fc1"
       },
       "extensions": {
         "exists": true
@@ -931,18 +4250,18 @@
       "title": "pf.ontology.model:Role.review_intent",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T22:35:09Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/model.py",
         "language": "python",
         "symbol": "Role.review_intent",
-        "digest": "git:3e691a864da03459b04489a674bbba0a1839b1ea"
+        "digest": "git:513888ee8c2df8cfa1d09562ad3dc2793c4f741e"
       },
       "extensions": {
         "exists": true
@@ -954,18 +4273,106 @@
       "title": "pf.tools.recce:generate_config",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:50:23Z",
+        "created_at": "2026-08-17T23:50:05Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/tools/recce.py",
         "language": "python",
         "symbol": "generate_config",
-        "digest": "git:8a560994bb5a994b5a57b37a07f99114656b18a3"
+        "digest": "git:6d6c7a4515c5aa68b9642ca221805c28a15f4fc1"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.elementary.bootstrap-project",
+      "kind": "artifact",
+      "title": "pf.tools.elementary:bootstrap_project",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:29Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/elementary.py",
+        "language": "python",
+        "symbol": "bootstrap_project"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.elementary.ensure-package",
+      "kind": "artifact",
+      "title": "pf.tools.elementary:ensure_package",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:29Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/elementary.py",
+        "language": "python",
+        "symbol": "ensure_package"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.expectations.write-tests",
+      "kind": "artifact",
+      "title": "pf.tools.expectations:write_tests",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:29Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/expectations.py",
+        "language": "python",
+        "symbol": "write_tests"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.expectations.bootstrap-project",
+      "kind": "artifact",
+      "title": "pf.tools.expectations:bootstrap_project",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:29Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/expectations.py",
+        "language": "python",
+        "symbol": "bootstrap_project"
       },
       "extensions": {
         "exists": true
@@ -977,18 +4384,408 @@
       "title": "gate.yaml:denylist",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-17T00:38:30Z",
+        "created_at": "2026-08-18T18:40:22Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "configuration",
       "language": "yaml",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "gate.yaml",
         "language": "yaml",
         "symbol": "denylist",
-        "digest": "git:f0f6dc9c2d8e60c371d7df8c8a9af65e9571c965"
+        "digest": "git:7d51894f5fdae49fa67534d8359ac34a48175bc8"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.gate.yaml.platform-denylist",
+      "kind": "artifact",
+      "title": "gate.yaml:platform_denylist",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "configuration",
+      "language": "yaml",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "gate.yaml",
+        "language": "yaml",
+        "symbol": "platform_denylist",
+        "digest": "git:7d51894f5fdae49fa67534d8359ac34a48175bc8"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.loops.gate.check-path",
+      "kind": "artifact",
+      "title": "pf.loops.gate:check_path",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-15T05:28:10Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "loop",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/loops/gate.py",
+        "language": "python",
+        "symbol": "check_path",
+        "digest": "git:0e0d5d990b04901c47b39e09bf783eb4a8821183"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.spec.Tool.gate-sections",
+      "kind": "artifact",
+      "title": "pf.tools.spec:Tool.gate_sections",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-17T23:50:05Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/spec.py",
+        "language": "python",
+        "symbol": "Tool.gate_sections",
+        "digest": "git:3b36976709eb70b17628d2c2228e4e398ed2df05"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.decision",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:decision",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "decision",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.platform.hooks.post-tool-use.py",
+      "kind": "artifact",
+      "title": "platform/hooks/post_tool_use.py",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "hook",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/hooks/post_tool_use.py",
+        "language": "python",
+        "digest": "git:99dc8363fbb485907c66034f6c6fefdc51336650"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.chain.verify",
+      "kind": "artifact",
+      "title": "pf.provenance.chain:verify",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/chain.py",
+        "language": "python",
+        "symbol": "verify",
+        "digest": "git:07d2c60e49bda58cd6b9d51534b3417cec91777c"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.anchor.stamp-rfc3161",
+      "kind": "artifact",
+      "title": "pf.provenance.anchor:stamp_rfc3161",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/anchor.py",
+        "language": "python",
+        "symbol": "stamp_rfc3161",
+        "digest": "git:a38a0c14b0286745dbe157807967085d044af606"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.loops.gate.project-for",
+      "kind": "artifact",
+      "title": "pf.loops.gate:project_for",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-15T05:28:10Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "loop",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/loops/gate.py",
+        "language": "python",
+        "symbol": "project_for",
+        "digest": "git:0e0d5d990b04901c47b39e09bf783eb4a8821183"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.revoke",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:revoke",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "revoke",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.is-revoked",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:is_revoked",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "is_revoked",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.approve",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:approve",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "approve",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.audit.report",
+      "kind": "artifact",
+      "title": "pf.provenance.audit:report",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/audit.py",
+        "language": "python",
+        "symbol": "report",
+        "digest": "git:048a4041043b8b6d2628b0f97929752c079fb95e"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.agents.base.AGENTS",
+      "kind": "artifact",
+      "title": "pf.agents.base:AGENTS",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/agents/base.py",
+        "language": "python",
+        "symbol": "AGENTS",
+        "digest": "git:21365423e93b1c6427aa7dbf6dbb2823993e42c2"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.vendor.model.load-registry",
+      "kind": "artifact",
+      "title": "pf.vendor.model:load_registry",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-13T01:11:58Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/vendor/model.py",
+        "language": "python",
+        "symbol": "load_registry",
+        "digest": "git:3364fcfb711181efa434a9fe7024e4dcc01984df"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.vendor.verify.verify",
+      "kind": "artifact",
+      "title": "pf.vendor.verify:verify",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/vendor/verify.py",
+        "language": "python",
+        "symbol": "verify",
+        "digest": "git:4b39f17a26d3f030c4f2ef101c60a502c2f9ccfb"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.air.coverage.assess",
+      "kind": "artifact",
+      "title": "pf.air.coverage:assess",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/air/coverage.py",
+        "language": "python",
+        "symbol": "assess",
+        "digest": "git:fd67a5e7eeec7fdfe079c96e066992764601c00f"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.air.register.render-register",
+      "kind": "artifact",
+      "title": "pf.air.register:render_register",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/air/register.py",
+        "language": "python",
+        "symbol": "render_register",
+        "digest": "git:c45d0bbbe459fadea3ab3edfbf96beb6db505f25"
       },
       "extensions": {
         "exists": true
@@ -1002,7 +4799,7 @@
       "to": "intent.pf.money-requires-currency",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1013,7 +4810,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1022,8 +4819,8 @@
       "to": "artifact.pf.pf.ontology.validate.money-without-currency",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1032,8 +4829,8 @@
       "to": "evidence.pf.money-requires-currency.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:53:39Z",
-        "verified_at": "2026-08-16T23:53:39Z"
+        "created_at": "2026-08-19T21:36:25Z",
+        "verified_at": "2026-08-19T21:36:25Z"
       }
     },
     {
@@ -1042,7 +4839,7 @@
       "to": "intent.pf.entity-requires-identity",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1053,7 +4850,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1062,8 +4859,8 @@
       "to": "artifact.pf.pf.ontology.validate.class-without-identity",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1072,8 +4869,8 @@
       "to": "evidence.pf.entity-requires-identity.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:53:39Z",
-        "verified_at": "2026-08-16T23:53:39Z"
+        "created_at": "2026-08-19T21:36:26Z",
+        "verified_at": "2026-08-19T21:36:26Z"
       }
     },
     {
@@ -1082,7 +4879,7 @@
       "to": "intent.pf.link-must-be-in-topology",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1093,7 +4890,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1102,8 +4899,8 @@
       "to": "artifact.pf.pf.ontology.validate.illegal-edge",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1112,8 +4909,8 @@
       "to": "evidence.pf.link-must-be-in-topology.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:53:39Z",
-        "verified_at": "2026-08-16T23:53:39Z"
+        "created_at": "2026-08-19T21:36:26Z",
+        "verified_at": "2026-08-19T21:36:26Z"
       }
     },
     {
@@ -1122,7 +4919,7 @@
       "to": "intent.pf.pii-not-in-consumption",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1133,7 +4930,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1142,8 +4939,8 @@
       "to": "artifact.pf.pf.loops.registry.pii-audit",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1152,8 +4949,8 @@
       "to": "evidence.pf.pii-not-in-consumption.pf-loop-run-pii-audit",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:53:39Z",
-        "verified_at": "2026-08-16T23:53:39Z"
+        "created_at": "2026-08-19T21:36:26Z",
+        "verified_at": "2026-08-19T21:36:26Z"
       }
     },
     {
@@ -1162,8 +4959,8 @@
       "to": "evidence.pf.pii-not-in-consumption.state-md",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "verified_at": "2026-08-15T20:35:53Z"
+        "created_at": "2026-08-18T15:42:57Z",
+        "verified_at": "2026-08-18T15:42:57Z"
       }
     },
     {
@@ -1172,7 +4969,7 @@
       "to": "intent.pf.mart-declares-grain",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1183,7 +4980,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1192,8 +4989,8 @@
       "to": "artifact.pf.pf.kg.build.model-grain",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1202,8 +4999,8 @@
       "to": "evidence.pf.mart-declares-grain.kg-context-card-md",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:53:39Z",
-        "verified_at": "2026-08-16T23:53:39Z"
+        "created_at": "2026-08-19T21:36:25Z",
+        "verified_at": "2026-08-19T21:36:25Z"
       }
     },
     {
@@ -1212,7 +5009,7 @@
       "to": "intent.pf.metric-owns-aggregation",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1223,7 +5020,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1232,8 +5029,8 @@
       "to": "artifact.pf.pf.ontology.validate.metric-shaped-column",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1242,8 +5039,8 @@
       "to": "evidence.pf.metric-owns-aggregation.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:53:40Z",
-        "verified_at": "2026-08-16T23:53:40Z"
+        "created_at": "2026-08-19T21:36:27Z",
+        "verified_at": "2026-08-19T21:36:27Z"
       }
     },
     {
@@ -1252,7 +5049,7 @@
       "to": "intent.pf.change-declares-blast-radius",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1263,7 +5060,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1272,8 +5069,8 @@
       "to": "artifact.pf.platform.hooks.pre-tool-use.py",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1282,8 +5079,8 @@
       "to": "artifact.pf.platform.hooks.pre-commit.sh",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1292,8 +5089,8 @@
       "to": "evidence.pf.change-declares-blast-radius.impact-reports",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:53:40Z",
-        "verified_at": "2026-08-16T23:53:40Z"
+        "created_at": "2026-08-19T21:36:27Z",
+        "verified_at": "2026-08-19T21:36:27Z"
       }
     },
     {
@@ -1302,8 +5099,8 @@
       "to": "evidence.pf.change-declares-blast-radius.loop-ledger-json",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "verified_at": "2026-08-15T20:35:53Z"
+        "created_at": "2026-08-19T20:47:22Z",
+        "verified_at": "2026-08-19T20:47:22Z"
       }
     },
     {
@@ -1312,7 +5109,7 @@
       "to": "intent.pf.change-verified-against-baseline",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1323,7 +5120,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1332,8 +5129,8 @@
       "to": "artifact.pf.pf.tools.recce.dagster-assets",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1342,8 +5139,8 @@
       "to": "artifact.pf.pf.tools.recce.register-commands",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1352,8 +5149,8 @@
       "to": "evidence.pf.change-verified-against-baseline.pf-tool-recce-run",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T22:56:40Z",
-        "verified_at": "2026-08-16T22:56:40Z"
+        "created_at": "2026-08-19T21:36:28Z",
+        "verified_at": "2026-08-19T21:36:28Z"
       }
     },
     {
@@ -1362,7 +5159,7 @@
       "to": "intent.pf.review-artifacts-exclude-pii",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1373,7 +5170,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1382,8 +5179,8 @@
       "to": "artifact.pf.pf.ontology.model.Role.review-intent",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1392,8 +5189,8 @@
       "to": "artifact.pf.pf.tools.recce.generate-config",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1402,8 +5199,118 @@
       "to": "evidence.pf.review-artifacts-exclude-pii.pf-tool-recce-config",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-15T20:38:47Z",
-        "verified_at": "2026-08-15T20:38:47Z"
+        "created_at": "2026-08-18T15:42:57Z",
+        "verified_at": "2026-08-18T15:42:57Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.derived-from.intent.pf.builds-record-observability",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "intent.pf.builds-record-observability",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.implemented-by.artifact.pf.pf.tools.elementary.bootstrap-project",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "artifact.pf.pf.tools.elementary.bootstrap-project",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.implemented-by.artifact.pf.pf.tools.elementary.ensure-package",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "artifact.pf.pf.tools.elementary.ensure-package",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.verified-by.evidence.pf.builds-record-observability.pf-tool-elementary-report",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "evidence.pf.builds-record-observability.pf-tool-elementary-report",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:29Z",
+        "verified_at": "2026-08-19T21:36:29Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.verified-by.evidence.pf.builds-record-observability.loop-ledger-json",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "evidence.pf.builds-record-observability.loop-ledger-json",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T20:47:22Z",
+        "verified_at": "2026-08-19T20:47:22Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.derived-from.intent.pf.quality-floor-derived-from-ontology",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "intent.pf.quality-floor-derived-from-ontology",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.implemented-by.artifact.pf.pf.tools.expectations.write-tests",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "artifact.pf.pf.tools.expectations.write-tests",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.implemented-by.artifact.pf.pf.tools.expectations.bootstrap-project",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "artifact.pf.pf.tools.expectations.bootstrap-project",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.verified-by.evidence.pf.quality-floor-derived-from-ontology.pf-tool-expectations-run",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "evidence.pf.quality-floor-derived-from-ontology.pf-tool-expectations-run",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:29Z",
+        "verified_at": "2026-08-19T21:36:29Z"
       }
     },
     {
@@ -1412,7 +5319,7 @@
       "to": "intent.pf.secrets-never-in-context",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1423,7 +5330,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1432,8 +5339,8 @@
       "to": "artifact.pf.gate.yaml.denylist",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1442,8 +5349,8 @@
       "to": "artifact.pf.platform.hooks.pre-tool-use.py",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1452,8 +5359,528 @@
       "to": "evidence.pf.secrets-never-in-context.pf-gate",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:53:41Z",
-        "verified_at": "2026-08-16T23:53:41Z"
+        "created_at": "2026-08-19T21:36:30Z",
+        "verified_at": "2026-08-19T21:36:30Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.derived-from.intent.pf.agent-authority-is-least-privilege",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "intent.pf.agent-authority-is-least-privilege",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.implemented-by.artifact.pf.gate.yaml.denylist",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "artifact.pf.gate.yaml.denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.implemented-by.artifact.pf.gate.yaml.platform-denylist",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "artifact.pf.gate.yaml.platform-denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.implemented-by.artifact.pf.pf.loops.gate.check-path",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "artifact.pf.pf.loops.gate.check-path",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.verified-by.evidence.pf.agent-authority-is-least-privilege.pf-gate",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "evidence.pf.agent-authority-is-least-privilege.pf-gate",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:30Z",
+        "verified_at": "2026-08-19T21:36:30Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.derived-from.intent.pf.tool-contribution-may-only-tighten",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "intent.pf.tool-contribution-may-only-tighten",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.implemented-by.artifact.pf.pf.tools.spec.Tool.gate-sections",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "artifact.pf.pf.tools.spec.Tool.gate-sections",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.verified-by.evidence.pf.tool-contribution-may-only-tighten.pf-check",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "evidence.pf.tool-contribution-may-only-tighten.pf-check",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:31Z",
+        "verified_at": "2026-08-19T21:36:31Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.derived-from.intent.pf.agent-decisions-are-recorded",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "intent.pf.agent-decisions-are-recorded",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.implemented-by.artifact.pf.pf.provenance.ledger.decision",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "artifact.pf.pf.provenance.ledger.decision",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.implemented-by.artifact.pf.platform.hooks.pre-tool-use.py",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "artifact.pf.platform.hooks.pre-tool-use.py",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.implemented-by.artifact.pf.platform.hooks.post-tool-use.py",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "artifact.pf.platform.hooks.post-tool-use.py",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.verified-by.evidence.pf.agent-decisions-are-recorded.pf-provenance-verify",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "evidence.pf.agent-decisions-are-recorded.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:31Z",
+        "verified_at": "2026-08-19T21:36:31Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.derived-from.intent.pf.evidence-chain-is-tamper-evident",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "intent.pf.evidence-chain-is-tamper-evident",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.implemented-by.artifact.pf.pf.provenance.chain.verify",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "artifact.pf.pf.provenance.chain.verify",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.implemented-by.artifact.pf.pf.provenance.anchor.stamp-rfc3161",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "artifact.pf.pf.provenance.anchor.stamp-rfc3161",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.implemented-by.artifact.pf.gate.yaml.denylist",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "artifact.pf.gate.yaml.denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.verified-by.evidence.pf.evidence-chain-is-tamper-evident.pf-provenance-verify",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "evidence.pf.evidence-chain-is-tamper-evident.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:32Z",
+        "verified_at": "2026-08-19T21:36:32Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.derived-from.intent.pf.sister-projects-are-isolated",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "intent.pf.sister-projects-are-isolated",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.implemented-by.artifact.pf.gate.yaml.platform-denylist",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "artifact.pf.gate.yaml.platform-denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.implemented-by.artifact.pf.pf.loops.gate.project-for",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "artifact.pf.pf.loops.gate.project-for",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.verified-by.evidence.pf.sister-projects-are-isolated.pf-gate",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "evidence.pf.sister-projects-are-isolated.pf-gate",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:32Z",
+        "verified_at": "2026-08-19T21:36:32Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.derived-from.intent.pf.agent-authority-is-revocable",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "intent.pf.agent-authority-is-revocable",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.implemented-by.artifact.pf.pf.provenance.ledger.revoke",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "artifact.pf.pf.provenance.ledger.revoke",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.implemented-by.artifact.pf.pf.provenance.ledger.is-revoked",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "artifact.pf.pf.provenance.ledger.is-revoked",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.verified-by.evidence.pf.agent-authority-is-revocable.pf-provenance-verify",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "evidence.pf.agent-authority-is-revocable.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:32Z",
+        "verified_at": "2026-08-19T21:36:32Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.derived-from.intent.pf.high-impact-actions-need-a-human",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "intent.pf.high-impact-actions-need-a-human",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.implemented-by.artifact.pf.pf.provenance.ledger.approve",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "artifact.pf.pf.provenance.ledger.approve",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.implemented-by.artifact.pf.pf.provenance.audit.report",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "artifact.pf.pf.provenance.audit.report",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.verified-by.evidence.pf.high-impact-actions-need-a-human.pf-provenance-verify",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "evidence.pf.high-impact-actions-need-a-human.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:33Z",
+        "verified_at": "2026-08-19T21:36:33Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.derived-from.intent.pf.model-routing-is-declared",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "intent.pf.model-routing-is-declared",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.implemented-by.artifact.pf.pf.agents.base.AGENTS",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "artifact.pf.pf.agents.base.AGENTS",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.verified-by.evidence.pf.model-routing-is-declared.pf-provenance-verify",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "evidence.pf.model-routing-is-declared.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:33Z",
+        "verified_at": "2026-08-19T21:36:33Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.derived-from.intent.pf.upstream-licences-are-reviewed",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "intent.pf.upstream-licences-are-reviewed",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.implemented-by.artifact.pf.pf.vendor.model.load-registry",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "artifact.pf.pf.vendor.model.load-registry",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.implemented-by.artifact.pf.pf.vendor.verify.verify",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "artifact.pf.pf.vendor.verify.verify",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.verified-by.evidence.pf.upstream-licences-are-reviewed.pf-check",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "evidence.pf.upstream-licences-are-reviewed.pf-check",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:34Z",
+        "verified_at": "2026-08-19T21:36:34Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.derived-from.intent.pf.control-baseline-is-declared",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "intent.pf.control-baseline-is-declared",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.implemented-by.artifact.pf.pf.air.coverage.assess",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "artifact.pf.pf.air.coverage.assess",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.implemented-by.artifact.pf.pf.air.register.render-register",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "artifact.pf.pf.air.register.render-register",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.verified-by.evidence.pf.control-baseline-is-declared.pf-air-coverage",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "evidence.pf.control-baseline-is-declared.pf-air-coverage",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:34Z",
+        "verified_at": "2026-08-19T21:36:34Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.verified-by.evidence.pf.control-baseline-is-declared.governance-air-register-md",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "evidence.pf.control-baseline-is-declared.governance-air-register-md",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:20Z",
+        "verified_at": "2026-08-19T18:05:20Z"
       }
     }
   ],

--- a/groups/acme/projects/acme-rollup/governance/otop.json
+++ b/groups/acme/projects/acme-rollup/governance/otop.json
@@ -4,9 +4,9 @@
     "id": "otop.pf.acme.acme-rollup",
     "title": "Policy and evidence \u2014 acme/acme-rollup",
     "repository": "https://github.com/Atomz-org/data-platform.git",
-    "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+    "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
     "metadata": {
-      "created_at": "2026-08-16T23:43:53Z",
+      "created_at": "2026-08-19T21:36:59Z",
       "actor": "pf.projections.otop"
     }
   },
@@ -17,13 +17,13 @@
       "title": "Agentic Data Platform governance policy",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
         "scope": "acme/acme-rollup",
         "source": "platform/src/pf/ontology/policy.yaml",
-        "rules": 10
+        "rules": 22
       }
     },
     {
@@ -32,7 +32,7 @@
       "title": "A monetary amount without its currency is not a number, it is a bug waiting for a second entity to be onboarded.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -45,7 +45,7 @@
       "title": "money-requires-currency",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -61,6 +61,138 @@
         "params": {
           "sibling": "currency_code",
           "scope": "resource"
+        },
+        "controls": [
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -70,8 +202,8 @@
       "title": "pf check for money-requires-currency",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:43:51Z",
-        "observed_at": "2026-08-16T23:43:51Z",
+        "created_at": "2026-08-19T21:36:51Z",
+        "observed_at": "2026-08-19T21:36:51Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -95,7 +227,7 @@
       "title": "A class with no identity property cannot participate in a derived join, so every BI and MDL projection of it is a guess.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -108,7 +240,7 @@
       "title": "entity-requires-identity",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -123,6 +255,138 @@
         },
         "params": {
           "exclude_abstract": true
+        },
+        "controls": [
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -132,8 +396,8 @@
       "title": "pf check for entity-requires-identity",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:43:52Z",
-        "observed_at": "2026-08-16T23:43:52Z",
+        "created_at": "2026-08-19T21:36:52Z",
+        "observed_at": "2026-08-19T21:36:52Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -157,7 +421,7 @@
       "title": "A foreign key pointing at a class the topology does not relate to is an undeclared join. Undeclared joins are how two teams compute different revenue from th...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -170,7 +434,7 @@
       "title": "link-must-be-in-topology",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -183,7 +447,139 @@
         "applies_to": {
           "annotation": "links"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -192,8 +588,8 @@
       "title": "pf check for link-must-be-in-topology",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:43:52Z",
-        "observed_at": "2026-08-16T23:43:52Z",
+        "created_at": "2026-08-19T21:36:52Z",
+        "observed_at": "2026-08-19T21:36:52Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -217,7 +613,7 @@
       "title": "PII may land in raw and staging. It must not reach a mart or an exposure without a masking policy or an explicit, recorded waiver.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -230,7 +626,7 @@
       "title": "pii-not-in-consumption",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -249,6 +645,153 @@
             "semantic",
             "consumption"
           ]
+        },
+        "controls": [
+          "AIR-DET-16",
+          "AIR-PREV-12"
+        ],
+        "control_titles": {
+          "AIR-DET-16": "Preserving Source Data Access Controls in AI Systems",
+          "AIR-PREV-12": "Role-Based Access Control for AI Data"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-3-2",
+              "title": "ISO 42001: AI roles and responsibilities",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-3",
+              "title": "ISO 42001: Acquisition of data",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-9-2",
+              "title": "ISO 42001: Processes for responsible use of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-21",
+              "title": "AC-21 Information Sharing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A238%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C521.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ca-8",
+              "title": "CA-8 Penetration Testing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A351%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "cm-12",
+              "title": "CM-12 Information Location",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ia-2",
+              "title": "IA-2 Identification And Authentication (organizational Users)",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A467%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ia-4",
+              "title": "IA-4 Identifier Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A479%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C422.0%2C0%5D"
+            },
+            {
+              "key": "ia-5",
+              "title": "IA-5 Authenticator Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A485%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -258,8 +801,8 @@
       "title": "pf loop run pii-audit for pii-not-in-consumption",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:43:52Z",
-        "observed_at": "2026-08-16T23:43:52Z",
+        "created_at": "2026-08-19T21:36:52Z",
+        "observed_at": "2026-08-19T21:36:52Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "PII_findings",
@@ -283,8 +826,8 @@
       "title": "STATE.md for pii-not-in-consumption",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "observed_at": "2026-08-15T20:35:53Z",
+        "created_at": "2026-08-18T15:42:57Z",
+        "observed_at": "2026-08-18T15:42:57Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "open_findings",
@@ -308,7 +851,7 @@
       "title": "Grain is the one fact a downstream consumer cannot infer and cannot survive guessing. An undeclared grain is how a join silently fans out.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -321,7 +864,7 @@
       "title": "mart-declares-grain",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "SHOULD",
@@ -336,6 +879,98 @@
         },
         "params": {
           "field": "grain"
+        },
+        "controls": [
+          "AIR-DET-13"
+        ],
+        "control_titles": {
+          "AIR-DET-13": "Providing Citations and Source Traceability for AI-Generated Information"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t5-1",
+              "title": "Table 5.1: Disclosure of AI Use in Products and Services to End-Users",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=49"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-1-2",
+              "title": "ISO 42001: Objectives for responsible development of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-7",
+              "title": "ISO 42001: AI system technical documentation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-2",
+              "title": "ISO 42001: System documentation and information for users",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-10",
+              "title": "AU-10 Non-repudiation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A301%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-8",
+              "title": "SA-8 Security And Privacy Engineering Principles",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A842%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -345,8 +980,8 @@
       "title": "kg/context_card.md for mart-declares-grain",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:43:51Z",
-        "observed_at": "2026-08-16T23:43:51Z",
+        "created_at": "2026-08-19T21:36:51Z",
+        "observed_at": "2026-08-19T21:36:51Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "project_index",
@@ -370,7 +1005,7 @@
       "title": "Aggregation policy \u2014 which statuses count, which timestamp, which filter \u2014 belongs to exactly one metric definition. A mart column named `revenue` is a secon...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -383,7 +1018,7 @@
       "title": "metric-owns-aggregation",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "SHOULD",
@@ -404,6 +1039,98 @@
             "churn_rate",
             "ltv"
           ]
+        },
+        "controls": [
+          "AIR-DET-13"
+        ],
+        "control_titles": {
+          "AIR-DET-13": "Providing Citations and Source Traceability for AI-Generated Information"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t5-1",
+              "title": "Table 5.1: Disclosure of AI Use in Products and Services to End-Users",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=49"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-1-2",
+              "title": "ISO 42001: Objectives for responsible development of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-7",
+              "title": "ISO 42001: AI system technical documentation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-2",
+              "title": "ISO 42001: System documentation and information for users",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-10",
+              "title": "AU-10 Non-repudiation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A301%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-8",
+              "title": "SA-8 Security And Privacy Engineering Principles",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A842%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -413,8 +1140,8 @@
       "title": "pf check for metric-owns-aggregation",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:43:52Z",
-        "observed_at": "2026-08-16T23:43:52Z",
+        "created_at": "2026-08-19T21:36:53Z",
+        "observed_at": "2026-08-19T21:36:53Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -438,7 +1165,7 @@
       "title": "A model or column change must report what it breaks before it lands, including the human who owns each affected exposure.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -451,7 +1178,7 @@
       "title": "change-declares-blast-radius",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -464,7 +1191,158 @@
         "applies_to": {
           "artifact_glob": "**/transform/models/**"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-DET-21",
+          "AIR-PREV-18"
+        ],
+        "control_titles": {
+          "AIR-DET-21": "Agent Decision Audit and Explainability",
+          "AIR-PREV-18": "Agent Authority Least Privilege Framework"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00040",
+              "title": "ATR-2026-00040 Agent Privilege Escalation",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/privilege-escalation/ATR-2026-00040-privilege-escalation.yaml"
+            },
+            {
+              "key": "ATR-2026-00098",
+              "title": "ATR-2026-00098 Unauthorized Financial Action by Agent",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/excessive-autonomy/ATR-2026-00098-unauthorized-financial-action.yaml"
+            }
+          ],
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a12",
+              "title": "III.S2.A12: Record-Keeping",
+              "url": "https://artificialintelligenceact.eu/article/12/"
+            },
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c3-s3-a26",
+              "title": "III.S3.A26: Obligations of Deployers of High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/26/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -473,8 +1351,8 @@
       "title": "impact_reports for change-declares-blast-radius",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:43:52Z",
-        "observed_at": "2026-08-16T23:43:52Z",
+        "created_at": "2026-08-19T21:36:53Z",
+        "observed_at": "2026-08-19T21:36:53Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "blast_radius_history",
@@ -498,8 +1376,8 @@
       "title": "loop-ledger.json for change-declares-blast-radius",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "observed_at": "2026-08-15T20:35:53Z",
+        "created_at": "2026-08-19T20:47:22Z",
+        "observed_at": "2026-08-19T20:47:22Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "run_history",
@@ -523,7 +1401,7 @@
       "title": "A blast radius is a prediction made from lineage. Lineage cannot say whether the numbers actually moved, so a change to a mart must also be compared against ...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -536,7 +1414,7 @@
       "title": "change-verified-against-baseline",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "SHOULD",
@@ -549,7 +1427,94 @@
         "applies_to": {
           "artifact_glob": "**/transform/models/marts/**"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-PREV-5"
+        ],
+        "control_titles": {
+          "AIR-PREV-5": "System Acceptance Testing"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a15",
+              "title": "III.S2.A15: Accuracy, Robustness and Cybersecurity",
+              "url": "https://artificialintelligenceact.eu/article/15/"
+            },
+            {
+              "key": "c3-s2-a9",
+              "title": "III.S2.A9: Risk Management System",
+              "url": "https://artificialintelligenceact.eu/article/9/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-1",
+              "title": "Table 4.1: Assessment of Risk-Proportionate Controls",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=41"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-4",
+              "title": "ISO 42001: AI system verification and validation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-5",
+              "title": "ISO 42001: AI system deployment",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ca-2",
+              "title": "CA-2 Control Assessments",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A324%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C684%2C0%5D"
+            },
+            {
+              "key": "ca-6",
+              "title": "CA-6 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A339%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "cm-4",
+              "title": "CM-4 Impact Analyses",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A375%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C509.0%2C0%5D"
+            },
+            {
+              "key": "sa-11",
+              "title": "SA-11 Developer Testing And Evaluation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A899%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C601.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-2",
+              "title": "SI-2 Flaw Remediation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1070%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-6",
+              "title": "SI-6 Security And Privacy Function Verification",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1103%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C475.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -558,12 +1523,12 @@
       "title": "pf tool recce run for change-verified-against-baseline",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:56:47Z",
-        "observed_at": "2026-08-16T22:56:47Z",
+        "created_at": "2026-08-19T21:36:54Z",
+        "observed_at": "2026-08-19T21:36:54Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "data_diff_against_baseline",
-      "result": "pass",
+      "result": "unknown",
       "subjects": [
         {
           "id": "constraint.pf.change-verified-against-baseline",
@@ -574,7 +1539,7 @@
       "provenance": {
         "actor": "pf.projections.otop",
         "scope": "acme/acme-rollup",
-        "detail": "groups/acme/projects/acme-rollup/transform/recce_state.json"
+        "detail": "no baseline captured"
       }
     },
     {
@@ -583,7 +1548,7 @@
       "title": "A value-level diff writes the rows it compared into the review tool's state file, which is durable and shared. Diffing a column whose role is PII therefore p...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -596,7 +1561,7 @@
       "title": "review-artifacts-exclude-pii",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -609,7 +1574,194 @@
         "applies_to": {
           "artifact_glob": "**/transform/recce.yml"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-DET-1",
+          "AIR-PREV-12"
+        ],
+        "control_titles": {
+          "AIR-DET-1": "AI Data Leakage Prevention and Detection",
+          "AIR-PREV-12": "Role-Based Access Control for AI Data"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-3-2",
+              "title": "ISO 42001: AI roles and responsibilities",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-5-2",
+              "title": "ISO 42001: AI system impact assessment process",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-20",
+              "title": "AC-20 Use Of External Systems",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A232%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C598.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-13",
+              "title": "AU-13 Monitoring For Information Disclosure",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A310%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C556.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-3",
+              "title": "CA-3 Information Exchange",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A330%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C166.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-12",
+              "title": "CM-12 Information Location",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ia-2",
+              "title": "IA-2 Identification And Authentication (organizational Users)",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A467%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ia-4",
+              "title": "IA-4 Identifier Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A479%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C422.0%2C0%5D"
+            },
+            {
+              "key": "ia-5",
+              "title": "IA-5 Authenticator Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A485%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "ir-4",
+              "title": "IR-4 Incident Handling",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A527%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C626.0%2C0%5D"
+            },
+            {
+              "key": "ir-9",
+              "title": "IR-9 Information Spillage Response",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A548%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C135.0%2C0%5D"
+            },
+            {
+              "key": "mp-6",
+              "title": "MP-6 Media Sanitization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A593%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C314.0%2C0%5D"
+            },
+            {
+              "key": "sa-9",
+              "title": "SA-9 External System Services",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A884%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C665.0%2C0%5D"
+            },
+            {
+              "key": "sc-28",
+              "title": "SC-28 Protection Of Information AT Rest",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1019%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C191.0%2C0%5D"
+            },
+            {
+              "key": "sc-7",
+              "title": "SC-7 Boundary Protection",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A962%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C399.0%2C0%5D"
+            },
+            {
+              "key": "sc-8",
+              "title": "SC-8 Transmission Confidentiality And Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A983%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C223.0%2C0%5D"
+            },
+            {
+              "key": "si-20",
+              "title": "SI-20 Tainting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1151%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C232.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -618,8 +1770,8 @@
       "title": "pf tool recce config for review-artifacts-exclude-pii",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T20:38:47Z",
-        "observed_at": "2026-08-15T20:38:47Z",
+        "created_at": "2026-08-18T15:42:57Z",
+        "observed_at": "2026-08-18T15:42:57Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "derived_review_checks",
@@ -638,12 +1790,580 @@
       }
     },
     {
+      "id": "intent.pf.builds-record-observability",
+      "kind": "intent",
+      "title": "A dbt build that leaves no queryable record cannot be triaged; failures get diagnosed from whichever log happened to survive. Every build must record its run...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A dbt build that leaves no queryable record cannot be triaged; failures get diagnosed from whichever log happened to survive. Every build must record its run and test results into the warehouse with history \u2014 for every test framework at once \u2014 so \"is this new, recurring, or flaky?\" is a query, not an archaeology dig."
+      }
+    },
+    {
+      "id": "constraint.pf.builds-record-observability",
+      "kind": "constraint",
+      "title": "builds-record-observability",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "observability_recorded",
+      "checkability": "automated",
+      "assertion": "observability_recorded on artifact_glob=**/transform/packages.yml",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/transform/packages.yml"
+        },
+        "params": {},
+        "controls": [
+          "AIR-DET-4",
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-DET-4": "AI System Observability",
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t7-adoption",
+              "title": "Table 7: AI Adoption Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=57"
+            },
+            {
+              "key": "t7-nature",
+              "title": "Table 7: Nature and Use Cases of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            },
+            {
+              "key": "t7-performance",
+              "title": "Table 7: AI System Performance Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-8",
+              "title": "ISO 42001: AI system recording of event logs",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "au-11",
+              "title": "AU-11 Audit Record Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C462.0%2C0%5D"
+            },
+            {
+              "key": "au-12",
+              "title": "AU-12 Audit Record Generation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C122.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "ir-4",
+              "title": "IR-4 Incident Handling",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A527%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C626.0%2C0%5D"
+            },
+            {
+              "key": "ir-5",
+              "title": "IR-5 Incident Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A539%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C387%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-10",
+              "title": "RA-10 Threat Hunting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A812%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C110.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.builds-record-observability.pf-tool-elementary-report",
+      "kind": "evidence",
+      "title": "pf tool elementary report for builds-record-observability",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:55Z",
+        "observed_at": "2026-08-19T21:36:55Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "observability_report_over_recorded_history",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.builds-record-observability",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-rollup",
+        "detail": "pf tool elementary report not produced yet"
+      }
+    },
+    {
+      "id": "evidence.pf.builds-record-observability.loop-ledger-json",
+      "kind": "evidence",
+      "title": "loop-ledger.json for builds-record-observability",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T20:47:22Z",
+        "observed_at": "2026-08-19T20:47:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "run_history",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.builds-record-observability",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-rollup",
+        "detail": "loop-ledger.json"
+      }
+    },
+    {
+      "id": "intent.pf.quality-floor-derived-from-ontology",
+      "kind": "intent",
+      "title": "Hand-written test coverage decays to whichever models someone remembered. The floor \u2014 an annotated mart is never empty, a declared identity identifies \u2014 must...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Hand-written test coverage decays to whichever models someone remembered. The floor \u2014 an annotated mart is never empty, a declared identity identifies \u2014 must be derived from the ontology roles, so coverage is a function of annotation rather than of memory, and a wrong test is a wrong role rather than a stale file."
+      }
+    },
+    {
+      "id": "constraint.pf.quality-floor-derived-from-ontology",
+      "kind": "constraint",
+      "title": "quality-floor-derived-from-ontology",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "tests_derived_from_roles",
+      "checkability": "automated",
+      "assertion": "tests_derived_from_roles on artifact_glob=**/transform/tests/expectations/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/transform/tests/expectations/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-6",
+          "AIR-PREV-5"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity",
+          "AIR-PREV-5": "System Acceptance Testing"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            },
+            {
+              "key": "c3-s2-a15",
+              "title": "III.S2.A15: Accuracy, Robustness and Cybersecurity",
+              "url": "https://artificialintelligenceact.eu/article/15/"
+            },
+            {
+              "key": "c3-s2-a9",
+              "title": "III.S2.A9: Risk Management System",
+              "url": "https://artificialintelligenceact.eu/article/9/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-1",
+              "title": "Table 4.1: Assessment of Risk-Proportionate Controls",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=41"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-4",
+              "title": "ISO 42001: AI system verification and validation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-5",
+              "title": "ISO 42001: AI system deployment",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-2",
+              "title": "CA-2 Control Assessments",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A324%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C684%2C0%5D"
+            },
+            {
+              "key": "ca-6",
+              "title": "CA-6 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A339%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "cm-4",
+              "title": "CM-4 Impact Analyses",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A375%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C509.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-11",
+              "title": "SA-11 Developer Testing And Evaluation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A899%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C601.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-2",
+              "title": "SI-2 Flaw Remediation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1070%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-6",
+              "title": "SI-6 Security And Privacy Function Verification",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1103%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C475.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.quality-floor-derived-from-ontology.pf-tool-expectations-run",
+      "kind": "evidence",
+      "title": "pf tool expectations run for quality-floor-derived-from-ontology",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:55Z",
+        "observed_at": "2026-08-19T21:36:55Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "quality_floor_verdicts",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.quality-floor-derived-from-ontology",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-rollup",
+        "detail": "pf tool expectations run not produced yet"
+      }
+    },
+    {
       "id": "intent.pf.secrets-never-in-context",
       "kind": "intent",
       "title": "A credential placed in a prompt, a model file or a committed artefact is durably persisted and replayed into every later session.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -656,7 +2376,7 @@
       "title": "secrets-never-in-context",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -669,7 +2389,131 @@
         "applies_to": {
           "artifact_glob": "**/secrets.toml"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-PREV-23",
+          "AIR-DET-16"
+        ],
+        "control_titles": {
+          "AIR-PREV-23": "Agentic System Credential Protection Framework",
+          "AIR-DET-16": "Preserving Source Data Access Controls in AI Systems"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00113",
+              "title": "ATR-2026-00113 Credential Theft via Agent Channel",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/context-exfiltration/ATR-2026-00113-credential-theft.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-3",
+              "title": "ISO 42001: Acquisition of data",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-9-2",
+              "title": "ISO 42001: Processes for responsible use of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-21",
+              "title": "AC-21 Information Sharing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A238%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C521.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ca-8",
+              "title": "CA-8 Penetration Testing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A351%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ia-5",
+              "title": "IA-5 Authenticator Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A485%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "sc-28",
+              "title": "SC-28 Protection Of Information AT Rest",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1019%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C191.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -678,8 +2522,8 @@
       "title": "pf gate for secrets-never-in-context",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:43:53Z",
-        "observed_at": "2026-08-16T23:43:53Z",
+        "created_at": "2026-08-19T21:36:55Z",
+        "observed_at": "2026-08-19T21:36:55Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "path_verdict",
@@ -698,23 +2542,1498 @@
       }
     },
     {
+      "id": "intent.pf.agent-authority-is-least-privilege",
+      "kind": "intent",
+      "title": "An agent reaches the filesystem through one path gate, and the paths it may never write are declared rather than remembered. Least privilege that lives in a ...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "An agent reaches the filesystem through one path gate, and the paths it may never write are declared rather than remembered. Least privilege that lives in a prompt is a request; in a denylist it is a control."
+      }
+    },
+    {
+      "id": "constraint.pf.agent-authority-is-least-privilege",
+      "kind": "constraint",
+      "title": "agent-authority-is-least-privilege",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "path_denied",
+      "checkability": "automated",
+      "assertion": "path_denied on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-18"
+        ],
+        "control_titles": {
+          "AIR-PREV-18": "Agent Authority Least Privilege Framework"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00040",
+              "title": "ATR-2026-00040 Agent Privilege Escalation",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/privilege-escalation/ATR-2026-00040-privilege-escalation.yaml"
+            },
+            {
+              "key": "ATR-2026-00098",
+              "title": "ATR-2026-00098 Unauthorized Financial Action by Agent",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/excessive-autonomy/ATR-2026-00098-unauthorized-financial-action.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.agent-authority-is-least-privilege.pf-gate",
+      "kind": "evidence",
+      "title": "pf gate for agent-authority-is-least-privilege",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:56Z",
+        "observed_at": "2026-08-19T21:36:56Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "path_verdict",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.agent-authority-is-least-privilege",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-rollup",
+        "detail": "denylist present"
+      }
+    },
+    {
+      "id": "intent.pf.tool-contribution-may-only-tighten",
+      "kind": "intent",
+      "title": "A tool contributes gate rules, and a plugin system that can widen the policy judging it is not a policy. `Tool.gate_sections()` rejects a contribution to any...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A tool contributes gate rules, and a plugin system that can widen the policy judging it is not a policy. `Tool.gate_sections()` rejects a contribution to any loosening section at construction, so an unsafe tool fails at import rather than silently permitting more."
+      }
+    },
+    {
+      "id": "constraint.pf.tool-contribution-may-only-tighten",
+      "kind": "constraint",
+      "title": "tool-contribution-may-only-tighten",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "tightening_only",
+      "checkability": "automated",
+      "assertion": "tightening_only (sections=['denylist', 'platform_denylist', 'impact_required']) on artifact_glob=gate.capabilities.yaml",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "gate.capabilities.yaml"
+        },
+        "params": {
+          "sections": [
+            "denylist",
+            "platform_denylist",
+            "impact_required"
+          ]
+        },
+        "controls": [
+          "AIR-PREV-19"
+        ],
+        "control_titles": {
+          "AIR-PREV-19": "Tool Chain Validation and Sanitization"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00011",
+              "title": "ATR-2026-00011 Instruction Injection via Tool Output",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00011-tool-output-injection.yaml"
+            },
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00013",
+              "title": "ATR-2026-00013 Tool-Driven Server-Side Request Forgery",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00013-tool-ssrf.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "sc-4",
+              "title": "SC-4 Information In Shared System Resources",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A956%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-15",
+              "title": "SI-15 Information Output Filtering",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1136%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C355.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.tool-contribution-may-only-tighten.pf-check",
+      "kind": "evidence",
+      "title": "pf check for tool-contribution-may-only-tighten",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:56Z",
+        "observed_at": "2026-08-19T21:36:56Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "conformance_report",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.tool-contribution-may-only-tighten",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-rollup",
+        "detail": "0 error(s), 1 issue(s)"
+      }
+    },
+    {
+      "id": "intent.pf.agent-decisions-are-recorded",
+      "kind": "intent",
+      "title": "Every tool call an agent makes is written down before it happens and after it happens, and the gate's verdict is recorded for allows as well as denies. \"No r...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Every tool call an agent makes is written down before it happens and after it happens, and the gate's verdict is recorded for allows as well as denies. \"No rule applied\" and \"a rule allowed it\" are different facts, and only a record that carries both can answer what an agent was permitted to do."
+      }
+    },
+    {
+      "id": "constraint.pf.agent-decisions-are-recorded",
+      "kind": "constraint",
+      "title": "agent-decisions-are-recorded",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "action_recorded",
+      "checkability": "automated",
+      "assertion": "action_recorded (stages=['intent', 'decision', 'execution']) on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {
+          "stages": [
+            "intent",
+            "decision",
+            "execution"
+          ]
+        },
+        "controls": [
+          "AIR-DET-21",
+          "AIR-DET-4"
+        ],
+        "control_titles": {
+          "AIR-DET-21": "Agent Decision Audit and Explainability",
+          "AIR-DET-4": "AI System Observability"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a12",
+              "title": "III.S2.A12: Record-Keeping",
+              "url": "https://artificialintelligenceact.eu/article/12/"
+            },
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c3-s3-a26",
+              "title": "III.S3.A26: Obligations of Deployers of High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/26/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t7-adoption",
+              "title": "Table 7: AI Adoption Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=57"
+            },
+            {
+              "key": "t7-nature",
+              "title": "Table 7: Nature and Use Cases of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            },
+            {
+              "key": "t7-performance",
+              "title": "Table 7: AI System Performance Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-8",
+              "title": "ISO 42001: AI system recording of event logs",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-11",
+              "title": "AU-11 Audit Record Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C462.0%2C0%5D"
+            },
+            {
+              "key": "au-12",
+              "title": "AU-12 Audit Record Generation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C122.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ir-4",
+              "title": "IR-4 Incident Handling",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A527%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C626.0%2C0%5D"
+            },
+            {
+              "key": "ir-5",
+              "title": "IR-5 Incident Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A539%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C387%2C0%5D"
+            },
+            {
+              "key": "ra-10",
+              "title": "RA-10 Threat Hunting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A812%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C110.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.agent-decisions-are-recorded.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for agent-decisions-are-recorded",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:57Z",
+        "observed_at": "2026-08-19T21:36:57Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.agent-decisions-are-recorded",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-rollup",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.evidence-chain-is-tamper-evident",
+      "kind": "intent",
+      "title": "A log an agent can edit is not evidence. Each record carries the hash of the one before it, and the head is anchored to a timestamp authority with no stake i...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A log an agent can edit is not evidence. Each record carries the hash of the one before it, and the head is anchored to a timestamp authority with no stake in what it says \u2014 so editing the middle requires editing the end, and the end is countersigned."
+      }
+    },
+    {
+      "id": "constraint.pf.evidence-chain-is-tamper-evident",
+      "kind": "constraint",
+      "title": "evidence-chain-is-tamper-evident",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "hash_chained",
+      "checkability": "automated",
+      "assertion": "hash_chained on artifact_glob=provenance/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "provenance/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-DET-21"
+        ],
+        "control_titles": {
+          "AIR-DET-21": "Agent Decision Audit and Explainability"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a12",
+              "title": "III.S2.A12: Record-Keeping",
+              "url": "https://artificialintelligenceact.eu/article/12/"
+            },
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c3-s3-a26",
+              "title": "III.S3.A26: Obligations of Deployers of High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/26/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.evidence-chain-is-tamper-evident.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for evidence-chain-is-tamper-evident",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:57Z",
+        "observed_at": "2026-08-19T21:36:57Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.evidence-chain-is-tamper-evident",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-rollup",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.sister-projects-are-isolated",
+      "kind": "intent",
+      "title": "Business logic does not transfer between entities, so an assumption carried from one sister company into another is a bug by construction. A project session ...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Business logic does not transfer between entities, so an assumption carried from one sister company into another is a bug by construction. A project session may not read or write another project, and may not write shared infra at all."
+      }
+    },
+    {
+      "id": "constraint.pf.sister-projects-are-isolated",
+      "kind": "constraint",
+      "title": "sister-projects-are-isolated",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "cross_tenant_denied",
+      "checkability": "automated",
+      "assertion": "cross_tenant_denied on artifact_glob=groups/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "groups/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-22"
+        ],
+        "control_titles": {
+          "AIR-PREV-22": "Multi-Agent Isolation and Segmentation"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00030",
+              "title": "ATR-2026-00030 Cross-Agent Attack Detection",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/agent-manipulation/ATR-2026-00030-cross-agent-attack.yaml"
+            },
+            {
+              "key": "ATR-2026-00076",
+              "title": "ATR-2026-00076 Insecure Inter-Agent Communication",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/agent-manipulation/ATR-2026-00076-inter-agent-message-spoofing.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "sc-3",
+              "title": "SC-3 Security Function Isolation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A950%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C217.0%2C0%5D"
+            },
+            {
+              "key": "sc-32",
+              "title": "SC-32 System Partitioning",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1031%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C227.0%2C0%5D"
+            },
+            {
+              "key": "sc-7",
+              "title": "SC-7 Boundary Protection",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A962%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C399.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.sister-projects-are-isolated.pf-gate",
+      "kind": "evidence",
+      "title": "pf gate for sister-projects-are-isolated",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:57Z",
+        "observed_at": "2026-08-19T21:36:57Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "path_verdict",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.sister-projects-are-isolated",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-rollup",
+        "detail": "denylist present"
+      }
+    },
+    {
+      "id": "intent.pf.agent-authority-is-revocable",
+      "kind": "intent",
+      "title": "A control that cannot be switched off mid-incident is a control you find out about afterwards. Revocation is checked before intent is written, and an unreada...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A control that cannot be switched off mid-incident is a control you find out about afterwards. Revocation is checked before intent is written, and an unreadable revocation file fails closed."
+      }
+    },
+    {
+      "id": "constraint.pf.agent-authority-is-revocable",
+      "kind": "constraint",
+      "title": "agent-authority-is-revocable",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "revocable",
+      "checkability": "automated",
+      "assertion": "revocable on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-18"
+        ],
+        "control_titles": {
+          "AIR-PREV-18": "Agent Authority Least Privilege Framework"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00040",
+              "title": "ATR-2026-00040 Agent Privilege Escalation",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/privilege-escalation/ATR-2026-00040-privilege-escalation.yaml"
+            },
+            {
+              "key": "ATR-2026-00098",
+              "title": "ATR-2026-00098 Unauthorized Financial Action by Agent",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/excessive-autonomy/ATR-2026-00098-unauthorized-financial-action.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.agent-authority-is-revocable.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for agent-authority-is-revocable",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:58Z",
+        "observed_at": "2026-08-19T21:36:58Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.agent-authority-is-revocable",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-rollup",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.high-impact-actions-need-a-human",
+      "kind": "intent",
+      "title": "Human oversight is a chain that shows the approval, not a document that asserts it. Approvals are append-only and bound to the action they approve, and an ac...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Human oversight is a chain that shows the approval, not a document that asserts it. Approvals are append-only and bound to the action they approve, and an actor approving their own action is a finding rather than an approval."
+      }
+    },
+    {
+      "id": "constraint.pf.high-impact-actions-need-a-human",
+      "kind": "constraint",
+      "title": "high-impact-actions-need-a-human",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "approval_recorded",
+      "checkability": "automated",
+      "assertion": "approval_recorded on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-DET-11"
+        ],
+        "control_titles": {
+          "AIR-DET-11": "Human Feedback Loop for AI Systems"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a14",
+              "title": "III.S2.A14: Human Oversight",
+              "url": "https://artificialintelligenceact.eu/article/14/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-3-3",
+              "title": "ISO 42001: Reporting of concerns",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-2",
+              "title": "ISO 42001: System documentation and information for users",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ca-2",
+              "title": "CA-2 Control Assessments",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A324%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C684%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ir-6",
+              "title": "IR-6 Incident Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A542%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "pm-26",
+              "title": "PM-26 Complaint Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A722%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C365.0%2C0%5D"
+            },
+            {
+              "key": "ra-5",
+              "title": "RA-5 Vulnerability Monitoring And Scanning",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A797%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C594.0%2C0%5D"
+            },
+            {
+              "key": "si-2",
+              "title": "SI-2 Flaw Remediation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1070%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.high-impact-actions-need-a-human.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for high-impact-actions-need-a-human",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:58Z",
+        "observed_at": "2026-08-19T21:36:58Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.high-impact-actions-need-a-human",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-rollup",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.model-routing-is-declared",
+      "kind": "intent",
+      "title": "Which model answers which step is a declared table, not whatever the caller passed. An unregistered step is recorded as such, and the recorded verdict matche...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Which model answers which step is a declared table, not whatever the caller passed. An unregistered step is recorded as such, and the recorded verdict matches what actually happened rather than what policy would have preferred."
+      }
+    },
+    {
+      "id": "constraint.pf.model-routing-is-declared",
+      "kind": "constraint",
+      "title": "model-routing-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "routing_declared",
+      "checkability": "automated",
+      "assertion": "routing_declared on artifact_glob=**/agents/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/agents/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-10"
+        ],
+        "control_titles": {
+          "AIR-PREV-10": "AI Model Version Pinning"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-4",
+              "title": "ISO 42001: Tooling resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-3",
+              "title": "ISO 42001: Documentation of AI system design and development",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-5",
+              "title": "ISO 42001: AI system deployment",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "cm-2",
+              "title": "CM-2 Baseline Configuration",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A363%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "cm-3",
+              "title": "CM-3 Configuration Change Control",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A366%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C205.0%2C0%5D"
+            },
+            {
+              "key": "cm-4",
+              "title": "CM-4 Impact Analyses",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A375%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C509.0%2C0%5D"
+            },
+            {
+              "key": "cm-8",
+              "title": "CM-8 System Component Inventory",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A393%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C197.0%2C0%5D"
+            },
+            {
+              "key": "sa-10",
+              "title": "SA-10 Developer Configuration Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A890%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C211.0%2C0%5D"
+            },
+            {
+              "key": "sa-22",
+              "title": "SA-22 Unsupported System Components",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A941%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C497.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sr-4",
+              "title": "SR-4 Provenance",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1169%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C257.0%2C0%5D"
+            },
+            {
+              "key": "sr-8",
+              "title": "SR-8 Notification Agreements",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1184%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C620.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.model-routing-is-declared.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for model-routing-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:58Z",
+        "observed_at": "2026-08-19T21:36:58Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.model-routing-is-declared",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-rollup",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.upstream-licences-are-reviewed",
+      "kind": "intent",
+      "title": "Every upstream this platform borrowed from carries a licence, and some of them constrain what we may ship. The review is written down per upstream and surfac...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Every upstream this platform borrowed from carries a licence, and some of them constrain what we may ship. The review is written down per upstream and surfaced in the listing, so a constraint is a fact in the registry rather than something someone once checked."
+      }
+    },
+    {
+      "id": "constraint.pf.upstream-licences-are-reviewed",
+      "kind": "constraint",
+      "title": "upstream-licences-are-reviewed",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "licence_reviewed",
+      "checkability": "automated",
+      "assertion": "licence_reviewed on artifact_glob=vendor/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "vendor/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-7"
+        ],
+        "control_titles": {
+          "AIR-PREV-7": "Legal and Contractual Frameworks for AI Systems"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t4-1",
+              "title": "Table 4.1: Assessment of Risk-Proportionate Controls",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=41"
+            },
+            {
+              "key": "t4-7",
+              "title": "Table 4.7: Legal Framework and Accountability",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=44"
+            },
+            {
+              "key": "t7-third-party",
+              "title": "Table 7: Third-Party Dependencies and Concentrations",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-10-2",
+              "title": "ISO 42001: Allocating responsibilities",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-10-3",
+              "title": "ISO 42001: Suppliers",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-2-3",
+              "title": "ISO 42001: Alignment with other organizational policies",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-5",
+              "title": "ISO 42001: Information for interested parties",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-20",
+              "title": "AC-20 Use Of External Systems",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A232%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C598.0%2C0%5D"
+            },
+            {
+              "key": "ca-3",
+              "title": "CA-3 Information Exchange",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A330%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C166.0%2C0%5D"
+            },
+            {
+              "key": "ir-6",
+              "title": "IR-6 Incident Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A542%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "pm-30",
+              "title": "PM-30 Supply Chain Risk Management Strategy",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A728%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C427.0%2C0%5D"
+            },
+            {
+              "key": "ps-7",
+              "title": "PS-7 External Personnel Security",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A752%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C623.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-9",
+              "title": "SA-9 External System Services",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A884%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C665.0%2C0%5D"
+            },
+            {
+              "key": "sr-2",
+              "title": "SR-2 Supply Chain Risk Management Plan",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1163%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C684.0%2C0%5D"
+            },
+            {
+              "key": "sr-3",
+              "title": "SR-3 Supply Chain Controls And Processes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1166%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C440.0%2C0%5D"
+            },
+            {
+              "key": "sr-5",
+              "title": "SR-5 Acquisition Strategies, Tools, And Methods",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1175%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C243.0%2C0%5D"
+            },
+            {
+              "key": "sr-8",
+              "title": "SR-8 Notification Agreements",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1184%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C620.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.upstream-licences-are-reviewed.pf-check",
+      "kind": "evidence",
+      "title": "pf check for upstream-licences-are-reviewed",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:59Z",
+        "observed_at": "2026-08-19T21:36:59Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "conformance_report",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.upstream-licences-are-reviewed",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-rollup",
+        "detail": "0 error(s), 1 issue(s)"
+      }
+    },
+    {
+      "id": "intent.pf.control-baseline-is-declared",
+      "kind": "intent",
+      "title": "A risk register that names controls nobody enforces is a document. Each entity declares in `air.yaml` which controls it commits to; those are derived from th...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A risk register that names controls nobody enforces is a document. Each entity declares in `air.yaml` which controls it commits to; those are derived from the repository on every run and block the merge when they fail, while everything outside the baseline is reported and does not."
+      }
+    },
+    {
+      "id": "constraint.pf.control-baseline-is-declared",
+      "kind": "constraint",
+      "title": "control-baseline-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "baseline_declared",
+      "checkability": "automated",
+      "assertion": "baseline_declared on artifact_glob=**/air.yaml",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/air.yaml"
+        },
+        "params": {}
+      }
+    },
+    {
+      "id": "evidence.pf.control-baseline-is-declared.pf-air-coverage",
+      "kind": "evidence",
+      "title": "pf air coverage for control-baseline-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:59Z",
+        "observed_at": "2026-08-19T21:36:59Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "control_coverage_verdicts",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.control-baseline-is-declared",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-rollup",
+        "detail": "pf air coverage not produced yet"
+      }
+    },
+    {
+      "id": "evidence.pf.control-baseline-is-declared.governance-air-register-md",
+      "kind": "evidence",
+      "title": "governance/air-register.md for control-baseline-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:20Z",
+        "observed_at": "2026-08-19T18:05:20Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "per-entity_risk_register",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.control-baseline-is-declared",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-rollup",
+        "detail": "groups/acme/projects/acme-rollup/governance/air-register.md"
+      }
+    },
+    {
       "id": "artifact.pf.pf.ontology.validate.money-without-currency",
       "kind": "artifact",
       "title": "pf.ontology.validate:money-without-currency",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "money-without-currency",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -726,18 +4045,18 @@
       "title": "pf.ontology.validate:class-without-identity",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "class-without-identity",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -749,18 +4068,18 @@
       "title": "pf.ontology.validate:illegal-edge",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "illegal-edge",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -772,18 +4091,18 @@
       "title": "pf.loops.registry:pii_audit",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T02:49:37Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "loop",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/loops/registry.py",
         "language": "python",
         "symbol": "pii_audit",
-        "digest": "git:293a23d6448c5fe70cee7c96a01f2690d8af47c2"
+        "digest": "git:e81ff725c18b4ff2a8187f5fb953a9dc003a56f4"
       },
       "extensions": {
         "exists": true
@@ -795,18 +4114,18 @@
       "title": "pf.kg.build:model-grain",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T02:04:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/kg/build.py",
         "language": "python",
         "symbol": "model-grain",
-        "digest": "git:2c8398b8a1246d27395ac2140ceba10eea0d3072"
+        "digest": "git:db169407ccb59827ce7f3c5932b2b4a0d40e1124"
       },
       "extensions": {
         "exists": true
@@ -818,18 +4137,18 @@
       "title": "pf.ontology.validate:metric-shaped-column",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "metric-shaped-column",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -841,17 +4160,17 @@
       "title": "platform/hooks/pre_tool_use.py",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T00:11:17Z",
+        "created_at": "2026-08-18T18:40:22Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "hook",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/hooks/pre_tool_use.py",
         "language": "python",
-        "digest": "git:2cb586ed58222bcb50e9cd0013d536cb2c9e6856"
+        "digest": "git:230bc9d9639eaa71c8c511affccb14881cdfc1f1"
       },
       "extensions": {
         "exists": true
@@ -863,14 +4182,14 @@
       "title": "platform/hooks/pre_commit.sh",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-12T16:06:37Z",
+        "created_at": "2026-08-12T14:06:37Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "hook",
       "language": "bash",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/hooks/pre_commit.sh",
         "language": "bash",
         "digest": "git:ce8e6f322ce15a546c16d2eb25bddf4fab5b6688"
@@ -885,18 +4204,18 @@
       "title": "pf.tools.recce:dagster_assets",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:50:23Z",
+        "created_at": "2026-08-17T23:50:05Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/tools/recce.py",
         "language": "python",
         "symbol": "dagster_assets",
-        "digest": "git:8a560994bb5a994b5a57b37a07f99114656b18a3"
+        "digest": "git:6d6c7a4515c5aa68b9642ca221805c28a15f4fc1"
       },
       "extensions": {
         "exists": true
@@ -908,18 +4227,18 @@
       "title": "pf.tools.recce:register_commands",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:50:23Z",
+        "created_at": "2026-08-17T23:50:05Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/tools/recce.py",
         "language": "python",
         "symbol": "register_commands",
-        "digest": "git:8a560994bb5a994b5a57b37a07f99114656b18a3"
+        "digest": "git:6d6c7a4515c5aa68b9642ca221805c28a15f4fc1"
       },
       "extensions": {
         "exists": true
@@ -931,18 +4250,18 @@
       "title": "pf.ontology.model:Role.review_intent",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T22:35:09Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/model.py",
         "language": "python",
         "symbol": "Role.review_intent",
-        "digest": "git:3e691a864da03459b04489a674bbba0a1839b1ea"
+        "digest": "git:513888ee8c2df8cfa1d09562ad3dc2793c4f741e"
       },
       "extensions": {
         "exists": true
@@ -954,18 +4273,106 @@
       "title": "pf.tools.recce:generate_config",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:50:23Z",
+        "created_at": "2026-08-17T23:50:05Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/tools/recce.py",
         "language": "python",
         "symbol": "generate_config",
-        "digest": "git:8a560994bb5a994b5a57b37a07f99114656b18a3"
+        "digest": "git:6d6c7a4515c5aa68b9642ca221805c28a15f4fc1"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.elementary.bootstrap-project",
+      "kind": "artifact",
+      "title": "pf.tools.elementary:bootstrap_project",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:54Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/elementary.py",
+        "language": "python",
+        "symbol": "bootstrap_project"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.elementary.ensure-package",
+      "kind": "artifact",
+      "title": "pf.tools.elementary:ensure_package",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:55Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/elementary.py",
+        "language": "python",
+        "symbol": "ensure_package"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.expectations.write-tests",
+      "kind": "artifact",
+      "title": "pf.tools.expectations:write_tests",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:55Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/expectations.py",
+        "language": "python",
+        "symbol": "write_tests"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.expectations.bootstrap-project",
+      "kind": "artifact",
+      "title": "pf.tools.expectations:bootstrap_project",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:55Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/expectations.py",
+        "language": "python",
+        "symbol": "bootstrap_project"
       },
       "extensions": {
         "exists": true
@@ -977,18 +4384,408 @@
       "title": "gate.yaml:denylist",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-17T00:38:30Z",
+        "created_at": "2026-08-18T18:40:22Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "configuration",
       "language": "yaml",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "gate.yaml",
         "language": "yaml",
         "symbol": "denylist",
-        "digest": "git:f0f6dc9c2d8e60c371d7df8c8a9af65e9571c965"
+        "digest": "git:7d51894f5fdae49fa67534d8359ac34a48175bc8"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.gate.yaml.platform-denylist",
+      "kind": "artifact",
+      "title": "gate.yaml:platform_denylist",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "configuration",
+      "language": "yaml",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "gate.yaml",
+        "language": "yaml",
+        "symbol": "platform_denylist",
+        "digest": "git:7d51894f5fdae49fa67534d8359ac34a48175bc8"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.loops.gate.check-path",
+      "kind": "artifact",
+      "title": "pf.loops.gate:check_path",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-15T05:28:10Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "loop",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/loops/gate.py",
+        "language": "python",
+        "symbol": "check_path",
+        "digest": "git:0e0d5d990b04901c47b39e09bf783eb4a8821183"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.spec.Tool.gate-sections",
+      "kind": "artifact",
+      "title": "pf.tools.spec:Tool.gate_sections",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-17T23:50:05Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/spec.py",
+        "language": "python",
+        "symbol": "Tool.gate_sections",
+        "digest": "git:3b36976709eb70b17628d2c2228e4e398ed2df05"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.decision",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:decision",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "decision",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.platform.hooks.post-tool-use.py",
+      "kind": "artifact",
+      "title": "platform/hooks/post_tool_use.py",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "hook",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/hooks/post_tool_use.py",
+        "language": "python",
+        "digest": "git:99dc8363fbb485907c66034f6c6fefdc51336650"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.chain.verify",
+      "kind": "artifact",
+      "title": "pf.provenance.chain:verify",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/chain.py",
+        "language": "python",
+        "symbol": "verify",
+        "digest": "git:07d2c60e49bda58cd6b9d51534b3417cec91777c"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.anchor.stamp-rfc3161",
+      "kind": "artifact",
+      "title": "pf.provenance.anchor:stamp_rfc3161",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/anchor.py",
+        "language": "python",
+        "symbol": "stamp_rfc3161",
+        "digest": "git:a38a0c14b0286745dbe157807967085d044af606"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.loops.gate.project-for",
+      "kind": "artifact",
+      "title": "pf.loops.gate:project_for",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-15T05:28:10Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "loop",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/loops/gate.py",
+        "language": "python",
+        "symbol": "project_for",
+        "digest": "git:0e0d5d990b04901c47b39e09bf783eb4a8821183"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.revoke",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:revoke",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "revoke",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.is-revoked",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:is_revoked",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "is_revoked",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.approve",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:approve",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "approve",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.audit.report",
+      "kind": "artifact",
+      "title": "pf.provenance.audit:report",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/audit.py",
+        "language": "python",
+        "symbol": "report",
+        "digest": "git:048a4041043b8b6d2628b0f97929752c079fb95e"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.agents.base.AGENTS",
+      "kind": "artifact",
+      "title": "pf.agents.base:AGENTS",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/agents/base.py",
+        "language": "python",
+        "symbol": "AGENTS",
+        "digest": "git:21365423e93b1c6427aa7dbf6dbb2823993e42c2"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.vendor.model.load-registry",
+      "kind": "artifact",
+      "title": "pf.vendor.model:load_registry",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-13T01:11:58Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/vendor/model.py",
+        "language": "python",
+        "symbol": "load_registry",
+        "digest": "git:3364fcfb711181efa434a9fe7024e4dcc01984df"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.vendor.verify.verify",
+      "kind": "artifact",
+      "title": "pf.vendor.verify:verify",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/vendor/verify.py",
+        "language": "python",
+        "symbol": "verify",
+        "digest": "git:4b39f17a26d3f030c4f2ef101c60a502c2f9ccfb"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.air.coverage.assess",
+      "kind": "artifact",
+      "title": "pf.air.coverage:assess",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/air/coverage.py",
+        "language": "python",
+        "symbol": "assess",
+        "digest": "git:fd67a5e7eeec7fdfe079c96e066992764601c00f"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.air.register.render-register",
+      "kind": "artifact",
+      "title": "pf.air.register:render_register",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/air/register.py",
+        "language": "python",
+        "symbol": "render_register",
+        "digest": "git:c45d0bbbe459fadea3ab3edfbf96beb6db505f25"
       },
       "extensions": {
         "exists": true
@@ -1002,7 +4799,7 @@
       "to": "intent.pf.money-requires-currency",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1013,7 +4810,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1022,8 +4819,8 @@
       "to": "artifact.pf.pf.ontology.validate.money-without-currency",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1032,8 +4829,8 @@
       "to": "evidence.pf.money-requires-currency.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:43:51Z",
-        "verified_at": "2026-08-16T23:43:51Z"
+        "created_at": "2026-08-19T21:36:51Z",
+        "verified_at": "2026-08-19T21:36:51Z"
       }
     },
     {
@@ -1042,7 +4839,7 @@
       "to": "intent.pf.entity-requires-identity",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1053,7 +4850,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1062,8 +4859,8 @@
       "to": "artifact.pf.pf.ontology.validate.class-without-identity",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1072,8 +4869,8 @@
       "to": "evidence.pf.entity-requires-identity.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:43:52Z",
-        "verified_at": "2026-08-16T23:43:52Z"
+        "created_at": "2026-08-19T21:36:52Z",
+        "verified_at": "2026-08-19T21:36:52Z"
       }
     },
     {
@@ -1082,7 +4879,7 @@
       "to": "intent.pf.link-must-be-in-topology",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1093,7 +4890,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1102,8 +4899,8 @@
       "to": "artifact.pf.pf.ontology.validate.illegal-edge",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1112,8 +4909,8 @@
       "to": "evidence.pf.link-must-be-in-topology.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:43:52Z",
-        "verified_at": "2026-08-16T23:43:52Z"
+        "created_at": "2026-08-19T21:36:52Z",
+        "verified_at": "2026-08-19T21:36:52Z"
       }
     },
     {
@@ -1122,7 +4919,7 @@
       "to": "intent.pf.pii-not-in-consumption",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1133,7 +4930,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1142,8 +4939,8 @@
       "to": "artifact.pf.pf.loops.registry.pii-audit",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1152,8 +4949,8 @@
       "to": "evidence.pf.pii-not-in-consumption.pf-loop-run-pii-audit",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:43:52Z",
-        "verified_at": "2026-08-16T23:43:52Z"
+        "created_at": "2026-08-19T21:36:52Z",
+        "verified_at": "2026-08-19T21:36:52Z"
       }
     },
     {
@@ -1162,8 +4959,8 @@
       "to": "evidence.pf.pii-not-in-consumption.state-md",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "verified_at": "2026-08-15T20:35:53Z"
+        "created_at": "2026-08-18T15:42:57Z",
+        "verified_at": "2026-08-18T15:42:57Z"
       }
     },
     {
@@ -1172,7 +4969,7 @@
       "to": "intent.pf.mart-declares-grain",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1183,7 +4980,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1192,8 +4989,8 @@
       "to": "artifact.pf.pf.kg.build.model-grain",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1202,8 +4999,8 @@
       "to": "evidence.pf.mart-declares-grain.kg-context-card-md",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:43:51Z",
-        "verified_at": "2026-08-16T23:43:51Z"
+        "created_at": "2026-08-19T21:36:51Z",
+        "verified_at": "2026-08-19T21:36:51Z"
       }
     },
     {
@@ -1212,7 +5009,7 @@
       "to": "intent.pf.metric-owns-aggregation",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1223,7 +5020,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1232,8 +5029,8 @@
       "to": "artifact.pf.pf.ontology.validate.metric-shaped-column",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1242,8 +5039,8 @@
       "to": "evidence.pf.metric-owns-aggregation.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:43:52Z",
-        "verified_at": "2026-08-16T23:43:52Z"
+        "created_at": "2026-08-19T21:36:53Z",
+        "verified_at": "2026-08-19T21:36:53Z"
       }
     },
     {
@@ -1252,7 +5049,7 @@
       "to": "intent.pf.change-declares-blast-radius",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1263,7 +5060,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1272,8 +5069,8 @@
       "to": "artifact.pf.platform.hooks.pre-tool-use.py",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1282,8 +5079,8 @@
       "to": "artifact.pf.platform.hooks.pre-commit.sh",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1292,8 +5089,8 @@
       "to": "evidence.pf.change-declares-blast-radius.impact-reports",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:43:52Z",
-        "verified_at": "2026-08-16T23:43:52Z"
+        "created_at": "2026-08-19T21:36:53Z",
+        "verified_at": "2026-08-19T21:36:53Z"
       }
     },
     {
@@ -1302,8 +5099,8 @@
       "to": "evidence.pf.change-declares-blast-radius.loop-ledger-json",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "verified_at": "2026-08-15T20:35:53Z"
+        "created_at": "2026-08-19T20:47:22Z",
+        "verified_at": "2026-08-19T20:47:22Z"
       }
     },
     {
@@ -1312,7 +5109,7 @@
       "to": "intent.pf.change-verified-against-baseline",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1323,7 +5120,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1332,8 +5129,8 @@
       "to": "artifact.pf.pf.tools.recce.dagster-assets",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1342,8 +5139,8 @@
       "to": "artifact.pf.pf.tools.recce.register-commands",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1352,8 +5149,8 @@
       "to": "evidence.pf.change-verified-against-baseline.pf-tool-recce-run",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T22:56:47Z",
-        "verified_at": "2026-08-16T22:56:47Z"
+        "created_at": "2026-08-19T21:36:54Z",
+        "verified_at": "2026-08-19T21:36:54Z"
       }
     },
     {
@@ -1362,7 +5159,7 @@
       "to": "intent.pf.review-artifacts-exclude-pii",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1373,7 +5170,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1382,8 +5179,8 @@
       "to": "artifact.pf.pf.ontology.model.Role.review-intent",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1392,8 +5189,8 @@
       "to": "artifact.pf.pf.tools.recce.generate-config",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1402,8 +5199,118 @@
       "to": "evidence.pf.review-artifacts-exclude-pii.pf-tool-recce-config",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-15T20:38:47Z",
-        "verified_at": "2026-08-15T20:38:47Z"
+        "created_at": "2026-08-18T15:42:57Z",
+        "verified_at": "2026-08-18T15:42:57Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.derived-from.intent.pf.builds-record-observability",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "intent.pf.builds-record-observability",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.implemented-by.artifact.pf.pf.tools.elementary.bootstrap-project",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "artifact.pf.pf.tools.elementary.bootstrap-project",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.implemented-by.artifact.pf.pf.tools.elementary.ensure-package",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "artifact.pf.pf.tools.elementary.ensure-package",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.verified-by.evidence.pf.builds-record-observability.pf-tool-elementary-report",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "evidence.pf.builds-record-observability.pf-tool-elementary-report",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:55Z",
+        "verified_at": "2026-08-19T21:36:55Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.verified-by.evidence.pf.builds-record-observability.loop-ledger-json",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "evidence.pf.builds-record-observability.loop-ledger-json",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T20:47:22Z",
+        "verified_at": "2026-08-19T20:47:22Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.derived-from.intent.pf.quality-floor-derived-from-ontology",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "intent.pf.quality-floor-derived-from-ontology",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.implemented-by.artifact.pf.pf.tools.expectations.write-tests",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "artifact.pf.pf.tools.expectations.write-tests",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.implemented-by.artifact.pf.pf.tools.expectations.bootstrap-project",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "artifact.pf.pf.tools.expectations.bootstrap-project",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.verified-by.evidence.pf.quality-floor-derived-from-ontology.pf-tool-expectations-run",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "evidence.pf.quality-floor-derived-from-ontology.pf-tool-expectations-run",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:55Z",
+        "verified_at": "2026-08-19T21:36:55Z"
       }
     },
     {
@@ -1412,7 +5319,7 @@
       "to": "intent.pf.secrets-never-in-context",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1423,7 +5330,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1432,8 +5339,8 @@
       "to": "artifact.pf.gate.yaml.denylist",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1442,8 +5349,8 @@
       "to": "artifact.pf.platform.hooks.pre-tool-use.py",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1452,8 +5359,528 @@
       "to": "evidence.pf.secrets-never-in-context.pf-gate",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:43:53Z",
-        "verified_at": "2026-08-16T23:43:53Z"
+        "created_at": "2026-08-19T21:36:55Z",
+        "verified_at": "2026-08-19T21:36:55Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.derived-from.intent.pf.agent-authority-is-least-privilege",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "intent.pf.agent-authority-is-least-privilege",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.implemented-by.artifact.pf.gate.yaml.denylist",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "artifact.pf.gate.yaml.denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.implemented-by.artifact.pf.gate.yaml.platform-denylist",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "artifact.pf.gate.yaml.platform-denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.implemented-by.artifact.pf.pf.loops.gate.check-path",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "artifact.pf.pf.loops.gate.check-path",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.verified-by.evidence.pf.agent-authority-is-least-privilege.pf-gate",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "evidence.pf.agent-authority-is-least-privilege.pf-gate",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:56Z",
+        "verified_at": "2026-08-19T21:36:56Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.derived-from.intent.pf.tool-contribution-may-only-tighten",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "intent.pf.tool-contribution-may-only-tighten",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.implemented-by.artifact.pf.pf.tools.spec.Tool.gate-sections",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "artifact.pf.pf.tools.spec.Tool.gate-sections",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.verified-by.evidence.pf.tool-contribution-may-only-tighten.pf-check",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "evidence.pf.tool-contribution-may-only-tighten.pf-check",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:56Z",
+        "verified_at": "2026-08-19T21:36:56Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.derived-from.intent.pf.agent-decisions-are-recorded",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "intent.pf.agent-decisions-are-recorded",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.implemented-by.artifact.pf.pf.provenance.ledger.decision",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "artifact.pf.pf.provenance.ledger.decision",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.implemented-by.artifact.pf.platform.hooks.pre-tool-use.py",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "artifact.pf.platform.hooks.pre-tool-use.py",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.implemented-by.artifact.pf.platform.hooks.post-tool-use.py",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "artifact.pf.platform.hooks.post-tool-use.py",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.verified-by.evidence.pf.agent-decisions-are-recorded.pf-provenance-verify",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "evidence.pf.agent-decisions-are-recorded.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:57Z",
+        "verified_at": "2026-08-19T21:36:57Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.derived-from.intent.pf.evidence-chain-is-tamper-evident",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "intent.pf.evidence-chain-is-tamper-evident",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.implemented-by.artifact.pf.pf.provenance.chain.verify",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "artifact.pf.pf.provenance.chain.verify",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.implemented-by.artifact.pf.pf.provenance.anchor.stamp-rfc3161",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "artifact.pf.pf.provenance.anchor.stamp-rfc3161",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.implemented-by.artifact.pf.gate.yaml.denylist",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "artifact.pf.gate.yaml.denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.verified-by.evidence.pf.evidence-chain-is-tamper-evident.pf-provenance-verify",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "evidence.pf.evidence-chain-is-tamper-evident.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:57Z",
+        "verified_at": "2026-08-19T21:36:57Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.derived-from.intent.pf.sister-projects-are-isolated",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "intent.pf.sister-projects-are-isolated",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.implemented-by.artifact.pf.gate.yaml.platform-denylist",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "artifact.pf.gate.yaml.platform-denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.implemented-by.artifact.pf.pf.loops.gate.project-for",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "artifact.pf.pf.loops.gate.project-for",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.verified-by.evidence.pf.sister-projects-are-isolated.pf-gate",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "evidence.pf.sister-projects-are-isolated.pf-gate",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:57Z",
+        "verified_at": "2026-08-19T21:36:57Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.derived-from.intent.pf.agent-authority-is-revocable",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "intent.pf.agent-authority-is-revocable",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.implemented-by.artifact.pf.pf.provenance.ledger.revoke",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "artifact.pf.pf.provenance.ledger.revoke",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.implemented-by.artifact.pf.pf.provenance.ledger.is-revoked",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "artifact.pf.pf.provenance.ledger.is-revoked",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.verified-by.evidence.pf.agent-authority-is-revocable.pf-provenance-verify",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "evidence.pf.agent-authority-is-revocable.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:58Z",
+        "verified_at": "2026-08-19T21:36:58Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.derived-from.intent.pf.high-impact-actions-need-a-human",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "intent.pf.high-impact-actions-need-a-human",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.implemented-by.artifact.pf.pf.provenance.ledger.approve",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "artifact.pf.pf.provenance.ledger.approve",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.implemented-by.artifact.pf.pf.provenance.audit.report",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "artifact.pf.pf.provenance.audit.report",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.verified-by.evidence.pf.high-impact-actions-need-a-human.pf-provenance-verify",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "evidence.pf.high-impact-actions-need-a-human.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:58Z",
+        "verified_at": "2026-08-19T21:36:58Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.derived-from.intent.pf.model-routing-is-declared",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "intent.pf.model-routing-is-declared",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.implemented-by.artifact.pf.pf.agents.base.AGENTS",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "artifact.pf.pf.agents.base.AGENTS",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.verified-by.evidence.pf.model-routing-is-declared.pf-provenance-verify",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "evidence.pf.model-routing-is-declared.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:58Z",
+        "verified_at": "2026-08-19T21:36:58Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.derived-from.intent.pf.upstream-licences-are-reviewed",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "intent.pf.upstream-licences-are-reviewed",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.implemented-by.artifact.pf.pf.vendor.model.load-registry",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "artifact.pf.pf.vendor.model.load-registry",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.implemented-by.artifact.pf.pf.vendor.verify.verify",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "artifact.pf.pf.vendor.verify.verify",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.verified-by.evidence.pf.upstream-licences-are-reviewed.pf-check",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "evidence.pf.upstream-licences-are-reviewed.pf-check",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:59Z",
+        "verified_at": "2026-08-19T21:36:59Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.derived-from.intent.pf.control-baseline-is-declared",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "intent.pf.control-baseline-is-declared",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.implemented-by.artifact.pf.pf.air.coverage.assess",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "artifact.pf.pf.air.coverage.assess",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.implemented-by.artifact.pf.pf.air.register.render-register",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "artifact.pf.pf.air.register.render-register",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.verified-by.evidence.pf.control-baseline-is-declared.pf-air-coverage",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "evidence.pf.control-baseline-is-declared.pf-air-coverage",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:36:59Z",
+        "verified_at": "2026-08-19T21:36:59Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.verified-by.evidence.pf.control-baseline-is-declared.governance-air-register-md",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "evidence.pf.control-baseline-is-declared.governance-air-register-md",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:20Z",
+        "verified_at": "2026-08-19T18:05:20Z"
       }
     }
   ],

--- a/groups/acme/projects/acme-us/governance/otop.json
+++ b/groups/acme/projects/acme-us/governance/otop.json
@@ -4,9 +4,9 @@
     "id": "otop.pf.acme.acme-us",
     "title": "Policy and evidence \u2014 acme/acme-us",
     "repository": "https://github.com/Atomz-org/data-platform.git",
-    "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+    "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
     "metadata": {
-      "created_at": "2026-08-16T23:44:00Z",
+      "created_at": "2026-08-19T21:37:23Z",
       "actor": "pf.projections.otop"
     }
   },
@@ -17,13 +17,13 @@
       "title": "Agentic Data Platform governance policy",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
         "scope": "acme/acme-us",
         "source": "platform/src/pf/ontology/policy.yaml",
-        "rules": 10
+        "rules": 22
       }
     },
     {
@@ -32,7 +32,7 @@
       "title": "A monetary amount without its currency is not a number, it is a bug waiting for a second entity to be onboarded.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -45,7 +45,7 @@
       "title": "money-requires-currency",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -61,6 +61,138 @@
         "params": {
           "sibling": "currency_code",
           "scope": "resource"
+        },
+        "controls": [
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -70,8 +202,8 @@
       "title": "pf check for money-requires-currency",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:43:59Z",
-        "observed_at": "2026-08-16T23:43:59Z",
+        "created_at": "2026-08-19T21:37:14Z",
+        "observed_at": "2026-08-19T21:37:14Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -95,7 +227,7 @@
       "title": "A class with no identity property cannot participate in a derived join, so every BI and MDL projection of it is a guess.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -108,7 +240,7 @@
       "title": "entity-requires-identity",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -123,6 +255,138 @@
         },
         "params": {
           "exclude_abstract": true
+        },
+        "controls": [
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -132,8 +396,8 @@
       "title": "pf check for entity-requires-identity",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:43:59Z",
-        "observed_at": "2026-08-16T23:43:59Z",
+        "created_at": "2026-08-19T21:37:15Z",
+        "observed_at": "2026-08-19T21:37:15Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -157,7 +421,7 @@
       "title": "A foreign key pointing at a class the topology does not relate to is an undeclared join. Undeclared joins are how two teams compute different revenue from th...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -170,7 +434,7 @@
       "title": "link-must-be-in-topology",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -183,7 +447,139 @@
         "applies_to": {
           "annotation": "links"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -192,8 +588,8 @@
       "title": "pf check for link-must-be-in-topology",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:43:59Z",
-        "observed_at": "2026-08-16T23:43:59Z",
+        "created_at": "2026-08-19T21:37:15Z",
+        "observed_at": "2026-08-19T21:37:15Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -217,7 +613,7 @@
       "title": "PII may land in raw and staging. It must not reach a mart or an exposure without a masking policy or an explicit, recorded waiver.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -230,7 +626,7 @@
       "title": "pii-not-in-consumption",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -249,6 +645,153 @@
             "semantic",
             "consumption"
           ]
+        },
+        "controls": [
+          "AIR-DET-16",
+          "AIR-PREV-12"
+        ],
+        "control_titles": {
+          "AIR-DET-16": "Preserving Source Data Access Controls in AI Systems",
+          "AIR-PREV-12": "Role-Based Access Control for AI Data"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-3-2",
+              "title": "ISO 42001: AI roles and responsibilities",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-3",
+              "title": "ISO 42001: Acquisition of data",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-9-2",
+              "title": "ISO 42001: Processes for responsible use of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-21",
+              "title": "AC-21 Information Sharing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A238%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C521.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ca-8",
+              "title": "CA-8 Penetration Testing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A351%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "cm-12",
+              "title": "CM-12 Information Location",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ia-2",
+              "title": "IA-2 Identification And Authentication (organizational Users)",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A467%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ia-4",
+              "title": "IA-4 Identifier Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A479%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C422.0%2C0%5D"
+            },
+            {
+              "key": "ia-5",
+              "title": "IA-5 Authenticator Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A485%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -283,8 +826,8 @@
       "title": "STATE.md for pii-not-in-consumption",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "observed_at": "2026-08-15T20:35:53Z",
+        "created_at": "2026-08-18T15:42:57Z",
+        "observed_at": "2026-08-18T15:42:57Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "open_findings",
@@ -308,7 +851,7 @@
       "title": "Grain is the one fact a downstream consumer cannot infer and cannot survive guessing. An undeclared grain is how a join silently fans out.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -321,7 +864,7 @@
       "title": "mart-declares-grain",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "SHOULD",
@@ -336,6 +879,98 @@
         },
         "params": {
           "field": "grain"
+        },
+        "controls": [
+          "AIR-DET-13"
+        ],
+        "control_titles": {
+          "AIR-DET-13": "Providing Citations and Source Traceability for AI-Generated Information"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t5-1",
+              "title": "Table 5.1: Disclosure of AI Use in Products and Services to End-Users",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=49"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-1-2",
+              "title": "ISO 42001: Objectives for responsible development of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-7",
+              "title": "ISO 42001: AI system technical documentation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-2",
+              "title": "ISO 42001: System documentation and information for users",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-10",
+              "title": "AU-10 Non-repudiation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A301%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-8",
+              "title": "SA-8 Security And Privacy Engineering Principles",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A842%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -345,8 +980,8 @@
       "title": "kg/context_card.md for mart-declares-grain",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:43:59Z",
-        "observed_at": "2026-08-16T23:43:59Z",
+        "created_at": "2026-08-19T21:37:14Z",
+        "observed_at": "2026-08-19T21:37:14Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "project_index",
@@ -370,7 +1005,7 @@
       "title": "Aggregation policy \u2014 which statuses count, which timestamp, which filter \u2014 belongs to exactly one metric definition. A mart column named `revenue` is a secon...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -383,7 +1018,7 @@
       "title": "metric-owns-aggregation",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "SHOULD",
@@ -404,6 +1039,98 @@
             "churn_rate",
             "ltv"
           ]
+        },
+        "controls": [
+          "AIR-DET-13"
+        ],
+        "control_titles": {
+          "AIR-DET-13": "Providing Citations and Source Traceability for AI-Generated Information"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t5-1",
+              "title": "Table 5.1: Disclosure of AI Use in Products and Services to End-Users",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=49"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-1-2",
+              "title": "ISO 42001: Objectives for responsible development of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-7",
+              "title": "ISO 42001: AI system technical documentation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-2",
+              "title": "ISO 42001: System documentation and information for users",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-10",
+              "title": "AU-10 Non-repudiation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A301%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-8",
+              "title": "SA-8 Security And Privacy Engineering Principles",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A842%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -413,8 +1140,8 @@
       "title": "pf check for metric-owns-aggregation",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:44:00Z",
-        "observed_at": "2026-08-16T23:44:00Z",
+        "created_at": "2026-08-19T21:37:16Z",
+        "observed_at": "2026-08-19T21:37:16Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -438,7 +1165,7 @@
       "title": "A model or column change must report what it breaks before it lands, including the human who owns each affected exposure.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -451,7 +1178,7 @@
       "title": "change-declares-blast-radius",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -464,7 +1191,158 @@
         "applies_to": {
           "artifact_glob": "**/transform/models/**"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-DET-21",
+          "AIR-PREV-18"
+        ],
+        "control_titles": {
+          "AIR-DET-21": "Agent Decision Audit and Explainability",
+          "AIR-PREV-18": "Agent Authority Least Privilege Framework"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00040",
+              "title": "ATR-2026-00040 Agent Privilege Escalation",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/privilege-escalation/ATR-2026-00040-privilege-escalation.yaml"
+            },
+            {
+              "key": "ATR-2026-00098",
+              "title": "ATR-2026-00098 Unauthorized Financial Action by Agent",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/excessive-autonomy/ATR-2026-00098-unauthorized-financial-action.yaml"
+            }
+          ],
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a12",
+              "title": "III.S2.A12: Record-Keeping",
+              "url": "https://artificialintelligenceact.eu/article/12/"
+            },
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c3-s3-a26",
+              "title": "III.S3.A26: Obligations of Deployers of High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/26/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -473,8 +1351,8 @@
       "title": "impact_reports for change-declares-blast-radius",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:44:00Z",
-        "observed_at": "2026-08-16T23:44:00Z",
+        "created_at": "2026-08-19T21:37:16Z",
+        "observed_at": "2026-08-19T21:37:16Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "blast_radius_history",
@@ -498,8 +1376,8 @@
       "title": "loop-ledger.json for change-declares-blast-radius",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "observed_at": "2026-08-15T20:35:53Z",
+        "created_at": "2026-08-19T20:47:22Z",
+        "observed_at": "2026-08-19T20:47:22Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "run_history",
@@ -523,7 +1401,7 @@
       "title": "A blast radius is a prediction made from lineage. Lineage cannot say whether the numbers actually moved, so a change to a mart must also be compared against ...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -536,7 +1414,7 @@
       "title": "change-verified-against-baseline",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "SHOULD",
@@ -549,7 +1427,94 @@
         "applies_to": {
           "artifact_glob": "**/transform/models/marts/**"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-PREV-5"
+        ],
+        "control_titles": {
+          "AIR-PREV-5": "System Acceptance Testing"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a15",
+              "title": "III.S2.A15: Accuracy, Robustness and Cybersecurity",
+              "url": "https://artificialintelligenceact.eu/article/15/"
+            },
+            {
+              "key": "c3-s2-a9",
+              "title": "III.S2.A9: Risk Management System",
+              "url": "https://artificialintelligenceact.eu/article/9/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-1",
+              "title": "Table 4.1: Assessment of Risk-Proportionate Controls",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=41"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-4",
+              "title": "ISO 42001: AI system verification and validation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-5",
+              "title": "ISO 42001: AI system deployment",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ca-2",
+              "title": "CA-2 Control Assessments",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A324%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C684%2C0%5D"
+            },
+            {
+              "key": "ca-6",
+              "title": "CA-6 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A339%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "cm-4",
+              "title": "CM-4 Impact Analyses",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A375%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C509.0%2C0%5D"
+            },
+            {
+              "key": "sa-11",
+              "title": "SA-11 Developer Testing And Evaluation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A899%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C601.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-2",
+              "title": "SI-2 Flaw Remediation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1070%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-6",
+              "title": "SI-6 Security And Privacy Function Verification",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1103%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C475.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -558,12 +1523,12 @@
       "title": "pf tool recce run for change-verified-against-baseline",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:56:57Z",
-        "observed_at": "2026-08-16T22:56:57Z",
+        "created_at": "2026-08-19T21:37:17Z",
+        "observed_at": "2026-08-19T21:37:17Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "data_diff_against_baseline",
-      "result": "pass",
+      "result": "unknown",
       "subjects": [
         {
           "id": "constraint.pf.change-verified-against-baseline",
@@ -574,7 +1539,7 @@
       "provenance": {
         "actor": "pf.projections.otop",
         "scope": "acme/acme-us",
-        "detail": "groups/acme/projects/acme-us/transform/recce_state.json"
+        "detail": "no baseline captured"
       }
     },
     {
@@ -583,7 +1548,7 @@
       "title": "A value-level diff writes the rows it compared into the review tool's state file, which is durable and shared. Diffing a column whose role is PII therefore p...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -596,7 +1561,7 @@
       "title": "review-artifacts-exclude-pii",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -609,7 +1574,194 @@
         "applies_to": {
           "artifact_glob": "**/transform/recce.yml"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-DET-1",
+          "AIR-PREV-12"
+        ],
+        "control_titles": {
+          "AIR-DET-1": "AI Data Leakage Prevention and Detection",
+          "AIR-PREV-12": "Role-Based Access Control for AI Data"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-3-2",
+              "title": "ISO 42001: AI roles and responsibilities",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-5-2",
+              "title": "ISO 42001: AI system impact assessment process",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-20",
+              "title": "AC-20 Use Of External Systems",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A232%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C598.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-13",
+              "title": "AU-13 Monitoring For Information Disclosure",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A310%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C556.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-3",
+              "title": "CA-3 Information Exchange",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A330%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C166.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-12",
+              "title": "CM-12 Information Location",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ia-2",
+              "title": "IA-2 Identification And Authentication (organizational Users)",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A467%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ia-4",
+              "title": "IA-4 Identifier Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A479%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C422.0%2C0%5D"
+            },
+            {
+              "key": "ia-5",
+              "title": "IA-5 Authenticator Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A485%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "ir-4",
+              "title": "IR-4 Incident Handling",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A527%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C626.0%2C0%5D"
+            },
+            {
+              "key": "ir-9",
+              "title": "IR-9 Information Spillage Response",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A548%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C135.0%2C0%5D"
+            },
+            {
+              "key": "mp-6",
+              "title": "MP-6 Media Sanitization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A593%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C314.0%2C0%5D"
+            },
+            {
+              "key": "sa-9",
+              "title": "SA-9 External System Services",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A884%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C665.0%2C0%5D"
+            },
+            {
+              "key": "sc-28",
+              "title": "SC-28 Protection Of Information AT Rest",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1019%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C191.0%2C0%5D"
+            },
+            {
+              "key": "sc-7",
+              "title": "SC-7 Boundary Protection",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A962%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C399.0%2C0%5D"
+            },
+            {
+              "key": "sc-8",
+              "title": "SC-8 Transmission Confidentiality And Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A983%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C223.0%2C0%5D"
+            },
+            {
+              "key": "si-20",
+              "title": "SI-20 Tainting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1151%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C232.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -618,8 +1770,8 @@
       "title": "pf tool recce config for review-artifacts-exclude-pii",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T20:38:47Z",
-        "observed_at": "2026-08-15T20:38:47Z",
+        "created_at": "2026-08-18T15:42:57Z",
+        "observed_at": "2026-08-18T15:42:57Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "derived_review_checks",
@@ -638,12 +1790,580 @@
       }
     },
     {
+      "id": "intent.pf.builds-record-observability",
+      "kind": "intent",
+      "title": "A dbt build that leaves no queryable record cannot be triaged; failures get diagnosed from whichever log happened to survive. Every build must record its run...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A dbt build that leaves no queryable record cannot be triaged; failures get diagnosed from whichever log happened to survive. Every build must record its run and test results into the warehouse with history \u2014 for every test framework at once \u2014 so \"is this new, recurring, or flaky?\" is a query, not an archaeology dig."
+      }
+    },
+    {
+      "id": "constraint.pf.builds-record-observability",
+      "kind": "constraint",
+      "title": "builds-record-observability",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "observability_recorded",
+      "checkability": "automated",
+      "assertion": "observability_recorded on artifact_glob=**/transform/packages.yml",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/transform/packages.yml"
+        },
+        "params": {},
+        "controls": [
+          "AIR-DET-4",
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-DET-4": "AI System Observability",
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t7-adoption",
+              "title": "Table 7: AI Adoption Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=57"
+            },
+            {
+              "key": "t7-nature",
+              "title": "Table 7: Nature and Use Cases of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            },
+            {
+              "key": "t7-performance",
+              "title": "Table 7: AI System Performance Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-8",
+              "title": "ISO 42001: AI system recording of event logs",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "au-11",
+              "title": "AU-11 Audit Record Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C462.0%2C0%5D"
+            },
+            {
+              "key": "au-12",
+              "title": "AU-12 Audit Record Generation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C122.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "ir-4",
+              "title": "IR-4 Incident Handling",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A527%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C626.0%2C0%5D"
+            },
+            {
+              "key": "ir-5",
+              "title": "IR-5 Incident Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A539%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C387%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-10",
+              "title": "RA-10 Threat Hunting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A812%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C110.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.builds-record-observability.pf-tool-elementary-report",
+      "kind": "evidence",
+      "title": "pf tool elementary report for builds-record-observability",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:18Z",
+        "observed_at": "2026-08-19T21:37:18Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "observability_report_over_recorded_history",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.builds-record-observability",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-us",
+        "detail": "pf tool elementary report not produced yet"
+      }
+    },
+    {
+      "id": "evidence.pf.builds-record-observability.loop-ledger-json",
+      "kind": "evidence",
+      "title": "loop-ledger.json for builds-record-observability",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T20:47:22Z",
+        "observed_at": "2026-08-19T20:47:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "run_history",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.builds-record-observability",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-us",
+        "detail": "loop-ledger.json"
+      }
+    },
+    {
+      "id": "intent.pf.quality-floor-derived-from-ontology",
+      "kind": "intent",
+      "title": "Hand-written test coverage decays to whichever models someone remembered. The floor \u2014 an annotated mart is never empty, a declared identity identifies \u2014 must...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Hand-written test coverage decays to whichever models someone remembered. The floor \u2014 an annotated mart is never empty, a declared identity identifies \u2014 must be derived from the ontology roles, so coverage is a function of annotation rather than of memory, and a wrong test is a wrong role rather than a stale file."
+      }
+    },
+    {
+      "id": "constraint.pf.quality-floor-derived-from-ontology",
+      "kind": "constraint",
+      "title": "quality-floor-derived-from-ontology",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "tests_derived_from_roles",
+      "checkability": "automated",
+      "assertion": "tests_derived_from_roles on artifact_glob=**/transform/tests/expectations/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/transform/tests/expectations/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-6",
+          "AIR-PREV-5"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity",
+          "AIR-PREV-5": "System Acceptance Testing"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            },
+            {
+              "key": "c3-s2-a15",
+              "title": "III.S2.A15: Accuracy, Robustness and Cybersecurity",
+              "url": "https://artificialintelligenceact.eu/article/15/"
+            },
+            {
+              "key": "c3-s2-a9",
+              "title": "III.S2.A9: Risk Management System",
+              "url": "https://artificialintelligenceact.eu/article/9/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-1",
+              "title": "Table 4.1: Assessment of Risk-Proportionate Controls",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=41"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-4",
+              "title": "ISO 42001: AI system verification and validation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-5",
+              "title": "ISO 42001: AI system deployment",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-2",
+              "title": "CA-2 Control Assessments",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A324%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C684%2C0%5D"
+            },
+            {
+              "key": "ca-6",
+              "title": "CA-6 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A339%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "cm-4",
+              "title": "CM-4 Impact Analyses",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A375%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C509.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-11",
+              "title": "SA-11 Developer Testing And Evaluation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A899%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C601.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-2",
+              "title": "SI-2 Flaw Remediation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1070%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-6",
+              "title": "SI-6 Security And Privacy Function Verification",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1103%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C475.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.quality-floor-derived-from-ontology.pf-tool-expectations-run",
+      "kind": "evidence",
+      "title": "pf tool expectations run for quality-floor-derived-from-ontology",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:18Z",
+        "observed_at": "2026-08-19T21:37:18Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "quality_floor_verdicts",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.quality-floor-derived-from-ontology",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-us",
+        "detail": "pf tool expectations run not produced yet"
+      }
+    },
+    {
       "id": "intent.pf.secrets-never-in-context",
       "kind": "intent",
       "title": "A credential placed in a prompt, a model file or a committed artefact is durably persisted and replayed into every later session.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -656,7 +2376,7 @@
       "title": "secrets-never-in-context",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -669,7 +2389,131 @@
         "applies_to": {
           "artifact_glob": "**/secrets.toml"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-PREV-23",
+          "AIR-DET-16"
+        ],
+        "control_titles": {
+          "AIR-PREV-23": "Agentic System Credential Protection Framework",
+          "AIR-DET-16": "Preserving Source Data Access Controls in AI Systems"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00113",
+              "title": "ATR-2026-00113 Credential Theft via Agent Channel",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/context-exfiltration/ATR-2026-00113-credential-theft.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-3",
+              "title": "ISO 42001: Acquisition of data",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-9-2",
+              "title": "ISO 42001: Processes for responsible use of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-21",
+              "title": "AC-21 Information Sharing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A238%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C521.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ca-8",
+              "title": "CA-8 Penetration Testing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A351%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ia-5",
+              "title": "IA-5 Authenticator Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A485%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "sc-28",
+              "title": "SC-28 Protection Of Information AT Rest",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1019%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C191.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -678,8 +2522,8 @@
       "title": "pf gate for secrets-never-in-context",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:44:00Z",
-        "observed_at": "2026-08-16T23:44:00Z",
+        "created_at": "2026-08-19T21:37:18Z",
+        "observed_at": "2026-08-19T21:37:18Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "path_verdict",
@@ -698,23 +2542,1498 @@
       }
     },
     {
+      "id": "intent.pf.agent-authority-is-least-privilege",
+      "kind": "intent",
+      "title": "An agent reaches the filesystem through one path gate, and the paths it may never write are declared rather than remembered. Least privilege that lives in a ...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "An agent reaches the filesystem through one path gate, and the paths it may never write are declared rather than remembered. Least privilege that lives in a prompt is a request; in a denylist it is a control."
+      }
+    },
+    {
+      "id": "constraint.pf.agent-authority-is-least-privilege",
+      "kind": "constraint",
+      "title": "agent-authority-is-least-privilege",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "path_denied",
+      "checkability": "automated",
+      "assertion": "path_denied on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-18"
+        ],
+        "control_titles": {
+          "AIR-PREV-18": "Agent Authority Least Privilege Framework"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00040",
+              "title": "ATR-2026-00040 Agent Privilege Escalation",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/privilege-escalation/ATR-2026-00040-privilege-escalation.yaml"
+            },
+            {
+              "key": "ATR-2026-00098",
+              "title": "ATR-2026-00098 Unauthorized Financial Action by Agent",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/excessive-autonomy/ATR-2026-00098-unauthorized-financial-action.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.agent-authority-is-least-privilege.pf-gate",
+      "kind": "evidence",
+      "title": "pf gate for agent-authority-is-least-privilege",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:19Z",
+        "observed_at": "2026-08-19T21:37:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "path_verdict",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.agent-authority-is-least-privilege",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-us",
+        "detail": "denylist present"
+      }
+    },
+    {
+      "id": "intent.pf.tool-contribution-may-only-tighten",
+      "kind": "intent",
+      "title": "A tool contributes gate rules, and a plugin system that can widen the policy judging it is not a policy. `Tool.gate_sections()` rejects a contribution to any...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A tool contributes gate rules, and a plugin system that can widen the policy judging it is not a policy. `Tool.gate_sections()` rejects a contribution to any loosening section at construction, so an unsafe tool fails at import rather than silently permitting more."
+      }
+    },
+    {
+      "id": "constraint.pf.tool-contribution-may-only-tighten",
+      "kind": "constraint",
+      "title": "tool-contribution-may-only-tighten",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "tightening_only",
+      "checkability": "automated",
+      "assertion": "tightening_only (sections=['denylist', 'platform_denylist', 'impact_required']) on artifact_glob=gate.capabilities.yaml",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "gate.capabilities.yaml"
+        },
+        "params": {
+          "sections": [
+            "denylist",
+            "platform_denylist",
+            "impact_required"
+          ]
+        },
+        "controls": [
+          "AIR-PREV-19"
+        ],
+        "control_titles": {
+          "AIR-PREV-19": "Tool Chain Validation and Sanitization"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00011",
+              "title": "ATR-2026-00011 Instruction Injection via Tool Output",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00011-tool-output-injection.yaml"
+            },
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00013",
+              "title": "ATR-2026-00013 Tool-Driven Server-Side Request Forgery",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00013-tool-ssrf.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "sc-4",
+              "title": "SC-4 Information In Shared System Resources",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A956%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-15",
+              "title": "SI-15 Information Output Filtering",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1136%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C355.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.tool-contribution-may-only-tighten.pf-check",
+      "kind": "evidence",
+      "title": "pf check for tool-contribution-may-only-tighten",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:19Z",
+        "observed_at": "2026-08-19T21:37:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "conformance_report",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.tool-contribution-may-only-tighten",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-us",
+        "detail": "0 error(s), 0 issue(s)"
+      }
+    },
+    {
+      "id": "intent.pf.agent-decisions-are-recorded",
+      "kind": "intent",
+      "title": "Every tool call an agent makes is written down before it happens and after it happens, and the gate's verdict is recorded for allows as well as denies. \"No r...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Every tool call an agent makes is written down before it happens and after it happens, and the gate's verdict is recorded for allows as well as denies. \"No rule applied\" and \"a rule allowed it\" are different facts, and only a record that carries both can answer what an agent was permitted to do."
+      }
+    },
+    {
+      "id": "constraint.pf.agent-decisions-are-recorded",
+      "kind": "constraint",
+      "title": "agent-decisions-are-recorded",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "action_recorded",
+      "checkability": "automated",
+      "assertion": "action_recorded (stages=['intent', 'decision', 'execution']) on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {
+          "stages": [
+            "intent",
+            "decision",
+            "execution"
+          ]
+        },
+        "controls": [
+          "AIR-DET-21",
+          "AIR-DET-4"
+        ],
+        "control_titles": {
+          "AIR-DET-21": "Agent Decision Audit and Explainability",
+          "AIR-DET-4": "AI System Observability"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a12",
+              "title": "III.S2.A12: Record-Keeping",
+              "url": "https://artificialintelligenceact.eu/article/12/"
+            },
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c3-s3-a26",
+              "title": "III.S3.A26: Obligations of Deployers of High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/26/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t7-adoption",
+              "title": "Table 7: AI Adoption Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=57"
+            },
+            {
+              "key": "t7-nature",
+              "title": "Table 7: Nature and Use Cases of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            },
+            {
+              "key": "t7-performance",
+              "title": "Table 7: AI System Performance Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-8",
+              "title": "ISO 42001: AI system recording of event logs",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-11",
+              "title": "AU-11 Audit Record Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C462.0%2C0%5D"
+            },
+            {
+              "key": "au-12",
+              "title": "AU-12 Audit Record Generation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C122.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ir-4",
+              "title": "IR-4 Incident Handling",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A527%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C626.0%2C0%5D"
+            },
+            {
+              "key": "ir-5",
+              "title": "IR-5 Incident Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A539%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C387%2C0%5D"
+            },
+            {
+              "key": "ra-10",
+              "title": "RA-10 Threat Hunting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A812%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C110.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.agent-decisions-are-recorded.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for agent-decisions-are-recorded",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:20Z",
+        "observed_at": "2026-08-19T21:37:20Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.agent-decisions-are-recorded",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-us",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.evidence-chain-is-tamper-evident",
+      "kind": "intent",
+      "title": "A log an agent can edit is not evidence. Each record carries the hash of the one before it, and the head is anchored to a timestamp authority with no stake i...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A log an agent can edit is not evidence. Each record carries the hash of the one before it, and the head is anchored to a timestamp authority with no stake in what it says \u2014 so editing the middle requires editing the end, and the end is countersigned."
+      }
+    },
+    {
+      "id": "constraint.pf.evidence-chain-is-tamper-evident",
+      "kind": "constraint",
+      "title": "evidence-chain-is-tamper-evident",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "hash_chained",
+      "checkability": "automated",
+      "assertion": "hash_chained on artifact_glob=provenance/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "provenance/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-DET-21"
+        ],
+        "control_titles": {
+          "AIR-DET-21": "Agent Decision Audit and Explainability"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a12",
+              "title": "III.S2.A12: Record-Keeping",
+              "url": "https://artificialintelligenceact.eu/article/12/"
+            },
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c3-s3-a26",
+              "title": "III.S3.A26: Obligations of Deployers of High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/26/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.evidence-chain-is-tamper-evident.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for evidence-chain-is-tamper-evident",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:20Z",
+        "observed_at": "2026-08-19T21:37:20Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.evidence-chain-is-tamper-evident",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-us",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.sister-projects-are-isolated",
+      "kind": "intent",
+      "title": "Business logic does not transfer between entities, so an assumption carried from one sister company into another is a bug by construction. A project session ...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Business logic does not transfer between entities, so an assumption carried from one sister company into another is a bug by construction. A project session may not read or write another project, and may not write shared infra at all."
+      }
+    },
+    {
+      "id": "constraint.pf.sister-projects-are-isolated",
+      "kind": "constraint",
+      "title": "sister-projects-are-isolated",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "cross_tenant_denied",
+      "checkability": "automated",
+      "assertion": "cross_tenant_denied on artifact_glob=groups/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "groups/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-22"
+        ],
+        "control_titles": {
+          "AIR-PREV-22": "Multi-Agent Isolation and Segmentation"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00030",
+              "title": "ATR-2026-00030 Cross-Agent Attack Detection",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/agent-manipulation/ATR-2026-00030-cross-agent-attack.yaml"
+            },
+            {
+              "key": "ATR-2026-00076",
+              "title": "ATR-2026-00076 Insecure Inter-Agent Communication",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/agent-manipulation/ATR-2026-00076-inter-agent-message-spoofing.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "sc-3",
+              "title": "SC-3 Security Function Isolation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A950%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C217.0%2C0%5D"
+            },
+            {
+              "key": "sc-32",
+              "title": "SC-32 System Partitioning",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1031%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C227.0%2C0%5D"
+            },
+            {
+              "key": "sc-7",
+              "title": "SC-7 Boundary Protection",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A962%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C399.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.sister-projects-are-isolated.pf-gate",
+      "kind": "evidence",
+      "title": "pf gate for sister-projects-are-isolated",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:21Z",
+        "observed_at": "2026-08-19T21:37:21Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "path_verdict",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.sister-projects-are-isolated",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-us",
+        "detail": "denylist present"
+      }
+    },
+    {
+      "id": "intent.pf.agent-authority-is-revocable",
+      "kind": "intent",
+      "title": "A control that cannot be switched off mid-incident is a control you find out about afterwards. Revocation is checked before intent is written, and an unreada...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A control that cannot be switched off mid-incident is a control you find out about afterwards. Revocation is checked before intent is written, and an unreadable revocation file fails closed."
+      }
+    },
+    {
+      "id": "constraint.pf.agent-authority-is-revocable",
+      "kind": "constraint",
+      "title": "agent-authority-is-revocable",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "revocable",
+      "checkability": "automated",
+      "assertion": "revocable on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-18"
+        ],
+        "control_titles": {
+          "AIR-PREV-18": "Agent Authority Least Privilege Framework"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00040",
+              "title": "ATR-2026-00040 Agent Privilege Escalation",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/privilege-escalation/ATR-2026-00040-privilege-escalation.yaml"
+            },
+            {
+              "key": "ATR-2026-00098",
+              "title": "ATR-2026-00098 Unauthorized Financial Action by Agent",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/excessive-autonomy/ATR-2026-00098-unauthorized-financial-action.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.agent-authority-is-revocable.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for agent-authority-is-revocable",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:21Z",
+        "observed_at": "2026-08-19T21:37:21Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.agent-authority-is-revocable",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-us",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.high-impact-actions-need-a-human",
+      "kind": "intent",
+      "title": "Human oversight is a chain that shows the approval, not a document that asserts it. Approvals are append-only and bound to the action they approve, and an ac...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Human oversight is a chain that shows the approval, not a document that asserts it. Approvals are append-only and bound to the action they approve, and an actor approving their own action is a finding rather than an approval."
+      }
+    },
+    {
+      "id": "constraint.pf.high-impact-actions-need-a-human",
+      "kind": "constraint",
+      "title": "high-impact-actions-need-a-human",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "approval_recorded",
+      "checkability": "automated",
+      "assertion": "approval_recorded on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-DET-11"
+        ],
+        "control_titles": {
+          "AIR-DET-11": "Human Feedback Loop for AI Systems"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a14",
+              "title": "III.S2.A14: Human Oversight",
+              "url": "https://artificialintelligenceact.eu/article/14/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-3-3",
+              "title": "ISO 42001: Reporting of concerns",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-2",
+              "title": "ISO 42001: System documentation and information for users",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ca-2",
+              "title": "CA-2 Control Assessments",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A324%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C684%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ir-6",
+              "title": "IR-6 Incident Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A542%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "pm-26",
+              "title": "PM-26 Complaint Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A722%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C365.0%2C0%5D"
+            },
+            {
+              "key": "ra-5",
+              "title": "RA-5 Vulnerability Monitoring And Scanning",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A797%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C594.0%2C0%5D"
+            },
+            {
+              "key": "si-2",
+              "title": "SI-2 Flaw Remediation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1070%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.high-impact-actions-need-a-human.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for high-impact-actions-need-a-human",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:22Z",
+        "observed_at": "2026-08-19T21:37:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.high-impact-actions-need-a-human",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-us",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.model-routing-is-declared",
+      "kind": "intent",
+      "title": "Which model answers which step is a declared table, not whatever the caller passed. An unregistered step is recorded as such, and the recorded verdict matche...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Which model answers which step is a declared table, not whatever the caller passed. An unregistered step is recorded as such, and the recorded verdict matches what actually happened rather than what policy would have preferred."
+      }
+    },
+    {
+      "id": "constraint.pf.model-routing-is-declared",
+      "kind": "constraint",
+      "title": "model-routing-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "routing_declared",
+      "checkability": "automated",
+      "assertion": "routing_declared on artifact_glob=**/agents/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/agents/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-10"
+        ],
+        "control_titles": {
+          "AIR-PREV-10": "AI Model Version Pinning"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-4",
+              "title": "ISO 42001: Tooling resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-3",
+              "title": "ISO 42001: Documentation of AI system design and development",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-5",
+              "title": "ISO 42001: AI system deployment",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "cm-2",
+              "title": "CM-2 Baseline Configuration",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A363%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "cm-3",
+              "title": "CM-3 Configuration Change Control",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A366%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C205.0%2C0%5D"
+            },
+            {
+              "key": "cm-4",
+              "title": "CM-4 Impact Analyses",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A375%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C509.0%2C0%5D"
+            },
+            {
+              "key": "cm-8",
+              "title": "CM-8 System Component Inventory",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A393%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C197.0%2C0%5D"
+            },
+            {
+              "key": "sa-10",
+              "title": "SA-10 Developer Configuration Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A890%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C211.0%2C0%5D"
+            },
+            {
+              "key": "sa-22",
+              "title": "SA-22 Unsupported System Components",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A941%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C497.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sr-4",
+              "title": "SR-4 Provenance",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1169%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C257.0%2C0%5D"
+            },
+            {
+              "key": "sr-8",
+              "title": "SR-8 Notification Agreements",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1184%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C620.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.model-routing-is-declared.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for model-routing-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:22Z",
+        "observed_at": "2026-08-19T21:37:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.model-routing-is-declared",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-us",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.upstream-licences-are-reviewed",
+      "kind": "intent",
+      "title": "Every upstream this platform borrowed from carries a licence, and some of them constrain what we may ship. The review is written down per upstream and surfac...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Every upstream this platform borrowed from carries a licence, and some of them constrain what we may ship. The review is written down per upstream and surfaced in the listing, so a constraint is a fact in the registry rather than something someone once checked."
+      }
+    },
+    {
+      "id": "constraint.pf.upstream-licences-are-reviewed",
+      "kind": "constraint",
+      "title": "upstream-licences-are-reviewed",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "licence_reviewed",
+      "checkability": "automated",
+      "assertion": "licence_reviewed on artifact_glob=vendor/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "vendor/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-7"
+        ],
+        "control_titles": {
+          "AIR-PREV-7": "Legal and Contractual Frameworks for AI Systems"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t4-1",
+              "title": "Table 4.1: Assessment of Risk-Proportionate Controls",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=41"
+            },
+            {
+              "key": "t4-7",
+              "title": "Table 4.7: Legal Framework and Accountability",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=44"
+            },
+            {
+              "key": "t7-third-party",
+              "title": "Table 7: Third-Party Dependencies and Concentrations",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-10-2",
+              "title": "ISO 42001: Allocating responsibilities",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-10-3",
+              "title": "ISO 42001: Suppliers",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-2-3",
+              "title": "ISO 42001: Alignment with other organizational policies",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-5",
+              "title": "ISO 42001: Information for interested parties",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-20",
+              "title": "AC-20 Use Of External Systems",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A232%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C598.0%2C0%5D"
+            },
+            {
+              "key": "ca-3",
+              "title": "CA-3 Information Exchange",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A330%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C166.0%2C0%5D"
+            },
+            {
+              "key": "ir-6",
+              "title": "IR-6 Incident Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A542%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "pm-30",
+              "title": "PM-30 Supply Chain Risk Management Strategy",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A728%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C427.0%2C0%5D"
+            },
+            {
+              "key": "ps-7",
+              "title": "PS-7 External Personnel Security",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A752%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C623.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-9",
+              "title": "SA-9 External System Services",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A884%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C665.0%2C0%5D"
+            },
+            {
+              "key": "sr-2",
+              "title": "SR-2 Supply Chain Risk Management Plan",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1163%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C684.0%2C0%5D"
+            },
+            {
+              "key": "sr-3",
+              "title": "SR-3 Supply Chain Controls And Processes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1166%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C440.0%2C0%5D"
+            },
+            {
+              "key": "sr-5",
+              "title": "SR-5 Acquisition Strategies, Tools, And Methods",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1175%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C243.0%2C0%5D"
+            },
+            {
+              "key": "sr-8",
+              "title": "SR-8 Notification Agreements",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1184%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C620.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.upstream-licences-are-reviewed.pf-check",
+      "kind": "evidence",
+      "title": "pf check for upstream-licences-are-reviewed",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:22Z",
+        "observed_at": "2026-08-19T21:37:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "conformance_report",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.upstream-licences-are-reviewed",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-us",
+        "detail": "0 error(s), 0 issue(s)"
+      }
+    },
+    {
+      "id": "intent.pf.control-baseline-is-declared",
+      "kind": "intent",
+      "title": "A risk register that names controls nobody enforces is a document. Each entity declares in `air.yaml` which controls it commits to; those are derived from th...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A risk register that names controls nobody enforces is a document. Each entity declares in `air.yaml` which controls it commits to; those are derived from the repository on every run and block the merge when they fail, while everything outside the baseline is reported and does not."
+      }
+    },
+    {
+      "id": "constraint.pf.control-baseline-is-declared",
+      "kind": "constraint",
+      "title": "control-baseline-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "baseline_declared",
+      "checkability": "automated",
+      "assertion": "baseline_declared on artifact_glob=**/air.yaml",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/air.yaml"
+        },
+        "params": {}
+      }
+    },
+    {
+      "id": "evidence.pf.control-baseline-is-declared.pf-air-coverage",
+      "kind": "evidence",
+      "title": "pf air coverage for control-baseline-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:23Z",
+        "observed_at": "2026-08-19T21:37:23Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "control_coverage_verdicts",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.control-baseline-is-declared",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-us",
+        "detail": "pf air coverage not produced yet"
+      }
+    },
+    {
+      "id": "evidence.pf.control-baseline-is-declared.governance-air-register-md",
+      "kind": "evidence",
+      "title": "governance/air-register.md for control-baseline-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:20Z",
+        "observed_at": "2026-08-19T18:05:20Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "per-entity_risk_register",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.control-baseline-is-declared",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "acme/acme-us",
+        "detail": "groups/acme/projects/acme-us/governance/air-register.md"
+      }
+    },
+    {
       "id": "artifact.pf.pf.ontology.validate.money-without-currency",
       "kind": "artifact",
       "title": "pf.ontology.validate:money-without-currency",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "money-without-currency",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -726,18 +4045,18 @@
       "title": "pf.ontology.validate:class-without-identity",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "class-without-identity",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -749,18 +4068,18 @@
       "title": "pf.ontology.validate:illegal-edge",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "illegal-edge",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -772,18 +4091,18 @@
       "title": "pf.loops.registry:pii_audit",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T02:49:37Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "loop",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/loops/registry.py",
         "language": "python",
         "symbol": "pii_audit",
-        "digest": "git:293a23d6448c5fe70cee7c96a01f2690d8af47c2"
+        "digest": "git:e81ff725c18b4ff2a8187f5fb953a9dc003a56f4"
       },
       "extensions": {
         "exists": true
@@ -795,18 +4114,18 @@
       "title": "pf.kg.build:model-grain",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T02:04:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/kg/build.py",
         "language": "python",
         "symbol": "model-grain",
-        "digest": "git:2c8398b8a1246d27395ac2140ceba10eea0d3072"
+        "digest": "git:db169407ccb59827ce7f3c5932b2b4a0d40e1124"
       },
       "extensions": {
         "exists": true
@@ -818,18 +4137,18 @@
       "title": "pf.ontology.validate:metric-shaped-column",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "metric-shaped-column",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -841,17 +4160,17 @@
       "title": "platform/hooks/pre_tool_use.py",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T00:11:17Z",
+        "created_at": "2026-08-18T18:40:22Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "hook",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/hooks/pre_tool_use.py",
         "language": "python",
-        "digest": "git:2cb586ed58222bcb50e9cd0013d536cb2c9e6856"
+        "digest": "git:230bc9d9639eaa71c8c511affccb14881cdfc1f1"
       },
       "extensions": {
         "exists": true
@@ -863,14 +4182,14 @@
       "title": "platform/hooks/pre_commit.sh",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-12T16:06:37Z",
+        "created_at": "2026-08-12T14:06:37Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "hook",
       "language": "bash",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/hooks/pre_commit.sh",
         "language": "bash",
         "digest": "git:ce8e6f322ce15a546c16d2eb25bddf4fab5b6688"
@@ -885,18 +4204,18 @@
       "title": "pf.tools.recce:dagster_assets",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:50:23Z",
+        "created_at": "2026-08-17T23:50:05Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/tools/recce.py",
         "language": "python",
         "symbol": "dagster_assets",
-        "digest": "git:8a560994bb5a994b5a57b37a07f99114656b18a3"
+        "digest": "git:6d6c7a4515c5aa68b9642ca221805c28a15f4fc1"
       },
       "extensions": {
         "exists": true
@@ -908,18 +4227,18 @@
       "title": "pf.tools.recce:register_commands",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:50:23Z",
+        "created_at": "2026-08-17T23:50:05Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/tools/recce.py",
         "language": "python",
         "symbol": "register_commands",
-        "digest": "git:8a560994bb5a994b5a57b37a07f99114656b18a3"
+        "digest": "git:6d6c7a4515c5aa68b9642ca221805c28a15f4fc1"
       },
       "extensions": {
         "exists": true
@@ -931,18 +4250,18 @@
       "title": "pf.ontology.model:Role.review_intent",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T22:35:09Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/model.py",
         "language": "python",
         "symbol": "Role.review_intent",
-        "digest": "git:3e691a864da03459b04489a674bbba0a1839b1ea"
+        "digest": "git:513888ee8c2df8cfa1d09562ad3dc2793c4f741e"
       },
       "extensions": {
         "exists": true
@@ -954,18 +4273,106 @@
       "title": "pf.tools.recce:generate_config",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:50:23Z",
+        "created_at": "2026-08-17T23:50:05Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/tools/recce.py",
         "language": "python",
         "symbol": "generate_config",
-        "digest": "git:8a560994bb5a994b5a57b37a07f99114656b18a3"
+        "digest": "git:6d6c7a4515c5aa68b9642ca221805c28a15f4fc1"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.elementary.bootstrap-project",
+      "kind": "artifact",
+      "title": "pf.tools.elementary:bootstrap_project",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:18Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/elementary.py",
+        "language": "python",
+        "symbol": "bootstrap_project"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.elementary.ensure-package",
+      "kind": "artifact",
+      "title": "pf.tools.elementary:ensure_package",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:18Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/elementary.py",
+        "language": "python",
+        "symbol": "ensure_package"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.expectations.write-tests",
+      "kind": "artifact",
+      "title": "pf.tools.expectations:write_tests",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:18Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/expectations.py",
+        "language": "python",
+        "symbol": "write_tests"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.expectations.bootstrap-project",
+      "kind": "artifact",
+      "title": "pf.tools.expectations:bootstrap_project",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:18Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/expectations.py",
+        "language": "python",
+        "symbol": "bootstrap_project"
       },
       "extensions": {
         "exists": true
@@ -977,18 +4384,408 @@
       "title": "gate.yaml:denylist",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-17T00:38:30Z",
+        "created_at": "2026-08-18T18:40:22Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "configuration",
       "language": "yaml",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "gate.yaml",
         "language": "yaml",
         "symbol": "denylist",
-        "digest": "git:f0f6dc9c2d8e60c371d7df8c8a9af65e9571c965"
+        "digest": "git:7d51894f5fdae49fa67534d8359ac34a48175bc8"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.gate.yaml.platform-denylist",
+      "kind": "artifact",
+      "title": "gate.yaml:platform_denylist",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "configuration",
+      "language": "yaml",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "gate.yaml",
+        "language": "yaml",
+        "symbol": "platform_denylist",
+        "digest": "git:7d51894f5fdae49fa67534d8359ac34a48175bc8"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.loops.gate.check-path",
+      "kind": "artifact",
+      "title": "pf.loops.gate:check_path",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-15T05:28:10Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "loop",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/loops/gate.py",
+        "language": "python",
+        "symbol": "check_path",
+        "digest": "git:0e0d5d990b04901c47b39e09bf783eb4a8821183"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.spec.Tool.gate-sections",
+      "kind": "artifact",
+      "title": "pf.tools.spec:Tool.gate_sections",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-17T23:50:05Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/spec.py",
+        "language": "python",
+        "symbol": "Tool.gate_sections",
+        "digest": "git:3b36976709eb70b17628d2c2228e4e398ed2df05"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.decision",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:decision",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "decision",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.platform.hooks.post-tool-use.py",
+      "kind": "artifact",
+      "title": "platform/hooks/post_tool_use.py",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "hook",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/hooks/post_tool_use.py",
+        "language": "python",
+        "digest": "git:99dc8363fbb485907c66034f6c6fefdc51336650"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.chain.verify",
+      "kind": "artifact",
+      "title": "pf.provenance.chain:verify",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/chain.py",
+        "language": "python",
+        "symbol": "verify",
+        "digest": "git:07d2c60e49bda58cd6b9d51534b3417cec91777c"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.anchor.stamp-rfc3161",
+      "kind": "artifact",
+      "title": "pf.provenance.anchor:stamp_rfc3161",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/anchor.py",
+        "language": "python",
+        "symbol": "stamp_rfc3161",
+        "digest": "git:a38a0c14b0286745dbe157807967085d044af606"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.loops.gate.project-for",
+      "kind": "artifact",
+      "title": "pf.loops.gate:project_for",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-15T05:28:10Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "loop",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/loops/gate.py",
+        "language": "python",
+        "symbol": "project_for",
+        "digest": "git:0e0d5d990b04901c47b39e09bf783eb4a8821183"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.revoke",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:revoke",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "revoke",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.is-revoked",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:is_revoked",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "is_revoked",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.approve",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:approve",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "approve",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.audit.report",
+      "kind": "artifact",
+      "title": "pf.provenance.audit:report",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/audit.py",
+        "language": "python",
+        "symbol": "report",
+        "digest": "git:048a4041043b8b6d2628b0f97929752c079fb95e"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.agents.base.AGENTS",
+      "kind": "artifact",
+      "title": "pf.agents.base:AGENTS",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/agents/base.py",
+        "language": "python",
+        "symbol": "AGENTS",
+        "digest": "git:21365423e93b1c6427aa7dbf6dbb2823993e42c2"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.vendor.model.load-registry",
+      "kind": "artifact",
+      "title": "pf.vendor.model:load_registry",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-13T01:11:58Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/vendor/model.py",
+        "language": "python",
+        "symbol": "load_registry",
+        "digest": "git:3364fcfb711181efa434a9fe7024e4dcc01984df"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.vendor.verify.verify",
+      "kind": "artifact",
+      "title": "pf.vendor.verify:verify",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/vendor/verify.py",
+        "language": "python",
+        "symbol": "verify",
+        "digest": "git:4b39f17a26d3f030c4f2ef101c60a502c2f9ccfb"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.air.coverage.assess",
+      "kind": "artifact",
+      "title": "pf.air.coverage:assess",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/air/coverage.py",
+        "language": "python",
+        "symbol": "assess",
+        "digest": "git:fd67a5e7eeec7fdfe079c96e066992764601c00f"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.air.register.render-register",
+      "kind": "artifact",
+      "title": "pf.air.register:render_register",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/air/register.py",
+        "language": "python",
+        "symbol": "render_register",
+        "digest": "git:c45d0bbbe459fadea3ab3edfbf96beb6db505f25"
       },
       "extensions": {
         "exists": true
@@ -1002,7 +4799,7 @@
       "to": "intent.pf.money-requires-currency",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1013,7 +4810,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1022,8 +4819,8 @@
       "to": "artifact.pf.pf.ontology.validate.money-without-currency",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1032,8 +4829,8 @@
       "to": "evidence.pf.money-requires-currency.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:43:59Z",
-        "verified_at": "2026-08-16T23:43:59Z"
+        "created_at": "2026-08-19T21:37:14Z",
+        "verified_at": "2026-08-19T21:37:14Z"
       }
     },
     {
@@ -1042,7 +4839,7 @@
       "to": "intent.pf.entity-requires-identity",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1053,7 +4850,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1062,8 +4859,8 @@
       "to": "artifact.pf.pf.ontology.validate.class-without-identity",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1072,8 +4869,8 @@
       "to": "evidence.pf.entity-requires-identity.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:43:59Z",
-        "verified_at": "2026-08-16T23:43:59Z"
+        "created_at": "2026-08-19T21:37:15Z",
+        "verified_at": "2026-08-19T21:37:15Z"
       }
     },
     {
@@ -1082,7 +4879,7 @@
       "to": "intent.pf.link-must-be-in-topology",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1093,7 +4890,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1102,8 +4899,8 @@
       "to": "artifact.pf.pf.ontology.validate.illegal-edge",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1112,8 +4909,8 @@
       "to": "evidence.pf.link-must-be-in-topology.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:43:59Z",
-        "verified_at": "2026-08-16T23:43:59Z"
+        "created_at": "2026-08-19T21:37:15Z",
+        "verified_at": "2026-08-19T21:37:15Z"
       }
     },
     {
@@ -1122,7 +4919,7 @@
       "to": "intent.pf.pii-not-in-consumption",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1133,7 +4930,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1142,8 +4939,8 @@
       "to": "artifact.pf.pf.loops.registry.pii-audit",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1162,8 +4959,8 @@
       "to": "evidence.pf.pii-not-in-consumption.state-md",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "verified_at": "2026-08-15T20:35:53Z"
+        "created_at": "2026-08-18T15:42:57Z",
+        "verified_at": "2026-08-18T15:42:57Z"
       }
     },
     {
@@ -1172,7 +4969,7 @@
       "to": "intent.pf.mart-declares-grain",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1183,7 +4980,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1192,8 +4989,8 @@
       "to": "artifact.pf.pf.kg.build.model-grain",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1202,8 +4999,8 @@
       "to": "evidence.pf.mart-declares-grain.kg-context-card-md",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:43:59Z",
-        "verified_at": "2026-08-16T23:43:59Z"
+        "created_at": "2026-08-19T21:37:14Z",
+        "verified_at": "2026-08-19T21:37:14Z"
       }
     },
     {
@@ -1212,7 +5009,7 @@
       "to": "intent.pf.metric-owns-aggregation",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1223,7 +5020,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1232,8 +5029,8 @@
       "to": "artifact.pf.pf.ontology.validate.metric-shaped-column",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1242,8 +5039,8 @@
       "to": "evidence.pf.metric-owns-aggregation.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:44:00Z",
-        "verified_at": "2026-08-16T23:44:00Z"
+        "created_at": "2026-08-19T21:37:16Z",
+        "verified_at": "2026-08-19T21:37:16Z"
       }
     },
     {
@@ -1252,7 +5049,7 @@
       "to": "intent.pf.change-declares-blast-radius",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1263,7 +5060,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1272,8 +5069,8 @@
       "to": "artifact.pf.platform.hooks.pre-tool-use.py",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1282,8 +5079,8 @@
       "to": "artifact.pf.platform.hooks.pre-commit.sh",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1292,8 +5089,8 @@
       "to": "evidence.pf.change-declares-blast-radius.impact-reports",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:44:00Z",
-        "verified_at": "2026-08-16T23:44:00Z"
+        "created_at": "2026-08-19T21:37:16Z",
+        "verified_at": "2026-08-19T21:37:16Z"
       }
     },
     {
@@ -1302,8 +5099,8 @@
       "to": "evidence.pf.change-declares-blast-radius.loop-ledger-json",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "verified_at": "2026-08-15T20:35:53Z"
+        "created_at": "2026-08-19T20:47:22Z",
+        "verified_at": "2026-08-19T20:47:22Z"
       }
     },
     {
@@ -1312,7 +5109,7 @@
       "to": "intent.pf.change-verified-against-baseline",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1323,7 +5120,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1332,8 +5129,8 @@
       "to": "artifact.pf.pf.tools.recce.dagster-assets",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1342,8 +5139,8 @@
       "to": "artifact.pf.pf.tools.recce.register-commands",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1352,8 +5149,8 @@
       "to": "evidence.pf.change-verified-against-baseline.pf-tool-recce-run",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T22:56:57Z",
-        "verified_at": "2026-08-16T22:56:57Z"
+        "created_at": "2026-08-19T21:37:17Z",
+        "verified_at": "2026-08-19T21:37:17Z"
       }
     },
     {
@@ -1362,7 +5159,7 @@
       "to": "intent.pf.review-artifacts-exclude-pii",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1373,7 +5170,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1382,8 +5179,8 @@
       "to": "artifact.pf.pf.ontology.model.Role.review-intent",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1392,8 +5189,8 @@
       "to": "artifact.pf.pf.tools.recce.generate-config",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1402,8 +5199,118 @@
       "to": "evidence.pf.review-artifacts-exclude-pii.pf-tool-recce-config",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-15T20:38:47Z",
-        "verified_at": "2026-08-15T20:38:47Z"
+        "created_at": "2026-08-18T15:42:57Z",
+        "verified_at": "2026-08-18T15:42:57Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.derived-from.intent.pf.builds-record-observability",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "intent.pf.builds-record-observability",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.implemented-by.artifact.pf.pf.tools.elementary.bootstrap-project",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "artifact.pf.pf.tools.elementary.bootstrap-project",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.implemented-by.artifact.pf.pf.tools.elementary.ensure-package",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "artifact.pf.pf.tools.elementary.ensure-package",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.verified-by.evidence.pf.builds-record-observability.pf-tool-elementary-report",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "evidence.pf.builds-record-observability.pf-tool-elementary-report",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:18Z",
+        "verified_at": "2026-08-19T21:37:18Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.verified-by.evidence.pf.builds-record-observability.loop-ledger-json",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "evidence.pf.builds-record-observability.loop-ledger-json",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T20:47:22Z",
+        "verified_at": "2026-08-19T20:47:22Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.derived-from.intent.pf.quality-floor-derived-from-ontology",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "intent.pf.quality-floor-derived-from-ontology",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.implemented-by.artifact.pf.pf.tools.expectations.write-tests",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "artifact.pf.pf.tools.expectations.write-tests",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.implemented-by.artifact.pf.pf.tools.expectations.bootstrap-project",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "artifact.pf.pf.tools.expectations.bootstrap-project",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.verified-by.evidence.pf.quality-floor-derived-from-ontology.pf-tool-expectations-run",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "evidence.pf.quality-floor-derived-from-ontology.pf-tool-expectations-run",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:18Z",
+        "verified_at": "2026-08-19T21:37:18Z"
       }
     },
     {
@@ -1412,7 +5319,7 @@
       "to": "intent.pf.secrets-never-in-context",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1423,7 +5330,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1432,8 +5339,8 @@
       "to": "artifact.pf.gate.yaml.denylist",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1442,8 +5349,8 @@
       "to": "artifact.pf.platform.hooks.pre-tool-use.py",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1452,8 +5359,528 @@
       "to": "evidence.pf.secrets-never-in-context.pf-gate",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:44:00Z",
-        "verified_at": "2026-08-16T23:44:00Z"
+        "created_at": "2026-08-19T21:37:18Z",
+        "verified_at": "2026-08-19T21:37:18Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.derived-from.intent.pf.agent-authority-is-least-privilege",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "intent.pf.agent-authority-is-least-privilege",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.implemented-by.artifact.pf.gate.yaml.denylist",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "artifact.pf.gate.yaml.denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.implemented-by.artifact.pf.gate.yaml.platform-denylist",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "artifact.pf.gate.yaml.platform-denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.implemented-by.artifact.pf.pf.loops.gate.check-path",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "artifact.pf.pf.loops.gate.check-path",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.verified-by.evidence.pf.agent-authority-is-least-privilege.pf-gate",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "evidence.pf.agent-authority-is-least-privilege.pf-gate",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:19Z",
+        "verified_at": "2026-08-19T21:37:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.derived-from.intent.pf.tool-contribution-may-only-tighten",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "intent.pf.tool-contribution-may-only-tighten",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.implemented-by.artifact.pf.pf.tools.spec.Tool.gate-sections",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "artifact.pf.pf.tools.spec.Tool.gate-sections",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.verified-by.evidence.pf.tool-contribution-may-only-tighten.pf-check",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "evidence.pf.tool-contribution-may-only-tighten.pf-check",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:19Z",
+        "verified_at": "2026-08-19T21:37:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.derived-from.intent.pf.agent-decisions-are-recorded",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "intent.pf.agent-decisions-are-recorded",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.implemented-by.artifact.pf.pf.provenance.ledger.decision",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "artifact.pf.pf.provenance.ledger.decision",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.implemented-by.artifact.pf.platform.hooks.pre-tool-use.py",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "artifact.pf.platform.hooks.pre-tool-use.py",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.implemented-by.artifact.pf.platform.hooks.post-tool-use.py",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "artifact.pf.platform.hooks.post-tool-use.py",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.verified-by.evidence.pf.agent-decisions-are-recorded.pf-provenance-verify",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "evidence.pf.agent-decisions-are-recorded.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:20Z",
+        "verified_at": "2026-08-19T21:37:20Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.derived-from.intent.pf.evidence-chain-is-tamper-evident",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "intent.pf.evidence-chain-is-tamper-evident",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.implemented-by.artifact.pf.pf.provenance.chain.verify",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "artifact.pf.pf.provenance.chain.verify",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.implemented-by.artifact.pf.pf.provenance.anchor.stamp-rfc3161",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "artifact.pf.pf.provenance.anchor.stamp-rfc3161",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.implemented-by.artifact.pf.gate.yaml.denylist",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "artifact.pf.gate.yaml.denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.verified-by.evidence.pf.evidence-chain-is-tamper-evident.pf-provenance-verify",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "evidence.pf.evidence-chain-is-tamper-evident.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:20Z",
+        "verified_at": "2026-08-19T21:37:20Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.derived-from.intent.pf.sister-projects-are-isolated",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "intent.pf.sister-projects-are-isolated",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.implemented-by.artifact.pf.gate.yaml.platform-denylist",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "artifact.pf.gate.yaml.platform-denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.implemented-by.artifact.pf.pf.loops.gate.project-for",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "artifact.pf.pf.loops.gate.project-for",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.verified-by.evidence.pf.sister-projects-are-isolated.pf-gate",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "evidence.pf.sister-projects-are-isolated.pf-gate",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:21Z",
+        "verified_at": "2026-08-19T21:37:21Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.derived-from.intent.pf.agent-authority-is-revocable",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "intent.pf.agent-authority-is-revocable",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.implemented-by.artifact.pf.pf.provenance.ledger.revoke",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "artifact.pf.pf.provenance.ledger.revoke",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.implemented-by.artifact.pf.pf.provenance.ledger.is-revoked",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "artifact.pf.pf.provenance.ledger.is-revoked",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.verified-by.evidence.pf.agent-authority-is-revocable.pf-provenance-verify",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "evidence.pf.agent-authority-is-revocable.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:21Z",
+        "verified_at": "2026-08-19T21:37:21Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.derived-from.intent.pf.high-impact-actions-need-a-human",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "intent.pf.high-impact-actions-need-a-human",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.implemented-by.artifact.pf.pf.provenance.ledger.approve",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "artifact.pf.pf.provenance.ledger.approve",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.implemented-by.artifact.pf.pf.provenance.audit.report",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "artifact.pf.pf.provenance.audit.report",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.verified-by.evidence.pf.high-impact-actions-need-a-human.pf-provenance-verify",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "evidence.pf.high-impact-actions-need-a-human.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:22Z",
+        "verified_at": "2026-08-19T21:37:22Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.derived-from.intent.pf.model-routing-is-declared",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "intent.pf.model-routing-is-declared",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.implemented-by.artifact.pf.pf.agents.base.AGENTS",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "artifact.pf.pf.agents.base.AGENTS",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.verified-by.evidence.pf.model-routing-is-declared.pf-provenance-verify",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "evidence.pf.model-routing-is-declared.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:22Z",
+        "verified_at": "2026-08-19T21:37:22Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.derived-from.intent.pf.upstream-licences-are-reviewed",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "intent.pf.upstream-licences-are-reviewed",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.implemented-by.artifact.pf.pf.vendor.model.load-registry",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "artifact.pf.pf.vendor.model.load-registry",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.implemented-by.artifact.pf.pf.vendor.verify.verify",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "artifact.pf.pf.vendor.verify.verify",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.verified-by.evidence.pf.upstream-licences-are-reviewed.pf-check",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "evidence.pf.upstream-licences-are-reviewed.pf-check",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:22Z",
+        "verified_at": "2026-08-19T21:37:22Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.derived-from.intent.pf.control-baseline-is-declared",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "intent.pf.control-baseline-is-declared",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.implemented-by.artifact.pf.pf.air.coverage.assess",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "artifact.pf.pf.air.coverage.assess",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.implemented-by.artifact.pf.pf.air.register.render-register",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "artifact.pf.pf.air.register.render-register",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.verified-by.evidence.pf.control-baseline-is-declared.pf-air-coverage",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "evidence.pf.control-baseline-is-declared.pf-air-coverage",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:23Z",
+        "verified_at": "2026-08-19T21:37:23Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.verified-by.evidence.pf.control-baseline-is-declared.governance-air-register-md",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "evidence.pf.control-baseline-is-declared.governance-air-register-md",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:20Z",
+        "verified_at": "2026-08-19T18:05:20Z"
       }
     }
   ],

--- a/groups/globex/projects/globex-core/governance/otop.json
+++ b/groups/globex/projects/globex-core/governance/otop.json
@@ -4,9 +4,9 @@
     "id": "otop.pf.globex.globex-core",
     "title": "Policy and evidence \u2014 globex/globex-core",
     "repository": "https://github.com/Atomz-org/data-platform.git",
-    "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+    "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
     "metadata": {
-      "created_at": "2026-08-16T23:44:09Z",
+      "created_at": "2026-08-19T21:37:45Z",
       "actor": "pf.projections.otop"
     }
   },
@@ -17,13 +17,13 @@
       "title": "Agentic Data Platform governance policy",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
         "scope": "globex/globex-core",
         "source": "platform/src/pf/ontology/policy.yaml",
-        "rules": 10
+        "rules": 22
       }
     },
     {
@@ -32,7 +32,7 @@
       "title": "A monetary amount without its currency is not a number, it is a bug waiting for a second entity to be onboarded.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -45,7 +45,7 @@
       "title": "money-requires-currency",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -61,6 +61,138 @@
         "params": {
           "sibling": "currency_code",
           "scope": "resource"
+        },
+        "controls": [
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -70,8 +202,8 @@
       "title": "pf check for money-requires-currency",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:44:08Z",
-        "observed_at": "2026-08-16T23:44:08Z",
+        "created_at": "2026-08-19T21:37:37Z",
+        "observed_at": "2026-08-19T21:37:37Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -95,7 +227,7 @@
       "title": "A class with no identity property cannot participate in a derived join, so every BI and MDL projection of it is a guess.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -108,7 +240,7 @@
       "title": "entity-requires-identity",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -123,6 +255,138 @@
         },
         "params": {
           "exclude_abstract": true
+        },
+        "controls": [
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -132,8 +396,8 @@
       "title": "pf check for entity-requires-identity",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:44:08Z",
-        "observed_at": "2026-08-16T23:44:08Z",
+        "created_at": "2026-08-19T21:37:37Z",
+        "observed_at": "2026-08-19T21:37:37Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -157,7 +421,7 @@
       "title": "A foreign key pointing at a class the topology does not relate to is an undeclared join. Undeclared joins are how two teams compute different revenue from th...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -170,7 +434,7 @@
       "title": "link-must-be-in-topology",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -183,7 +447,139 @@
         "applies_to": {
           "annotation": "links"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -192,8 +588,8 @@
       "title": "pf check for link-must-be-in-topology",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:44:08Z",
-        "observed_at": "2026-08-16T23:44:08Z",
+        "created_at": "2026-08-19T21:37:38Z",
+        "observed_at": "2026-08-19T21:37:38Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -217,7 +613,7 @@
       "title": "PII may land in raw and staging. It must not reach a mart or an exposure without a masking policy or an explicit, recorded waiver.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -230,7 +626,7 @@
       "title": "pii-not-in-consumption",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -249,6 +645,153 @@
             "semantic",
             "consumption"
           ]
+        },
+        "controls": [
+          "AIR-DET-16",
+          "AIR-PREV-12"
+        ],
+        "control_titles": {
+          "AIR-DET-16": "Preserving Source Data Access Controls in AI Systems",
+          "AIR-PREV-12": "Role-Based Access Control for AI Data"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-3-2",
+              "title": "ISO 42001: AI roles and responsibilities",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-3",
+              "title": "ISO 42001: Acquisition of data",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-9-2",
+              "title": "ISO 42001: Processes for responsible use of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-21",
+              "title": "AC-21 Information Sharing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A238%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C521.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ca-8",
+              "title": "CA-8 Penetration Testing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A351%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "cm-12",
+              "title": "CM-12 Information Location",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ia-2",
+              "title": "IA-2 Identification And Authentication (organizational Users)",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A467%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ia-4",
+              "title": "IA-4 Identifier Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A479%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C422.0%2C0%5D"
+            },
+            {
+              "key": "ia-5",
+              "title": "IA-5 Authenticator Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A485%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -258,8 +801,8 @@
       "title": "pf loop run pii-audit for pii-not-in-consumption",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:44:08Z",
-        "observed_at": "2026-08-16T23:44:08Z",
+        "created_at": "2026-08-19T21:37:38Z",
+        "observed_at": "2026-08-19T21:37:38Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "PII_findings",
@@ -283,8 +826,8 @@
       "title": "STATE.md for pii-not-in-consumption",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "observed_at": "2026-08-15T20:35:53Z",
+        "created_at": "2026-08-18T15:42:57Z",
+        "observed_at": "2026-08-18T15:42:57Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "open_findings",
@@ -308,7 +851,7 @@
       "title": "Grain is the one fact a downstream consumer cannot infer and cannot survive guessing. An undeclared grain is how a join silently fans out.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -321,7 +864,7 @@
       "title": "mart-declares-grain",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "SHOULD",
@@ -336,6 +879,98 @@
         },
         "params": {
           "field": "grain"
+        },
+        "controls": [
+          "AIR-DET-13"
+        ],
+        "control_titles": {
+          "AIR-DET-13": "Providing Citations and Source Traceability for AI-Generated Information"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t5-1",
+              "title": "Table 5.1: Disclosure of AI Use in Products and Services to End-Users",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=49"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-1-2",
+              "title": "ISO 42001: Objectives for responsible development of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-7",
+              "title": "ISO 42001: AI system technical documentation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-2",
+              "title": "ISO 42001: System documentation and information for users",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-10",
+              "title": "AU-10 Non-repudiation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A301%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-8",
+              "title": "SA-8 Security And Privacy Engineering Principles",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A842%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -345,8 +980,8 @@
       "title": "kg/context_card.md for mart-declares-grain",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:44:07Z",
-        "observed_at": "2026-08-16T23:44:07Z",
+        "created_at": "2026-08-19T21:37:37Z",
+        "observed_at": "2026-08-19T21:37:37Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "project_index",
@@ -370,7 +1005,7 @@
       "title": "Aggregation policy \u2014 which statuses count, which timestamp, which filter \u2014 belongs to exactly one metric definition. A mart column named `revenue` is a secon...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -383,7 +1018,7 @@
       "title": "metric-owns-aggregation",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "SHOULD",
@@ -404,6 +1039,98 @@
             "churn_rate",
             "ltv"
           ]
+        },
+        "controls": [
+          "AIR-DET-13"
+        ],
+        "control_titles": {
+          "AIR-DET-13": "Providing Citations and Source Traceability for AI-Generated Information"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t5-1",
+              "title": "Table 5.1: Disclosure of AI Use in Products and Services to End-Users",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=49"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-1-2",
+              "title": "ISO 42001: Objectives for responsible development of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-7",
+              "title": "ISO 42001: AI system technical documentation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-2",
+              "title": "ISO 42001: System documentation and information for users",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-10",
+              "title": "AU-10 Non-repudiation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A301%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-8",
+              "title": "SA-8 Security And Privacy Engineering Principles",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A842%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -413,8 +1140,8 @@
       "title": "pf check for metric-owns-aggregation",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:44:08Z",
-        "observed_at": "2026-08-16T23:44:08Z",
+        "created_at": "2026-08-19T21:37:39Z",
+        "observed_at": "2026-08-19T21:37:39Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -438,7 +1165,7 @@
       "title": "A model or column change must report what it breaks before it lands, including the human who owns each affected exposure.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -451,7 +1178,7 @@
       "title": "change-declares-blast-radius",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -464,7 +1191,158 @@
         "applies_to": {
           "artifact_glob": "**/transform/models/**"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-DET-21",
+          "AIR-PREV-18"
+        ],
+        "control_titles": {
+          "AIR-DET-21": "Agent Decision Audit and Explainability",
+          "AIR-PREV-18": "Agent Authority Least Privilege Framework"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00040",
+              "title": "ATR-2026-00040 Agent Privilege Escalation",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/privilege-escalation/ATR-2026-00040-privilege-escalation.yaml"
+            },
+            {
+              "key": "ATR-2026-00098",
+              "title": "ATR-2026-00098 Unauthorized Financial Action by Agent",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/excessive-autonomy/ATR-2026-00098-unauthorized-financial-action.yaml"
+            }
+          ],
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a12",
+              "title": "III.S2.A12: Record-Keeping",
+              "url": "https://artificialintelligenceact.eu/article/12/"
+            },
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c3-s3-a26",
+              "title": "III.S3.A26: Obligations of Deployers of High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/26/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -473,8 +1351,8 @@
       "title": "impact_reports for change-declares-blast-radius",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:44:08Z",
-        "observed_at": "2026-08-16T23:44:08Z",
+        "created_at": "2026-08-19T21:37:39Z",
+        "observed_at": "2026-08-19T21:37:39Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "blast_radius_history",
@@ -498,8 +1376,8 @@
       "title": "loop-ledger.json for change-declares-blast-radius",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "observed_at": "2026-08-15T20:35:53Z",
+        "created_at": "2026-08-19T20:47:22Z",
+        "observed_at": "2026-08-19T20:47:22Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "run_history",
@@ -523,7 +1401,7 @@
       "title": "A blast radius is a prediction made from lineage. Lineage cannot say whether the numbers actually moved, so a change to a mart must also be compared against ...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -536,7 +1414,7 @@
       "title": "change-verified-against-baseline",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "SHOULD",
@@ -549,7 +1427,94 @@
         "applies_to": {
           "artifact_glob": "**/transform/models/marts/**"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-PREV-5"
+        ],
+        "control_titles": {
+          "AIR-PREV-5": "System Acceptance Testing"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a15",
+              "title": "III.S2.A15: Accuracy, Robustness and Cybersecurity",
+              "url": "https://artificialintelligenceact.eu/article/15/"
+            },
+            {
+              "key": "c3-s2-a9",
+              "title": "III.S2.A9: Risk Management System",
+              "url": "https://artificialintelligenceact.eu/article/9/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-1",
+              "title": "Table 4.1: Assessment of Risk-Proportionate Controls",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=41"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-4",
+              "title": "ISO 42001: AI system verification and validation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-5",
+              "title": "ISO 42001: AI system deployment",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ca-2",
+              "title": "CA-2 Control Assessments",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A324%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C684%2C0%5D"
+            },
+            {
+              "key": "ca-6",
+              "title": "CA-6 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A339%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "cm-4",
+              "title": "CM-4 Impact Analyses",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A375%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C509.0%2C0%5D"
+            },
+            {
+              "key": "sa-11",
+              "title": "SA-11 Developer Testing And Evaluation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A899%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C601.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-2",
+              "title": "SI-2 Flaw Remediation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1070%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-6",
+              "title": "SI-6 Security And Privacy Function Verification",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1103%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C475.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -558,12 +1523,12 @@
       "title": "pf tool recce run for change-verified-against-baseline",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:57:06Z",
-        "observed_at": "2026-08-16T22:57:06Z",
+        "created_at": "2026-08-19T21:37:40Z",
+        "observed_at": "2026-08-19T21:37:40Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "data_diff_against_baseline",
-      "result": "pass",
+      "result": "unknown",
       "subjects": [
         {
           "id": "constraint.pf.change-verified-against-baseline",
@@ -574,7 +1539,7 @@
       "provenance": {
         "actor": "pf.projections.otop",
         "scope": "globex/globex-core",
-        "detail": "groups/globex/projects/globex-core/transform/recce_state.json"
+        "detail": "no baseline captured"
       }
     },
     {
@@ -583,7 +1548,7 @@
       "title": "A value-level diff writes the rows it compared into the review tool's state file, which is durable and shared. Diffing a column whose role is PII therefore p...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -596,7 +1561,7 @@
       "title": "review-artifacts-exclude-pii",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -609,7 +1574,194 @@
         "applies_to": {
           "artifact_glob": "**/transform/recce.yml"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-DET-1",
+          "AIR-PREV-12"
+        ],
+        "control_titles": {
+          "AIR-DET-1": "AI Data Leakage Prevention and Detection",
+          "AIR-PREV-12": "Role-Based Access Control for AI Data"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-3-2",
+              "title": "ISO 42001: AI roles and responsibilities",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-5-2",
+              "title": "ISO 42001: AI system impact assessment process",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-20",
+              "title": "AC-20 Use Of External Systems",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A232%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C598.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-13",
+              "title": "AU-13 Monitoring For Information Disclosure",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A310%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C556.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-3",
+              "title": "CA-3 Information Exchange",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A330%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C166.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-12",
+              "title": "CM-12 Information Location",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ia-2",
+              "title": "IA-2 Identification And Authentication (organizational Users)",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A467%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ia-4",
+              "title": "IA-4 Identifier Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A479%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C422.0%2C0%5D"
+            },
+            {
+              "key": "ia-5",
+              "title": "IA-5 Authenticator Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A485%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "ir-4",
+              "title": "IR-4 Incident Handling",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A527%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C626.0%2C0%5D"
+            },
+            {
+              "key": "ir-9",
+              "title": "IR-9 Information Spillage Response",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A548%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C135.0%2C0%5D"
+            },
+            {
+              "key": "mp-6",
+              "title": "MP-6 Media Sanitization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A593%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C314.0%2C0%5D"
+            },
+            {
+              "key": "sa-9",
+              "title": "SA-9 External System Services",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A884%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C665.0%2C0%5D"
+            },
+            {
+              "key": "sc-28",
+              "title": "SC-28 Protection Of Information AT Rest",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1019%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C191.0%2C0%5D"
+            },
+            {
+              "key": "sc-7",
+              "title": "SC-7 Boundary Protection",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A962%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C399.0%2C0%5D"
+            },
+            {
+              "key": "sc-8",
+              "title": "SC-8 Transmission Confidentiality And Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A983%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C223.0%2C0%5D"
+            },
+            {
+              "key": "si-20",
+              "title": "SI-20 Tainting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1151%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C232.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -618,8 +1770,8 @@
       "title": "pf tool recce config for review-artifacts-exclude-pii",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T20:38:47Z",
-        "observed_at": "2026-08-15T20:38:47Z",
+        "created_at": "2026-08-18T15:42:57Z",
+        "observed_at": "2026-08-18T15:42:57Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "derived_review_checks",
@@ -638,12 +1790,580 @@
       }
     },
     {
+      "id": "intent.pf.builds-record-observability",
+      "kind": "intent",
+      "title": "A dbt build that leaves no queryable record cannot be triaged; failures get diagnosed from whichever log happened to survive. Every build must record its run...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A dbt build that leaves no queryable record cannot be triaged; failures get diagnosed from whichever log happened to survive. Every build must record its run and test results into the warehouse with history \u2014 for every test framework at once \u2014 so \"is this new, recurring, or flaky?\" is a query, not an archaeology dig."
+      }
+    },
+    {
+      "id": "constraint.pf.builds-record-observability",
+      "kind": "constraint",
+      "title": "builds-record-observability",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "observability_recorded",
+      "checkability": "automated",
+      "assertion": "observability_recorded on artifact_glob=**/transform/packages.yml",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/transform/packages.yml"
+        },
+        "params": {},
+        "controls": [
+          "AIR-DET-4",
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-DET-4": "AI System Observability",
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t7-adoption",
+              "title": "Table 7: AI Adoption Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=57"
+            },
+            {
+              "key": "t7-nature",
+              "title": "Table 7: Nature and Use Cases of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            },
+            {
+              "key": "t7-performance",
+              "title": "Table 7: AI System Performance Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-8",
+              "title": "ISO 42001: AI system recording of event logs",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "au-11",
+              "title": "AU-11 Audit Record Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C462.0%2C0%5D"
+            },
+            {
+              "key": "au-12",
+              "title": "AU-12 Audit Record Generation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C122.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "ir-4",
+              "title": "IR-4 Incident Handling",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A527%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C626.0%2C0%5D"
+            },
+            {
+              "key": "ir-5",
+              "title": "IR-5 Incident Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A539%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C387%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-10",
+              "title": "RA-10 Threat Hunting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A812%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C110.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.builds-record-observability.pf-tool-elementary-report",
+      "kind": "evidence",
+      "title": "pf tool elementary report for builds-record-observability",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:40Z",
+        "observed_at": "2026-08-19T21:37:40Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "observability_report_over_recorded_history",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.builds-record-observability",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-core",
+        "detail": "pf tool elementary report not produced yet"
+      }
+    },
+    {
+      "id": "evidence.pf.builds-record-observability.loop-ledger-json",
+      "kind": "evidence",
+      "title": "loop-ledger.json for builds-record-observability",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T20:47:22Z",
+        "observed_at": "2026-08-19T20:47:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "run_history",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.builds-record-observability",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-core",
+        "detail": "loop-ledger.json"
+      }
+    },
+    {
+      "id": "intent.pf.quality-floor-derived-from-ontology",
+      "kind": "intent",
+      "title": "Hand-written test coverage decays to whichever models someone remembered. The floor \u2014 an annotated mart is never empty, a declared identity identifies \u2014 must...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Hand-written test coverage decays to whichever models someone remembered. The floor \u2014 an annotated mart is never empty, a declared identity identifies \u2014 must be derived from the ontology roles, so coverage is a function of annotation rather than of memory, and a wrong test is a wrong role rather than a stale file."
+      }
+    },
+    {
+      "id": "constraint.pf.quality-floor-derived-from-ontology",
+      "kind": "constraint",
+      "title": "quality-floor-derived-from-ontology",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "tests_derived_from_roles",
+      "checkability": "automated",
+      "assertion": "tests_derived_from_roles on artifact_glob=**/transform/tests/expectations/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/transform/tests/expectations/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-6",
+          "AIR-PREV-5"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity",
+          "AIR-PREV-5": "System Acceptance Testing"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            },
+            {
+              "key": "c3-s2-a15",
+              "title": "III.S2.A15: Accuracy, Robustness and Cybersecurity",
+              "url": "https://artificialintelligenceact.eu/article/15/"
+            },
+            {
+              "key": "c3-s2-a9",
+              "title": "III.S2.A9: Risk Management System",
+              "url": "https://artificialintelligenceact.eu/article/9/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-1",
+              "title": "Table 4.1: Assessment of Risk-Proportionate Controls",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=41"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-4",
+              "title": "ISO 42001: AI system verification and validation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-5",
+              "title": "ISO 42001: AI system deployment",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-2",
+              "title": "CA-2 Control Assessments",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A324%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C684%2C0%5D"
+            },
+            {
+              "key": "ca-6",
+              "title": "CA-6 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A339%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "cm-4",
+              "title": "CM-4 Impact Analyses",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A375%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C509.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-11",
+              "title": "SA-11 Developer Testing And Evaluation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A899%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C601.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-2",
+              "title": "SI-2 Flaw Remediation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1070%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-6",
+              "title": "SI-6 Security And Privacy Function Verification",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1103%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C475.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.quality-floor-derived-from-ontology.pf-tool-expectations-run",
+      "kind": "evidence",
+      "title": "pf tool expectations run for quality-floor-derived-from-ontology",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:41Z",
+        "observed_at": "2026-08-19T21:37:41Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "quality_floor_verdicts",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.quality-floor-derived-from-ontology",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-core",
+        "detail": "pf tool expectations run not produced yet"
+      }
+    },
+    {
       "id": "intent.pf.secrets-never-in-context",
       "kind": "intent",
       "title": "A credential placed in a prompt, a model file or a committed artefact is durably persisted and replayed into every later session.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -656,7 +2376,7 @@
       "title": "secrets-never-in-context",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -669,7 +2389,131 @@
         "applies_to": {
           "artifact_glob": "**/secrets.toml"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-PREV-23",
+          "AIR-DET-16"
+        ],
+        "control_titles": {
+          "AIR-PREV-23": "Agentic System Credential Protection Framework",
+          "AIR-DET-16": "Preserving Source Data Access Controls in AI Systems"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00113",
+              "title": "ATR-2026-00113 Credential Theft via Agent Channel",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/context-exfiltration/ATR-2026-00113-credential-theft.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-3",
+              "title": "ISO 42001: Acquisition of data",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-9-2",
+              "title": "ISO 42001: Processes for responsible use of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-21",
+              "title": "AC-21 Information Sharing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A238%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C521.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ca-8",
+              "title": "CA-8 Penetration Testing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A351%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ia-5",
+              "title": "IA-5 Authenticator Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A485%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "sc-28",
+              "title": "SC-28 Protection Of Information AT Rest",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1019%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C191.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -678,8 +2522,8 @@
       "title": "pf gate for secrets-never-in-context",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:44:09Z",
-        "observed_at": "2026-08-16T23:44:09Z",
+        "created_at": "2026-08-19T21:37:41Z",
+        "observed_at": "2026-08-19T21:37:41Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "path_verdict",
@@ -698,23 +2542,1498 @@
       }
     },
     {
+      "id": "intent.pf.agent-authority-is-least-privilege",
+      "kind": "intent",
+      "title": "An agent reaches the filesystem through one path gate, and the paths it may never write are declared rather than remembered. Least privilege that lives in a ...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "An agent reaches the filesystem through one path gate, and the paths it may never write are declared rather than remembered. Least privilege that lives in a prompt is a request; in a denylist it is a control."
+      }
+    },
+    {
+      "id": "constraint.pf.agent-authority-is-least-privilege",
+      "kind": "constraint",
+      "title": "agent-authority-is-least-privilege",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "path_denied",
+      "checkability": "automated",
+      "assertion": "path_denied on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-18"
+        ],
+        "control_titles": {
+          "AIR-PREV-18": "Agent Authority Least Privilege Framework"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00040",
+              "title": "ATR-2026-00040 Agent Privilege Escalation",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/privilege-escalation/ATR-2026-00040-privilege-escalation.yaml"
+            },
+            {
+              "key": "ATR-2026-00098",
+              "title": "ATR-2026-00098 Unauthorized Financial Action by Agent",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/excessive-autonomy/ATR-2026-00098-unauthorized-financial-action.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.agent-authority-is-least-privilege.pf-gate",
+      "kind": "evidence",
+      "title": "pf gate for agent-authority-is-least-privilege",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:42Z",
+        "observed_at": "2026-08-19T21:37:42Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "path_verdict",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.agent-authority-is-least-privilege",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-core",
+        "detail": "denylist present"
+      }
+    },
+    {
+      "id": "intent.pf.tool-contribution-may-only-tighten",
+      "kind": "intent",
+      "title": "A tool contributes gate rules, and a plugin system that can widen the policy judging it is not a policy. `Tool.gate_sections()` rejects a contribution to any...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A tool contributes gate rules, and a plugin system that can widen the policy judging it is not a policy. `Tool.gate_sections()` rejects a contribution to any loosening section at construction, so an unsafe tool fails at import rather than silently permitting more."
+      }
+    },
+    {
+      "id": "constraint.pf.tool-contribution-may-only-tighten",
+      "kind": "constraint",
+      "title": "tool-contribution-may-only-tighten",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "tightening_only",
+      "checkability": "automated",
+      "assertion": "tightening_only (sections=['denylist', 'platform_denylist', 'impact_required']) on artifact_glob=gate.capabilities.yaml",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "gate.capabilities.yaml"
+        },
+        "params": {
+          "sections": [
+            "denylist",
+            "platform_denylist",
+            "impact_required"
+          ]
+        },
+        "controls": [
+          "AIR-PREV-19"
+        ],
+        "control_titles": {
+          "AIR-PREV-19": "Tool Chain Validation and Sanitization"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00011",
+              "title": "ATR-2026-00011 Instruction Injection via Tool Output",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00011-tool-output-injection.yaml"
+            },
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00013",
+              "title": "ATR-2026-00013 Tool-Driven Server-Side Request Forgery",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00013-tool-ssrf.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "sc-4",
+              "title": "SC-4 Information In Shared System Resources",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A956%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-15",
+              "title": "SI-15 Information Output Filtering",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1136%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C355.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.tool-contribution-may-only-tighten.pf-check",
+      "kind": "evidence",
+      "title": "pf check for tool-contribution-may-only-tighten",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:42Z",
+        "observed_at": "2026-08-19T21:37:42Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "conformance_report",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.tool-contribution-may-only-tighten",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-core",
+        "detail": "0 error(s), 1 issue(s)"
+      }
+    },
+    {
+      "id": "intent.pf.agent-decisions-are-recorded",
+      "kind": "intent",
+      "title": "Every tool call an agent makes is written down before it happens and after it happens, and the gate's verdict is recorded for allows as well as denies. \"No r...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Every tool call an agent makes is written down before it happens and after it happens, and the gate's verdict is recorded for allows as well as denies. \"No rule applied\" and \"a rule allowed it\" are different facts, and only a record that carries both can answer what an agent was permitted to do."
+      }
+    },
+    {
+      "id": "constraint.pf.agent-decisions-are-recorded",
+      "kind": "constraint",
+      "title": "agent-decisions-are-recorded",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "action_recorded",
+      "checkability": "automated",
+      "assertion": "action_recorded (stages=['intent', 'decision', 'execution']) on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {
+          "stages": [
+            "intent",
+            "decision",
+            "execution"
+          ]
+        },
+        "controls": [
+          "AIR-DET-21",
+          "AIR-DET-4"
+        ],
+        "control_titles": {
+          "AIR-DET-21": "Agent Decision Audit and Explainability",
+          "AIR-DET-4": "AI System Observability"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a12",
+              "title": "III.S2.A12: Record-Keeping",
+              "url": "https://artificialintelligenceact.eu/article/12/"
+            },
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c3-s3-a26",
+              "title": "III.S3.A26: Obligations of Deployers of High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/26/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t7-adoption",
+              "title": "Table 7: AI Adoption Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=57"
+            },
+            {
+              "key": "t7-nature",
+              "title": "Table 7: Nature and Use Cases of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            },
+            {
+              "key": "t7-performance",
+              "title": "Table 7: AI System Performance Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-8",
+              "title": "ISO 42001: AI system recording of event logs",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-11",
+              "title": "AU-11 Audit Record Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C462.0%2C0%5D"
+            },
+            {
+              "key": "au-12",
+              "title": "AU-12 Audit Record Generation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C122.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ir-4",
+              "title": "IR-4 Incident Handling",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A527%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C626.0%2C0%5D"
+            },
+            {
+              "key": "ir-5",
+              "title": "IR-5 Incident Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A539%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C387%2C0%5D"
+            },
+            {
+              "key": "ra-10",
+              "title": "RA-10 Threat Hunting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A812%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C110.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.agent-decisions-are-recorded.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for agent-decisions-are-recorded",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:42Z",
+        "observed_at": "2026-08-19T21:37:42Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.agent-decisions-are-recorded",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-core",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.evidence-chain-is-tamper-evident",
+      "kind": "intent",
+      "title": "A log an agent can edit is not evidence. Each record carries the hash of the one before it, and the head is anchored to a timestamp authority with no stake i...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A log an agent can edit is not evidence. Each record carries the hash of the one before it, and the head is anchored to a timestamp authority with no stake in what it says \u2014 so editing the middle requires editing the end, and the end is countersigned."
+      }
+    },
+    {
+      "id": "constraint.pf.evidence-chain-is-tamper-evident",
+      "kind": "constraint",
+      "title": "evidence-chain-is-tamper-evident",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "hash_chained",
+      "checkability": "automated",
+      "assertion": "hash_chained on artifact_glob=provenance/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "provenance/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-DET-21"
+        ],
+        "control_titles": {
+          "AIR-DET-21": "Agent Decision Audit and Explainability"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a12",
+              "title": "III.S2.A12: Record-Keeping",
+              "url": "https://artificialintelligenceact.eu/article/12/"
+            },
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c3-s3-a26",
+              "title": "III.S3.A26: Obligations of Deployers of High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/26/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.evidence-chain-is-tamper-evident.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for evidence-chain-is-tamper-evident",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:43Z",
+        "observed_at": "2026-08-19T21:37:43Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.evidence-chain-is-tamper-evident",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-core",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.sister-projects-are-isolated",
+      "kind": "intent",
+      "title": "Business logic does not transfer between entities, so an assumption carried from one sister company into another is a bug by construction. A project session ...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Business logic does not transfer between entities, so an assumption carried from one sister company into another is a bug by construction. A project session may not read or write another project, and may not write shared infra at all."
+      }
+    },
+    {
+      "id": "constraint.pf.sister-projects-are-isolated",
+      "kind": "constraint",
+      "title": "sister-projects-are-isolated",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "cross_tenant_denied",
+      "checkability": "automated",
+      "assertion": "cross_tenant_denied on artifact_glob=groups/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "groups/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-22"
+        ],
+        "control_titles": {
+          "AIR-PREV-22": "Multi-Agent Isolation and Segmentation"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00030",
+              "title": "ATR-2026-00030 Cross-Agent Attack Detection",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/agent-manipulation/ATR-2026-00030-cross-agent-attack.yaml"
+            },
+            {
+              "key": "ATR-2026-00076",
+              "title": "ATR-2026-00076 Insecure Inter-Agent Communication",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/agent-manipulation/ATR-2026-00076-inter-agent-message-spoofing.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "sc-3",
+              "title": "SC-3 Security Function Isolation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A950%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C217.0%2C0%5D"
+            },
+            {
+              "key": "sc-32",
+              "title": "SC-32 System Partitioning",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1031%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C227.0%2C0%5D"
+            },
+            {
+              "key": "sc-7",
+              "title": "SC-7 Boundary Protection",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A962%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C399.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.sister-projects-are-isolated.pf-gate",
+      "kind": "evidence",
+      "title": "pf gate for sister-projects-are-isolated",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:43Z",
+        "observed_at": "2026-08-19T21:37:43Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "path_verdict",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.sister-projects-are-isolated",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-core",
+        "detail": "denylist present"
+      }
+    },
+    {
+      "id": "intent.pf.agent-authority-is-revocable",
+      "kind": "intent",
+      "title": "A control that cannot be switched off mid-incident is a control you find out about afterwards. Revocation is checked before intent is written, and an unreada...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A control that cannot be switched off mid-incident is a control you find out about afterwards. Revocation is checked before intent is written, and an unreadable revocation file fails closed."
+      }
+    },
+    {
+      "id": "constraint.pf.agent-authority-is-revocable",
+      "kind": "constraint",
+      "title": "agent-authority-is-revocable",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "revocable",
+      "checkability": "automated",
+      "assertion": "revocable on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-18"
+        ],
+        "control_titles": {
+          "AIR-PREV-18": "Agent Authority Least Privilege Framework"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00040",
+              "title": "ATR-2026-00040 Agent Privilege Escalation",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/privilege-escalation/ATR-2026-00040-privilege-escalation.yaml"
+            },
+            {
+              "key": "ATR-2026-00098",
+              "title": "ATR-2026-00098 Unauthorized Financial Action by Agent",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/excessive-autonomy/ATR-2026-00098-unauthorized-financial-action.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.agent-authority-is-revocable.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for agent-authority-is-revocable",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:44Z",
+        "observed_at": "2026-08-19T21:37:44Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.agent-authority-is-revocable",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-core",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.high-impact-actions-need-a-human",
+      "kind": "intent",
+      "title": "Human oversight is a chain that shows the approval, not a document that asserts it. Approvals are append-only and bound to the action they approve, and an ac...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Human oversight is a chain that shows the approval, not a document that asserts it. Approvals are append-only and bound to the action they approve, and an actor approving their own action is a finding rather than an approval."
+      }
+    },
+    {
+      "id": "constraint.pf.high-impact-actions-need-a-human",
+      "kind": "constraint",
+      "title": "high-impact-actions-need-a-human",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "approval_recorded",
+      "checkability": "automated",
+      "assertion": "approval_recorded on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-DET-11"
+        ],
+        "control_titles": {
+          "AIR-DET-11": "Human Feedback Loop for AI Systems"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a14",
+              "title": "III.S2.A14: Human Oversight",
+              "url": "https://artificialintelligenceact.eu/article/14/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-3-3",
+              "title": "ISO 42001: Reporting of concerns",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-2",
+              "title": "ISO 42001: System documentation and information for users",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ca-2",
+              "title": "CA-2 Control Assessments",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A324%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C684%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ir-6",
+              "title": "IR-6 Incident Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A542%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "pm-26",
+              "title": "PM-26 Complaint Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A722%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C365.0%2C0%5D"
+            },
+            {
+              "key": "ra-5",
+              "title": "RA-5 Vulnerability Monitoring And Scanning",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A797%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C594.0%2C0%5D"
+            },
+            {
+              "key": "si-2",
+              "title": "SI-2 Flaw Remediation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1070%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.high-impact-actions-need-a-human.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for high-impact-actions-need-a-human",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:44Z",
+        "observed_at": "2026-08-19T21:37:44Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.high-impact-actions-need-a-human",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-core",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.model-routing-is-declared",
+      "kind": "intent",
+      "title": "Which model answers which step is a declared table, not whatever the caller passed. An unregistered step is recorded as such, and the recorded verdict matche...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Which model answers which step is a declared table, not whatever the caller passed. An unregistered step is recorded as such, and the recorded verdict matches what actually happened rather than what policy would have preferred."
+      }
+    },
+    {
+      "id": "constraint.pf.model-routing-is-declared",
+      "kind": "constraint",
+      "title": "model-routing-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "routing_declared",
+      "checkability": "automated",
+      "assertion": "routing_declared on artifact_glob=**/agents/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/agents/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-10"
+        ],
+        "control_titles": {
+          "AIR-PREV-10": "AI Model Version Pinning"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-4",
+              "title": "ISO 42001: Tooling resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-3",
+              "title": "ISO 42001: Documentation of AI system design and development",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-5",
+              "title": "ISO 42001: AI system deployment",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "cm-2",
+              "title": "CM-2 Baseline Configuration",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A363%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "cm-3",
+              "title": "CM-3 Configuration Change Control",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A366%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C205.0%2C0%5D"
+            },
+            {
+              "key": "cm-4",
+              "title": "CM-4 Impact Analyses",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A375%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C509.0%2C0%5D"
+            },
+            {
+              "key": "cm-8",
+              "title": "CM-8 System Component Inventory",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A393%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C197.0%2C0%5D"
+            },
+            {
+              "key": "sa-10",
+              "title": "SA-10 Developer Configuration Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A890%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C211.0%2C0%5D"
+            },
+            {
+              "key": "sa-22",
+              "title": "SA-22 Unsupported System Components",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A941%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C497.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sr-4",
+              "title": "SR-4 Provenance",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1169%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C257.0%2C0%5D"
+            },
+            {
+              "key": "sr-8",
+              "title": "SR-8 Notification Agreements",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1184%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C620.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.model-routing-is-declared.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for model-routing-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:44Z",
+        "observed_at": "2026-08-19T21:37:44Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.model-routing-is-declared",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-core",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.upstream-licences-are-reviewed",
+      "kind": "intent",
+      "title": "Every upstream this platform borrowed from carries a licence, and some of them constrain what we may ship. The review is written down per upstream and surfac...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Every upstream this platform borrowed from carries a licence, and some of them constrain what we may ship. The review is written down per upstream and surfaced in the listing, so a constraint is a fact in the registry rather than something someone once checked."
+      }
+    },
+    {
+      "id": "constraint.pf.upstream-licences-are-reviewed",
+      "kind": "constraint",
+      "title": "upstream-licences-are-reviewed",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "licence_reviewed",
+      "checkability": "automated",
+      "assertion": "licence_reviewed on artifact_glob=vendor/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "vendor/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-7"
+        ],
+        "control_titles": {
+          "AIR-PREV-7": "Legal and Contractual Frameworks for AI Systems"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t4-1",
+              "title": "Table 4.1: Assessment of Risk-Proportionate Controls",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=41"
+            },
+            {
+              "key": "t4-7",
+              "title": "Table 4.7: Legal Framework and Accountability",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=44"
+            },
+            {
+              "key": "t7-third-party",
+              "title": "Table 7: Third-Party Dependencies and Concentrations",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-10-2",
+              "title": "ISO 42001: Allocating responsibilities",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-10-3",
+              "title": "ISO 42001: Suppliers",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-2-3",
+              "title": "ISO 42001: Alignment with other organizational policies",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-5",
+              "title": "ISO 42001: Information for interested parties",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-20",
+              "title": "AC-20 Use Of External Systems",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A232%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C598.0%2C0%5D"
+            },
+            {
+              "key": "ca-3",
+              "title": "CA-3 Information Exchange",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A330%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C166.0%2C0%5D"
+            },
+            {
+              "key": "ir-6",
+              "title": "IR-6 Incident Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A542%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "pm-30",
+              "title": "PM-30 Supply Chain Risk Management Strategy",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A728%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C427.0%2C0%5D"
+            },
+            {
+              "key": "ps-7",
+              "title": "PS-7 External Personnel Security",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A752%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C623.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-9",
+              "title": "SA-9 External System Services",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A884%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C665.0%2C0%5D"
+            },
+            {
+              "key": "sr-2",
+              "title": "SR-2 Supply Chain Risk Management Plan",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1163%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C684.0%2C0%5D"
+            },
+            {
+              "key": "sr-3",
+              "title": "SR-3 Supply Chain Controls And Processes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1166%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C440.0%2C0%5D"
+            },
+            {
+              "key": "sr-5",
+              "title": "SR-5 Acquisition Strategies, Tools, And Methods",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1175%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C243.0%2C0%5D"
+            },
+            {
+              "key": "sr-8",
+              "title": "SR-8 Notification Agreements",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1184%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C620.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.upstream-licences-are-reviewed.pf-check",
+      "kind": "evidence",
+      "title": "pf check for upstream-licences-are-reviewed",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:45Z",
+        "observed_at": "2026-08-19T21:37:45Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "conformance_report",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.upstream-licences-are-reviewed",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-core",
+        "detail": "0 error(s), 1 issue(s)"
+      }
+    },
+    {
+      "id": "intent.pf.control-baseline-is-declared",
+      "kind": "intent",
+      "title": "A risk register that names controls nobody enforces is a document. Each entity declares in `air.yaml` which controls it commits to; those are derived from th...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A risk register that names controls nobody enforces is a document. Each entity declares in `air.yaml` which controls it commits to; those are derived from the repository on every run and block the merge when they fail, while everything outside the baseline is reported and does not."
+      }
+    },
+    {
+      "id": "constraint.pf.control-baseline-is-declared",
+      "kind": "constraint",
+      "title": "control-baseline-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "baseline_declared",
+      "checkability": "automated",
+      "assertion": "baseline_declared on artifact_glob=**/air.yaml",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/air.yaml"
+        },
+        "params": {}
+      }
+    },
+    {
+      "id": "evidence.pf.control-baseline-is-declared.pf-air-coverage",
+      "kind": "evidence",
+      "title": "pf air coverage for control-baseline-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:45Z",
+        "observed_at": "2026-08-19T21:37:45Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "control_coverage_verdicts",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.control-baseline-is-declared",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-core",
+        "detail": "pf air coverage not produced yet"
+      }
+    },
+    {
+      "id": "evidence.pf.control-baseline-is-declared.governance-air-register-md",
+      "kind": "evidence",
+      "title": "governance/air-register.md for control-baseline-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:20Z",
+        "observed_at": "2026-08-19T18:05:20Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "per-entity_risk_register",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.control-baseline-is-declared",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-core",
+        "detail": "groups/globex/projects/globex-core/governance/air-register.md"
+      }
+    },
+    {
       "id": "artifact.pf.pf.ontology.validate.money-without-currency",
       "kind": "artifact",
       "title": "pf.ontology.validate:money-without-currency",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "money-without-currency",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -726,18 +4045,18 @@
       "title": "pf.ontology.validate:class-without-identity",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "class-without-identity",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -749,18 +4068,18 @@
       "title": "pf.ontology.validate:illegal-edge",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "illegal-edge",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -772,18 +4091,18 @@
       "title": "pf.loops.registry:pii_audit",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T02:49:37Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "loop",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/loops/registry.py",
         "language": "python",
         "symbol": "pii_audit",
-        "digest": "git:293a23d6448c5fe70cee7c96a01f2690d8af47c2"
+        "digest": "git:e81ff725c18b4ff2a8187f5fb953a9dc003a56f4"
       },
       "extensions": {
         "exists": true
@@ -795,18 +4114,18 @@
       "title": "pf.kg.build:model-grain",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T02:04:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/kg/build.py",
         "language": "python",
         "symbol": "model-grain",
-        "digest": "git:2c8398b8a1246d27395ac2140ceba10eea0d3072"
+        "digest": "git:db169407ccb59827ce7f3c5932b2b4a0d40e1124"
       },
       "extensions": {
         "exists": true
@@ -818,18 +4137,18 @@
       "title": "pf.ontology.validate:metric-shaped-column",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "metric-shaped-column",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -841,17 +4160,17 @@
       "title": "platform/hooks/pre_tool_use.py",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T00:11:17Z",
+        "created_at": "2026-08-18T18:40:22Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "hook",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/hooks/pre_tool_use.py",
         "language": "python",
-        "digest": "git:2cb586ed58222bcb50e9cd0013d536cb2c9e6856"
+        "digest": "git:230bc9d9639eaa71c8c511affccb14881cdfc1f1"
       },
       "extensions": {
         "exists": true
@@ -863,14 +4182,14 @@
       "title": "platform/hooks/pre_commit.sh",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-12T16:06:37Z",
+        "created_at": "2026-08-12T14:06:37Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "hook",
       "language": "bash",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/hooks/pre_commit.sh",
         "language": "bash",
         "digest": "git:ce8e6f322ce15a546c16d2eb25bddf4fab5b6688"
@@ -885,18 +4204,18 @@
       "title": "pf.tools.recce:dagster_assets",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:50:23Z",
+        "created_at": "2026-08-17T23:50:05Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/tools/recce.py",
         "language": "python",
         "symbol": "dagster_assets",
-        "digest": "git:8a560994bb5a994b5a57b37a07f99114656b18a3"
+        "digest": "git:6d6c7a4515c5aa68b9642ca221805c28a15f4fc1"
       },
       "extensions": {
         "exists": true
@@ -908,18 +4227,18 @@
       "title": "pf.tools.recce:register_commands",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:50:23Z",
+        "created_at": "2026-08-17T23:50:05Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/tools/recce.py",
         "language": "python",
         "symbol": "register_commands",
-        "digest": "git:8a560994bb5a994b5a57b37a07f99114656b18a3"
+        "digest": "git:6d6c7a4515c5aa68b9642ca221805c28a15f4fc1"
       },
       "extensions": {
         "exists": true
@@ -931,18 +4250,18 @@
       "title": "pf.ontology.model:Role.review_intent",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T22:35:09Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/model.py",
         "language": "python",
         "symbol": "Role.review_intent",
-        "digest": "git:3e691a864da03459b04489a674bbba0a1839b1ea"
+        "digest": "git:513888ee8c2df8cfa1d09562ad3dc2793c4f741e"
       },
       "extensions": {
         "exists": true
@@ -954,18 +4273,106 @@
       "title": "pf.tools.recce:generate_config",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:50:23Z",
+        "created_at": "2026-08-17T23:50:05Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/tools/recce.py",
         "language": "python",
         "symbol": "generate_config",
-        "digest": "git:8a560994bb5a994b5a57b37a07f99114656b18a3"
+        "digest": "git:6d6c7a4515c5aa68b9642ca221805c28a15f4fc1"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.elementary.bootstrap-project",
+      "kind": "artifact",
+      "title": "pf.tools.elementary:bootstrap_project",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:40Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/elementary.py",
+        "language": "python",
+        "symbol": "bootstrap_project"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.elementary.ensure-package",
+      "kind": "artifact",
+      "title": "pf.tools.elementary:ensure_package",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:40Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/elementary.py",
+        "language": "python",
+        "symbol": "ensure_package"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.expectations.write-tests",
+      "kind": "artifact",
+      "title": "pf.tools.expectations:write_tests",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:41Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/expectations.py",
+        "language": "python",
+        "symbol": "write_tests"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.expectations.bootstrap-project",
+      "kind": "artifact",
+      "title": "pf.tools.expectations:bootstrap_project",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:41Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/expectations.py",
+        "language": "python",
+        "symbol": "bootstrap_project"
       },
       "extensions": {
         "exists": true
@@ -977,18 +4384,408 @@
       "title": "gate.yaml:denylist",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-17T00:38:30Z",
+        "created_at": "2026-08-18T18:40:22Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "configuration",
       "language": "yaml",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "gate.yaml",
         "language": "yaml",
         "symbol": "denylist",
-        "digest": "git:f0f6dc9c2d8e60c371d7df8c8a9af65e9571c965"
+        "digest": "git:7d51894f5fdae49fa67534d8359ac34a48175bc8"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.gate.yaml.platform-denylist",
+      "kind": "artifact",
+      "title": "gate.yaml:platform_denylist",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "configuration",
+      "language": "yaml",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "gate.yaml",
+        "language": "yaml",
+        "symbol": "platform_denylist",
+        "digest": "git:7d51894f5fdae49fa67534d8359ac34a48175bc8"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.loops.gate.check-path",
+      "kind": "artifact",
+      "title": "pf.loops.gate:check_path",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-15T05:28:10Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "loop",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/loops/gate.py",
+        "language": "python",
+        "symbol": "check_path",
+        "digest": "git:0e0d5d990b04901c47b39e09bf783eb4a8821183"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.spec.Tool.gate-sections",
+      "kind": "artifact",
+      "title": "pf.tools.spec:Tool.gate_sections",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-17T23:50:05Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/spec.py",
+        "language": "python",
+        "symbol": "Tool.gate_sections",
+        "digest": "git:3b36976709eb70b17628d2c2228e4e398ed2df05"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.decision",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:decision",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "decision",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.platform.hooks.post-tool-use.py",
+      "kind": "artifact",
+      "title": "platform/hooks/post_tool_use.py",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "hook",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/hooks/post_tool_use.py",
+        "language": "python",
+        "digest": "git:99dc8363fbb485907c66034f6c6fefdc51336650"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.chain.verify",
+      "kind": "artifact",
+      "title": "pf.provenance.chain:verify",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/chain.py",
+        "language": "python",
+        "symbol": "verify",
+        "digest": "git:07d2c60e49bda58cd6b9d51534b3417cec91777c"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.anchor.stamp-rfc3161",
+      "kind": "artifact",
+      "title": "pf.provenance.anchor:stamp_rfc3161",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/anchor.py",
+        "language": "python",
+        "symbol": "stamp_rfc3161",
+        "digest": "git:a38a0c14b0286745dbe157807967085d044af606"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.loops.gate.project-for",
+      "kind": "artifact",
+      "title": "pf.loops.gate:project_for",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-15T05:28:10Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "loop",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/loops/gate.py",
+        "language": "python",
+        "symbol": "project_for",
+        "digest": "git:0e0d5d990b04901c47b39e09bf783eb4a8821183"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.revoke",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:revoke",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "revoke",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.is-revoked",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:is_revoked",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "is_revoked",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.approve",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:approve",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "approve",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.audit.report",
+      "kind": "artifact",
+      "title": "pf.provenance.audit:report",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/audit.py",
+        "language": "python",
+        "symbol": "report",
+        "digest": "git:048a4041043b8b6d2628b0f97929752c079fb95e"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.agents.base.AGENTS",
+      "kind": "artifact",
+      "title": "pf.agents.base:AGENTS",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/agents/base.py",
+        "language": "python",
+        "symbol": "AGENTS",
+        "digest": "git:21365423e93b1c6427aa7dbf6dbb2823993e42c2"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.vendor.model.load-registry",
+      "kind": "artifact",
+      "title": "pf.vendor.model:load_registry",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-13T01:11:58Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/vendor/model.py",
+        "language": "python",
+        "symbol": "load_registry",
+        "digest": "git:3364fcfb711181efa434a9fe7024e4dcc01984df"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.vendor.verify.verify",
+      "kind": "artifact",
+      "title": "pf.vendor.verify:verify",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/vendor/verify.py",
+        "language": "python",
+        "symbol": "verify",
+        "digest": "git:4b39f17a26d3f030c4f2ef101c60a502c2f9ccfb"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.air.coverage.assess",
+      "kind": "artifact",
+      "title": "pf.air.coverage:assess",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/air/coverage.py",
+        "language": "python",
+        "symbol": "assess",
+        "digest": "git:fd67a5e7eeec7fdfe079c96e066992764601c00f"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.air.register.render-register",
+      "kind": "artifact",
+      "title": "pf.air.register:render_register",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/air/register.py",
+        "language": "python",
+        "symbol": "render_register",
+        "digest": "git:c45d0bbbe459fadea3ab3edfbf96beb6db505f25"
       },
       "extensions": {
         "exists": true
@@ -1002,7 +4799,7 @@
       "to": "intent.pf.money-requires-currency",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1013,7 +4810,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1022,8 +4819,8 @@
       "to": "artifact.pf.pf.ontology.validate.money-without-currency",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1032,8 +4829,8 @@
       "to": "evidence.pf.money-requires-currency.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:44:08Z",
-        "verified_at": "2026-08-16T23:44:08Z"
+        "created_at": "2026-08-19T21:37:37Z",
+        "verified_at": "2026-08-19T21:37:37Z"
       }
     },
     {
@@ -1042,7 +4839,7 @@
       "to": "intent.pf.entity-requires-identity",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1053,7 +4850,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1062,8 +4859,8 @@
       "to": "artifact.pf.pf.ontology.validate.class-without-identity",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1072,8 +4869,8 @@
       "to": "evidence.pf.entity-requires-identity.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:44:08Z",
-        "verified_at": "2026-08-16T23:44:08Z"
+        "created_at": "2026-08-19T21:37:37Z",
+        "verified_at": "2026-08-19T21:37:37Z"
       }
     },
     {
@@ -1082,7 +4879,7 @@
       "to": "intent.pf.link-must-be-in-topology",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1093,7 +4890,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1102,8 +4899,8 @@
       "to": "artifact.pf.pf.ontology.validate.illegal-edge",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1112,8 +4909,8 @@
       "to": "evidence.pf.link-must-be-in-topology.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:44:08Z",
-        "verified_at": "2026-08-16T23:44:08Z"
+        "created_at": "2026-08-19T21:37:38Z",
+        "verified_at": "2026-08-19T21:37:38Z"
       }
     },
     {
@@ -1122,7 +4919,7 @@
       "to": "intent.pf.pii-not-in-consumption",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1133,7 +4930,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1142,8 +4939,8 @@
       "to": "artifact.pf.pf.loops.registry.pii-audit",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1152,8 +4949,8 @@
       "to": "evidence.pf.pii-not-in-consumption.pf-loop-run-pii-audit",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:44:08Z",
-        "verified_at": "2026-08-16T23:44:08Z"
+        "created_at": "2026-08-19T21:37:38Z",
+        "verified_at": "2026-08-19T21:37:38Z"
       }
     },
     {
@@ -1162,8 +4959,8 @@
       "to": "evidence.pf.pii-not-in-consumption.state-md",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "verified_at": "2026-08-15T20:35:53Z"
+        "created_at": "2026-08-18T15:42:57Z",
+        "verified_at": "2026-08-18T15:42:57Z"
       }
     },
     {
@@ -1172,7 +4969,7 @@
       "to": "intent.pf.mart-declares-grain",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1183,7 +4980,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1192,8 +4989,8 @@
       "to": "artifact.pf.pf.kg.build.model-grain",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1202,8 +4999,8 @@
       "to": "evidence.pf.mart-declares-grain.kg-context-card-md",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:44:07Z",
-        "verified_at": "2026-08-16T23:44:07Z"
+        "created_at": "2026-08-19T21:37:37Z",
+        "verified_at": "2026-08-19T21:37:37Z"
       }
     },
     {
@@ -1212,7 +5009,7 @@
       "to": "intent.pf.metric-owns-aggregation",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1223,7 +5020,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1232,8 +5029,8 @@
       "to": "artifact.pf.pf.ontology.validate.metric-shaped-column",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1242,8 +5039,8 @@
       "to": "evidence.pf.metric-owns-aggregation.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:44:08Z",
-        "verified_at": "2026-08-16T23:44:08Z"
+        "created_at": "2026-08-19T21:37:39Z",
+        "verified_at": "2026-08-19T21:37:39Z"
       }
     },
     {
@@ -1252,7 +5049,7 @@
       "to": "intent.pf.change-declares-blast-radius",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1263,7 +5060,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1272,8 +5069,8 @@
       "to": "artifact.pf.platform.hooks.pre-tool-use.py",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1282,8 +5079,8 @@
       "to": "artifact.pf.platform.hooks.pre-commit.sh",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1292,8 +5089,8 @@
       "to": "evidence.pf.change-declares-blast-radius.impact-reports",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:44:08Z",
-        "verified_at": "2026-08-16T23:44:08Z"
+        "created_at": "2026-08-19T21:37:39Z",
+        "verified_at": "2026-08-19T21:37:39Z"
       }
     },
     {
@@ -1302,8 +5099,8 @@
       "to": "evidence.pf.change-declares-blast-radius.loop-ledger-json",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "verified_at": "2026-08-15T20:35:53Z"
+        "created_at": "2026-08-19T20:47:22Z",
+        "verified_at": "2026-08-19T20:47:22Z"
       }
     },
     {
@@ -1312,7 +5109,7 @@
       "to": "intent.pf.change-verified-against-baseline",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1323,7 +5120,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1332,8 +5129,8 @@
       "to": "artifact.pf.pf.tools.recce.dagster-assets",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1342,8 +5139,8 @@
       "to": "artifact.pf.pf.tools.recce.register-commands",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1352,8 +5149,8 @@
       "to": "evidence.pf.change-verified-against-baseline.pf-tool-recce-run",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T22:57:06Z",
-        "verified_at": "2026-08-16T22:57:06Z"
+        "created_at": "2026-08-19T21:37:40Z",
+        "verified_at": "2026-08-19T21:37:40Z"
       }
     },
     {
@@ -1362,7 +5159,7 @@
       "to": "intent.pf.review-artifacts-exclude-pii",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1373,7 +5170,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1382,8 +5179,8 @@
       "to": "artifact.pf.pf.ontology.model.Role.review-intent",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1392,8 +5189,8 @@
       "to": "artifact.pf.pf.tools.recce.generate-config",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1402,8 +5199,118 @@
       "to": "evidence.pf.review-artifacts-exclude-pii.pf-tool-recce-config",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-15T20:38:47Z",
-        "verified_at": "2026-08-15T20:38:47Z"
+        "created_at": "2026-08-18T15:42:57Z",
+        "verified_at": "2026-08-18T15:42:57Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.derived-from.intent.pf.builds-record-observability",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "intent.pf.builds-record-observability",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.implemented-by.artifact.pf.pf.tools.elementary.bootstrap-project",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "artifact.pf.pf.tools.elementary.bootstrap-project",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.implemented-by.artifact.pf.pf.tools.elementary.ensure-package",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "artifact.pf.pf.tools.elementary.ensure-package",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.verified-by.evidence.pf.builds-record-observability.pf-tool-elementary-report",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "evidence.pf.builds-record-observability.pf-tool-elementary-report",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:40Z",
+        "verified_at": "2026-08-19T21:37:40Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.verified-by.evidence.pf.builds-record-observability.loop-ledger-json",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "evidence.pf.builds-record-observability.loop-ledger-json",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T20:47:22Z",
+        "verified_at": "2026-08-19T20:47:22Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.derived-from.intent.pf.quality-floor-derived-from-ontology",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "intent.pf.quality-floor-derived-from-ontology",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.implemented-by.artifact.pf.pf.tools.expectations.write-tests",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "artifact.pf.pf.tools.expectations.write-tests",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.implemented-by.artifact.pf.pf.tools.expectations.bootstrap-project",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "artifact.pf.pf.tools.expectations.bootstrap-project",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.verified-by.evidence.pf.quality-floor-derived-from-ontology.pf-tool-expectations-run",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "evidence.pf.quality-floor-derived-from-ontology.pf-tool-expectations-run",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:41Z",
+        "verified_at": "2026-08-19T21:37:41Z"
       }
     },
     {
@@ -1412,7 +5319,7 @@
       "to": "intent.pf.secrets-never-in-context",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1423,7 +5330,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1432,8 +5339,8 @@
       "to": "artifact.pf.gate.yaml.denylist",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1442,8 +5349,8 @@
       "to": "artifact.pf.platform.hooks.pre-tool-use.py",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1452,8 +5359,528 @@
       "to": "evidence.pf.secrets-never-in-context.pf-gate",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:44:09Z",
-        "verified_at": "2026-08-16T23:44:09Z"
+        "created_at": "2026-08-19T21:37:41Z",
+        "verified_at": "2026-08-19T21:37:41Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.derived-from.intent.pf.agent-authority-is-least-privilege",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "intent.pf.agent-authority-is-least-privilege",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.implemented-by.artifact.pf.gate.yaml.denylist",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "artifact.pf.gate.yaml.denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.implemented-by.artifact.pf.gate.yaml.platform-denylist",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "artifact.pf.gate.yaml.platform-denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.implemented-by.artifact.pf.pf.loops.gate.check-path",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "artifact.pf.pf.loops.gate.check-path",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.verified-by.evidence.pf.agent-authority-is-least-privilege.pf-gate",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "evidence.pf.agent-authority-is-least-privilege.pf-gate",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:42Z",
+        "verified_at": "2026-08-19T21:37:42Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.derived-from.intent.pf.tool-contribution-may-only-tighten",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "intent.pf.tool-contribution-may-only-tighten",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.implemented-by.artifact.pf.pf.tools.spec.Tool.gate-sections",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "artifact.pf.pf.tools.spec.Tool.gate-sections",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.verified-by.evidence.pf.tool-contribution-may-only-tighten.pf-check",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "evidence.pf.tool-contribution-may-only-tighten.pf-check",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:42Z",
+        "verified_at": "2026-08-19T21:37:42Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.derived-from.intent.pf.agent-decisions-are-recorded",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "intent.pf.agent-decisions-are-recorded",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.implemented-by.artifact.pf.pf.provenance.ledger.decision",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "artifact.pf.pf.provenance.ledger.decision",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.implemented-by.artifact.pf.platform.hooks.pre-tool-use.py",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "artifact.pf.platform.hooks.pre-tool-use.py",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.implemented-by.artifact.pf.platform.hooks.post-tool-use.py",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "artifact.pf.platform.hooks.post-tool-use.py",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.verified-by.evidence.pf.agent-decisions-are-recorded.pf-provenance-verify",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "evidence.pf.agent-decisions-are-recorded.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:42Z",
+        "verified_at": "2026-08-19T21:37:42Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.derived-from.intent.pf.evidence-chain-is-tamper-evident",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "intent.pf.evidence-chain-is-tamper-evident",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.implemented-by.artifact.pf.pf.provenance.chain.verify",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "artifact.pf.pf.provenance.chain.verify",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.implemented-by.artifact.pf.pf.provenance.anchor.stamp-rfc3161",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "artifact.pf.pf.provenance.anchor.stamp-rfc3161",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.implemented-by.artifact.pf.gate.yaml.denylist",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "artifact.pf.gate.yaml.denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.verified-by.evidence.pf.evidence-chain-is-tamper-evident.pf-provenance-verify",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "evidence.pf.evidence-chain-is-tamper-evident.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:43Z",
+        "verified_at": "2026-08-19T21:37:43Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.derived-from.intent.pf.sister-projects-are-isolated",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "intent.pf.sister-projects-are-isolated",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.implemented-by.artifact.pf.gate.yaml.platform-denylist",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "artifact.pf.gate.yaml.platform-denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.implemented-by.artifact.pf.pf.loops.gate.project-for",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "artifact.pf.pf.loops.gate.project-for",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.verified-by.evidence.pf.sister-projects-are-isolated.pf-gate",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "evidence.pf.sister-projects-are-isolated.pf-gate",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:43Z",
+        "verified_at": "2026-08-19T21:37:43Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.derived-from.intent.pf.agent-authority-is-revocable",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "intent.pf.agent-authority-is-revocable",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.implemented-by.artifact.pf.pf.provenance.ledger.revoke",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "artifact.pf.pf.provenance.ledger.revoke",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.implemented-by.artifact.pf.pf.provenance.ledger.is-revoked",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "artifact.pf.pf.provenance.ledger.is-revoked",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.verified-by.evidence.pf.agent-authority-is-revocable.pf-provenance-verify",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "evidence.pf.agent-authority-is-revocable.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:44Z",
+        "verified_at": "2026-08-19T21:37:44Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.derived-from.intent.pf.high-impact-actions-need-a-human",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "intent.pf.high-impact-actions-need-a-human",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.implemented-by.artifact.pf.pf.provenance.ledger.approve",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "artifact.pf.pf.provenance.ledger.approve",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.implemented-by.artifact.pf.pf.provenance.audit.report",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "artifact.pf.pf.provenance.audit.report",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.verified-by.evidence.pf.high-impact-actions-need-a-human.pf-provenance-verify",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "evidence.pf.high-impact-actions-need-a-human.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:44Z",
+        "verified_at": "2026-08-19T21:37:44Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.derived-from.intent.pf.model-routing-is-declared",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "intent.pf.model-routing-is-declared",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.implemented-by.artifact.pf.pf.agents.base.AGENTS",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "artifact.pf.pf.agents.base.AGENTS",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.verified-by.evidence.pf.model-routing-is-declared.pf-provenance-verify",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "evidence.pf.model-routing-is-declared.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:44Z",
+        "verified_at": "2026-08-19T21:37:44Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.derived-from.intent.pf.upstream-licences-are-reviewed",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "intent.pf.upstream-licences-are-reviewed",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.implemented-by.artifact.pf.pf.vendor.model.load-registry",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "artifact.pf.pf.vendor.model.load-registry",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.implemented-by.artifact.pf.pf.vendor.verify.verify",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "artifact.pf.pf.vendor.verify.verify",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.verified-by.evidence.pf.upstream-licences-are-reviewed.pf-check",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "evidence.pf.upstream-licences-are-reviewed.pf-check",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:45Z",
+        "verified_at": "2026-08-19T21:37:45Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.derived-from.intent.pf.control-baseline-is-declared",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "intent.pf.control-baseline-is-declared",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.implemented-by.artifact.pf.pf.air.coverage.assess",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "artifact.pf.pf.air.coverage.assess",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.implemented-by.artifact.pf.pf.air.register.render-register",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "artifact.pf.pf.air.register.render-register",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.verified-by.evidence.pf.control-baseline-is-declared.pf-air-coverage",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "evidence.pf.control-baseline-is-declared.pf-air-coverage",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:37:45Z",
+        "verified_at": "2026-08-19T21:37:45Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.verified-by.evidence.pf.control-baseline-is-declared.governance-air-register-md",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "evidence.pf.control-baseline-is-declared.governance-air-register-md",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:20Z",
+        "verified_at": "2026-08-19T18:05:20Z"
       }
     }
   ],

--- a/groups/globex/projects/globex-eu/governance/otop.json
+++ b/groups/globex/projects/globex-eu/governance/otop.json
@@ -4,9 +4,9 @@
     "id": "otop.pf.globex.globex-eu",
     "title": "Policy and evidence \u2014 globex/globex-eu",
     "repository": "https://github.com/Atomz-org/data-platform.git",
-    "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+    "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
     "metadata": {
-      "created_at": "2026-08-16T23:44:15Z",
+      "created_at": "2026-08-19T21:38:08Z",
       "actor": "pf.projections.otop"
     }
   },
@@ -17,13 +17,13 @@
       "title": "Agentic Data Platform governance policy",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
         "scope": "globex/globex-eu",
         "source": "platform/src/pf/ontology/policy.yaml",
-        "rules": 10
+        "rules": 22
       }
     },
     {
@@ -32,7 +32,7 @@
       "title": "A monetary amount without its currency is not a number, it is a bug waiting for a second entity to be onboarded.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -45,7 +45,7 @@
       "title": "money-requires-currency",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -61,6 +61,138 @@
         "params": {
           "sibling": "currency_code",
           "scope": "resource"
+        },
+        "controls": [
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -70,8 +202,8 @@
       "title": "pf check for money-requires-currency",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:44:14Z",
-        "observed_at": "2026-08-16T23:44:14Z",
+        "created_at": "2026-08-19T21:38:00Z",
+        "observed_at": "2026-08-19T21:38:00Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -95,7 +227,7 @@
       "title": "A class with no identity property cannot participate in a derived join, so every BI and MDL projection of it is a guess.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -108,7 +240,7 @@
       "title": "entity-requires-identity",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -123,6 +255,138 @@
         },
         "params": {
           "exclude_abstract": true
+        },
+        "controls": [
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -132,8 +396,8 @@
       "title": "pf check for entity-requires-identity",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:44:14Z",
-        "observed_at": "2026-08-16T23:44:14Z",
+        "created_at": "2026-08-19T21:38:00Z",
+        "observed_at": "2026-08-19T21:38:00Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -157,7 +421,7 @@
       "title": "A foreign key pointing at a class the topology does not relate to is an undeclared join. Undeclared joins are how two teams compute different revenue from th...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -170,7 +434,7 @@
       "title": "link-must-be-in-topology",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -183,7 +447,139 @@
         "applies_to": {
           "annotation": "links"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -192,8 +588,8 @@
       "title": "pf check for link-must-be-in-topology",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:44:14Z",
-        "observed_at": "2026-08-16T23:44:14Z",
+        "created_at": "2026-08-19T21:38:00Z",
+        "observed_at": "2026-08-19T21:38:00Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -217,7 +613,7 @@
       "title": "PII may land in raw and staging. It must not reach a mart or an exposure without a masking policy or an explicit, recorded waiver.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -230,7 +626,7 @@
       "title": "pii-not-in-consumption",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -249,6 +645,153 @@
             "semantic",
             "consumption"
           ]
+        },
+        "controls": [
+          "AIR-DET-16",
+          "AIR-PREV-12"
+        ],
+        "control_titles": {
+          "AIR-DET-16": "Preserving Source Data Access Controls in AI Systems",
+          "AIR-PREV-12": "Role-Based Access Control for AI Data"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-3-2",
+              "title": "ISO 42001: AI roles and responsibilities",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-3",
+              "title": "ISO 42001: Acquisition of data",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-9-2",
+              "title": "ISO 42001: Processes for responsible use of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-21",
+              "title": "AC-21 Information Sharing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A238%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C521.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ca-8",
+              "title": "CA-8 Penetration Testing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A351%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "cm-12",
+              "title": "CM-12 Information Location",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ia-2",
+              "title": "IA-2 Identification And Authentication (organizational Users)",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A467%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ia-4",
+              "title": "IA-4 Identifier Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A479%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C422.0%2C0%5D"
+            },
+            {
+              "key": "ia-5",
+              "title": "IA-5 Authenticator Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A485%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -258,8 +801,8 @@
       "title": "pf loop run pii-audit for pii-not-in-consumption",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:44:14Z",
-        "observed_at": "2026-08-16T23:44:14Z",
+        "created_at": "2026-08-19T21:38:01Z",
+        "observed_at": "2026-08-19T21:38:01Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "PII_findings",
@@ -283,8 +826,8 @@
       "title": "STATE.md for pii-not-in-consumption",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "observed_at": "2026-08-15T20:35:53Z",
+        "created_at": "2026-08-18T15:42:57Z",
+        "observed_at": "2026-08-18T15:42:57Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "open_findings",
@@ -308,7 +851,7 @@
       "title": "Grain is the one fact a downstream consumer cannot infer and cannot survive guessing. An undeclared grain is how a join silently fans out.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -321,7 +864,7 @@
       "title": "mart-declares-grain",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "SHOULD",
@@ -336,6 +879,98 @@
         },
         "params": {
           "field": "grain"
+        },
+        "controls": [
+          "AIR-DET-13"
+        ],
+        "control_titles": {
+          "AIR-DET-13": "Providing Citations and Source Traceability for AI-Generated Information"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t5-1",
+              "title": "Table 5.1: Disclosure of AI Use in Products and Services to End-Users",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=49"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-1-2",
+              "title": "ISO 42001: Objectives for responsible development of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-7",
+              "title": "ISO 42001: AI system technical documentation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-2",
+              "title": "ISO 42001: System documentation and information for users",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-10",
+              "title": "AU-10 Non-repudiation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A301%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-8",
+              "title": "SA-8 Security And Privacy Engineering Principles",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A842%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -345,8 +980,8 @@
       "title": "kg/context_card.md for mart-declares-grain",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:44:14Z",
-        "observed_at": "2026-08-16T23:44:14Z",
+        "created_at": "2026-08-19T21:37:59Z",
+        "observed_at": "2026-08-19T21:37:59Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "project_index",
@@ -370,7 +1005,7 @@
       "title": "Aggregation policy \u2014 which statuses count, which timestamp, which filter \u2014 belongs to exactly one metric definition. A mart column named `revenue` is a secon...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -383,7 +1018,7 @@
       "title": "metric-owns-aggregation",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "SHOULD",
@@ -404,6 +1039,98 @@
             "churn_rate",
             "ltv"
           ]
+        },
+        "controls": [
+          "AIR-DET-13"
+        ],
+        "control_titles": {
+          "AIR-DET-13": "Providing Citations and Source Traceability for AI-Generated Information"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t5-1",
+              "title": "Table 5.1: Disclosure of AI Use in Products and Services to End-Users",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=49"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-1-2",
+              "title": "ISO 42001: Objectives for responsible development of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-7",
+              "title": "ISO 42001: AI system technical documentation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-2",
+              "title": "ISO 42001: System documentation and information for users",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-10",
+              "title": "AU-10 Non-repudiation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A301%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-8",
+              "title": "SA-8 Security And Privacy Engineering Principles",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A842%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -413,8 +1140,8 @@
       "title": "pf check for metric-owns-aggregation",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:44:15Z",
-        "observed_at": "2026-08-16T23:44:15Z",
+        "created_at": "2026-08-19T21:38:01Z",
+        "observed_at": "2026-08-19T21:38:01Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -438,7 +1165,7 @@
       "title": "A model or column change must report what it breaks before it lands, including the human who owns each affected exposure.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -451,7 +1178,7 @@
       "title": "change-declares-blast-radius",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -464,7 +1191,158 @@
         "applies_to": {
           "artifact_glob": "**/transform/models/**"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-DET-21",
+          "AIR-PREV-18"
+        ],
+        "control_titles": {
+          "AIR-DET-21": "Agent Decision Audit and Explainability",
+          "AIR-PREV-18": "Agent Authority Least Privilege Framework"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00040",
+              "title": "ATR-2026-00040 Agent Privilege Escalation",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/privilege-escalation/ATR-2026-00040-privilege-escalation.yaml"
+            },
+            {
+              "key": "ATR-2026-00098",
+              "title": "ATR-2026-00098 Unauthorized Financial Action by Agent",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/excessive-autonomy/ATR-2026-00098-unauthorized-financial-action.yaml"
+            }
+          ],
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a12",
+              "title": "III.S2.A12: Record-Keeping",
+              "url": "https://artificialintelligenceact.eu/article/12/"
+            },
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c3-s3-a26",
+              "title": "III.S3.A26: Obligations of Deployers of High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/26/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -473,8 +1351,8 @@
       "title": "impact_reports for change-declares-blast-radius",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:44:15Z",
-        "observed_at": "2026-08-16T23:44:15Z",
+        "created_at": "2026-08-19T21:38:02Z",
+        "observed_at": "2026-08-19T21:38:02Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "blast_radius_history",
@@ -498,8 +1376,8 @@
       "title": "loop-ledger.json for change-declares-blast-radius",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "observed_at": "2026-08-15T20:35:53Z",
+        "created_at": "2026-08-19T20:47:22Z",
+        "observed_at": "2026-08-19T20:47:22Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "run_history",
@@ -523,7 +1401,7 @@
       "title": "A blast radius is a prediction made from lineage. Lineage cannot say whether the numbers actually moved, so a change to a mart must also be compared against ...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -536,7 +1414,7 @@
       "title": "change-verified-against-baseline",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "SHOULD",
@@ -549,7 +1427,94 @@
         "applies_to": {
           "artifact_glob": "**/transform/models/marts/**"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-PREV-5"
+        ],
+        "control_titles": {
+          "AIR-PREV-5": "System Acceptance Testing"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a15",
+              "title": "III.S2.A15: Accuracy, Robustness and Cybersecurity",
+              "url": "https://artificialintelligenceact.eu/article/15/"
+            },
+            {
+              "key": "c3-s2-a9",
+              "title": "III.S2.A9: Risk Management System",
+              "url": "https://artificialintelligenceact.eu/article/9/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-1",
+              "title": "Table 4.1: Assessment of Risk-Proportionate Controls",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=41"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-4",
+              "title": "ISO 42001: AI system verification and validation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-5",
+              "title": "ISO 42001: AI system deployment",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ca-2",
+              "title": "CA-2 Control Assessments",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A324%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C684%2C0%5D"
+            },
+            {
+              "key": "ca-6",
+              "title": "CA-6 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A339%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "cm-4",
+              "title": "CM-4 Impact Analyses",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A375%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C509.0%2C0%5D"
+            },
+            {
+              "key": "sa-11",
+              "title": "SA-11 Developer Testing And Evaluation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A899%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C601.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-2",
+              "title": "SI-2 Flaw Remediation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1070%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-6",
+              "title": "SI-6 Security And Privacy Function Verification",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1103%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C475.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -558,12 +1523,12 @@
       "title": "pf tool recce run for change-verified-against-baseline",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:57:13Z",
-        "observed_at": "2026-08-16T22:57:13Z",
+        "created_at": "2026-08-19T21:38:02Z",
+        "observed_at": "2026-08-19T21:38:02Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "data_diff_against_baseline",
-      "result": "pass",
+      "result": "unknown",
       "subjects": [
         {
           "id": "constraint.pf.change-verified-against-baseline",
@@ -574,7 +1539,7 @@
       "provenance": {
         "actor": "pf.projections.otop",
         "scope": "globex/globex-eu",
-        "detail": "groups/globex/projects/globex-eu/transform/recce_state.json"
+        "detail": "no baseline captured"
       }
     },
     {
@@ -583,7 +1548,7 @@
       "title": "A value-level diff writes the rows it compared into the review tool's state file, which is durable and shared. Diffing a column whose role is PII therefore p...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -596,7 +1561,7 @@
       "title": "review-artifacts-exclude-pii",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -609,7 +1574,194 @@
         "applies_to": {
           "artifact_glob": "**/transform/recce.yml"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-DET-1",
+          "AIR-PREV-12"
+        ],
+        "control_titles": {
+          "AIR-DET-1": "AI Data Leakage Prevention and Detection",
+          "AIR-PREV-12": "Role-Based Access Control for AI Data"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-3-2",
+              "title": "ISO 42001: AI roles and responsibilities",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-5-2",
+              "title": "ISO 42001: AI system impact assessment process",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-20",
+              "title": "AC-20 Use Of External Systems",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A232%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C598.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-13",
+              "title": "AU-13 Monitoring For Information Disclosure",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A310%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C556.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-3",
+              "title": "CA-3 Information Exchange",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A330%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C166.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-12",
+              "title": "CM-12 Information Location",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ia-2",
+              "title": "IA-2 Identification And Authentication (organizational Users)",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A467%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ia-4",
+              "title": "IA-4 Identifier Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A479%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C422.0%2C0%5D"
+            },
+            {
+              "key": "ia-5",
+              "title": "IA-5 Authenticator Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A485%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "ir-4",
+              "title": "IR-4 Incident Handling",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A527%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C626.0%2C0%5D"
+            },
+            {
+              "key": "ir-9",
+              "title": "IR-9 Information Spillage Response",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A548%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C135.0%2C0%5D"
+            },
+            {
+              "key": "mp-6",
+              "title": "MP-6 Media Sanitization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A593%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C314.0%2C0%5D"
+            },
+            {
+              "key": "sa-9",
+              "title": "SA-9 External System Services",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A884%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C665.0%2C0%5D"
+            },
+            {
+              "key": "sc-28",
+              "title": "SC-28 Protection Of Information AT Rest",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1019%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C191.0%2C0%5D"
+            },
+            {
+              "key": "sc-7",
+              "title": "SC-7 Boundary Protection",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A962%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C399.0%2C0%5D"
+            },
+            {
+              "key": "sc-8",
+              "title": "SC-8 Transmission Confidentiality And Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A983%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C223.0%2C0%5D"
+            },
+            {
+              "key": "si-20",
+              "title": "SI-20 Tainting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1151%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C232.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -618,8 +1770,8 @@
       "title": "pf tool recce config for review-artifacts-exclude-pii",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T20:38:47Z",
-        "observed_at": "2026-08-15T20:38:47Z",
+        "created_at": "2026-08-18T15:42:57Z",
+        "observed_at": "2026-08-18T15:42:57Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "derived_review_checks",
@@ -638,12 +1790,580 @@
       }
     },
     {
+      "id": "intent.pf.builds-record-observability",
+      "kind": "intent",
+      "title": "A dbt build that leaves no queryable record cannot be triaged; failures get diagnosed from whichever log happened to survive. Every build must record its run...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A dbt build that leaves no queryable record cannot be triaged; failures get diagnosed from whichever log happened to survive. Every build must record its run and test results into the warehouse with history \u2014 for every test framework at once \u2014 so \"is this new, recurring, or flaky?\" is a query, not an archaeology dig."
+      }
+    },
+    {
+      "id": "constraint.pf.builds-record-observability",
+      "kind": "constraint",
+      "title": "builds-record-observability",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "observability_recorded",
+      "checkability": "automated",
+      "assertion": "observability_recorded on artifact_glob=**/transform/packages.yml",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/transform/packages.yml"
+        },
+        "params": {},
+        "controls": [
+          "AIR-DET-4",
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-DET-4": "AI System Observability",
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t7-adoption",
+              "title": "Table 7: AI Adoption Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=57"
+            },
+            {
+              "key": "t7-nature",
+              "title": "Table 7: Nature and Use Cases of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            },
+            {
+              "key": "t7-performance",
+              "title": "Table 7: AI System Performance Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-8",
+              "title": "ISO 42001: AI system recording of event logs",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "au-11",
+              "title": "AU-11 Audit Record Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C462.0%2C0%5D"
+            },
+            {
+              "key": "au-12",
+              "title": "AU-12 Audit Record Generation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C122.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "ir-4",
+              "title": "IR-4 Incident Handling",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A527%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C626.0%2C0%5D"
+            },
+            {
+              "key": "ir-5",
+              "title": "IR-5 Incident Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A539%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C387%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-10",
+              "title": "RA-10 Threat Hunting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A812%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C110.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.builds-record-observability.pf-tool-elementary-report",
+      "kind": "evidence",
+      "title": "pf tool elementary report for builds-record-observability",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:03Z",
+        "observed_at": "2026-08-19T21:38:03Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "observability_report_over_recorded_history",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.builds-record-observability",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-eu",
+        "detail": "pf tool elementary report not produced yet"
+      }
+    },
+    {
+      "id": "evidence.pf.builds-record-observability.loop-ledger-json",
+      "kind": "evidence",
+      "title": "loop-ledger.json for builds-record-observability",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T20:47:22Z",
+        "observed_at": "2026-08-19T20:47:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "run_history",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.builds-record-observability",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-eu",
+        "detail": "loop-ledger.json"
+      }
+    },
+    {
+      "id": "intent.pf.quality-floor-derived-from-ontology",
+      "kind": "intent",
+      "title": "Hand-written test coverage decays to whichever models someone remembered. The floor \u2014 an annotated mart is never empty, a declared identity identifies \u2014 must...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Hand-written test coverage decays to whichever models someone remembered. The floor \u2014 an annotated mart is never empty, a declared identity identifies \u2014 must be derived from the ontology roles, so coverage is a function of annotation rather than of memory, and a wrong test is a wrong role rather than a stale file."
+      }
+    },
+    {
+      "id": "constraint.pf.quality-floor-derived-from-ontology",
+      "kind": "constraint",
+      "title": "quality-floor-derived-from-ontology",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "tests_derived_from_roles",
+      "checkability": "automated",
+      "assertion": "tests_derived_from_roles on artifact_glob=**/transform/tests/expectations/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/transform/tests/expectations/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-6",
+          "AIR-PREV-5"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity",
+          "AIR-PREV-5": "System Acceptance Testing"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            },
+            {
+              "key": "c3-s2-a15",
+              "title": "III.S2.A15: Accuracy, Robustness and Cybersecurity",
+              "url": "https://artificialintelligenceact.eu/article/15/"
+            },
+            {
+              "key": "c3-s2-a9",
+              "title": "III.S2.A9: Risk Management System",
+              "url": "https://artificialintelligenceact.eu/article/9/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-1",
+              "title": "Table 4.1: Assessment of Risk-Proportionate Controls",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=41"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-4",
+              "title": "ISO 42001: AI system verification and validation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-5",
+              "title": "ISO 42001: AI system deployment",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-2",
+              "title": "CA-2 Control Assessments",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A324%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C684%2C0%5D"
+            },
+            {
+              "key": "ca-6",
+              "title": "CA-6 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A339%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "cm-4",
+              "title": "CM-4 Impact Analyses",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A375%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C509.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-11",
+              "title": "SA-11 Developer Testing And Evaluation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A899%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C601.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-2",
+              "title": "SI-2 Flaw Remediation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1070%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-6",
+              "title": "SI-6 Security And Privacy Function Verification",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1103%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C475.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.quality-floor-derived-from-ontology.pf-tool-expectations-run",
+      "kind": "evidence",
+      "title": "pf tool expectations run for quality-floor-derived-from-ontology",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:04Z",
+        "observed_at": "2026-08-19T21:38:04Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "quality_floor_verdicts",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.quality-floor-derived-from-ontology",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-eu",
+        "detail": "pf tool expectations run not produced yet"
+      }
+    },
+    {
       "id": "intent.pf.secrets-never-in-context",
       "kind": "intent",
       "title": "A credential placed in a prompt, a model file or a committed artefact is durably persisted and replayed into every later session.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -656,7 +2376,7 @@
       "title": "secrets-never-in-context",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -669,7 +2389,131 @@
         "applies_to": {
           "artifact_glob": "**/secrets.toml"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-PREV-23",
+          "AIR-DET-16"
+        ],
+        "control_titles": {
+          "AIR-PREV-23": "Agentic System Credential Protection Framework",
+          "AIR-DET-16": "Preserving Source Data Access Controls in AI Systems"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00113",
+              "title": "ATR-2026-00113 Credential Theft via Agent Channel",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/context-exfiltration/ATR-2026-00113-credential-theft.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-3",
+              "title": "ISO 42001: Acquisition of data",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-9-2",
+              "title": "ISO 42001: Processes for responsible use of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-21",
+              "title": "AC-21 Information Sharing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A238%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C521.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ca-8",
+              "title": "CA-8 Penetration Testing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A351%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ia-5",
+              "title": "IA-5 Authenticator Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A485%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "sc-28",
+              "title": "SC-28 Protection Of Information AT Rest",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1019%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C191.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -678,8 +2522,8 @@
       "title": "pf gate for secrets-never-in-context",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:44:15Z",
-        "observed_at": "2026-08-16T23:44:15Z",
+        "created_at": "2026-08-19T21:38:04Z",
+        "observed_at": "2026-08-19T21:38:04Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "path_verdict",
@@ -698,23 +2542,1498 @@
       }
     },
     {
+      "id": "intent.pf.agent-authority-is-least-privilege",
+      "kind": "intent",
+      "title": "An agent reaches the filesystem through one path gate, and the paths it may never write are declared rather than remembered. Least privilege that lives in a ...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "An agent reaches the filesystem through one path gate, and the paths it may never write are declared rather than remembered. Least privilege that lives in a prompt is a request; in a denylist it is a control."
+      }
+    },
+    {
+      "id": "constraint.pf.agent-authority-is-least-privilege",
+      "kind": "constraint",
+      "title": "agent-authority-is-least-privilege",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "path_denied",
+      "checkability": "automated",
+      "assertion": "path_denied on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-18"
+        ],
+        "control_titles": {
+          "AIR-PREV-18": "Agent Authority Least Privilege Framework"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00040",
+              "title": "ATR-2026-00040 Agent Privilege Escalation",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/privilege-escalation/ATR-2026-00040-privilege-escalation.yaml"
+            },
+            {
+              "key": "ATR-2026-00098",
+              "title": "ATR-2026-00098 Unauthorized Financial Action by Agent",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/excessive-autonomy/ATR-2026-00098-unauthorized-financial-action.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.agent-authority-is-least-privilege.pf-gate",
+      "kind": "evidence",
+      "title": "pf gate for agent-authority-is-least-privilege",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:04Z",
+        "observed_at": "2026-08-19T21:38:04Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "path_verdict",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.agent-authority-is-least-privilege",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-eu",
+        "detail": "denylist present"
+      }
+    },
+    {
+      "id": "intent.pf.tool-contribution-may-only-tighten",
+      "kind": "intent",
+      "title": "A tool contributes gate rules, and a plugin system that can widen the policy judging it is not a policy. `Tool.gate_sections()` rejects a contribution to any...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A tool contributes gate rules, and a plugin system that can widen the policy judging it is not a policy. `Tool.gate_sections()` rejects a contribution to any loosening section at construction, so an unsafe tool fails at import rather than silently permitting more."
+      }
+    },
+    {
+      "id": "constraint.pf.tool-contribution-may-only-tighten",
+      "kind": "constraint",
+      "title": "tool-contribution-may-only-tighten",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "tightening_only",
+      "checkability": "automated",
+      "assertion": "tightening_only (sections=['denylist', 'platform_denylist', 'impact_required']) on artifact_glob=gate.capabilities.yaml",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "gate.capabilities.yaml"
+        },
+        "params": {
+          "sections": [
+            "denylist",
+            "platform_denylist",
+            "impact_required"
+          ]
+        },
+        "controls": [
+          "AIR-PREV-19"
+        ],
+        "control_titles": {
+          "AIR-PREV-19": "Tool Chain Validation and Sanitization"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00011",
+              "title": "ATR-2026-00011 Instruction Injection via Tool Output",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00011-tool-output-injection.yaml"
+            },
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00013",
+              "title": "ATR-2026-00013 Tool-Driven Server-Side Request Forgery",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00013-tool-ssrf.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "sc-4",
+              "title": "SC-4 Information In Shared System Resources",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A956%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-15",
+              "title": "SI-15 Information Output Filtering",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1136%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C355.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.tool-contribution-may-only-tighten.pf-check",
+      "kind": "evidence",
+      "title": "pf check for tool-contribution-may-only-tighten",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:05Z",
+        "observed_at": "2026-08-19T21:38:05Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "conformance_report",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.tool-contribution-may-only-tighten",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-eu",
+        "detail": "0 error(s), 1 issue(s)"
+      }
+    },
+    {
+      "id": "intent.pf.agent-decisions-are-recorded",
+      "kind": "intent",
+      "title": "Every tool call an agent makes is written down before it happens and after it happens, and the gate's verdict is recorded for allows as well as denies. \"No r...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Every tool call an agent makes is written down before it happens and after it happens, and the gate's verdict is recorded for allows as well as denies. \"No rule applied\" and \"a rule allowed it\" are different facts, and only a record that carries both can answer what an agent was permitted to do."
+      }
+    },
+    {
+      "id": "constraint.pf.agent-decisions-are-recorded",
+      "kind": "constraint",
+      "title": "agent-decisions-are-recorded",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "action_recorded",
+      "checkability": "automated",
+      "assertion": "action_recorded (stages=['intent', 'decision', 'execution']) on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {
+          "stages": [
+            "intent",
+            "decision",
+            "execution"
+          ]
+        },
+        "controls": [
+          "AIR-DET-21",
+          "AIR-DET-4"
+        ],
+        "control_titles": {
+          "AIR-DET-21": "Agent Decision Audit and Explainability",
+          "AIR-DET-4": "AI System Observability"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a12",
+              "title": "III.S2.A12: Record-Keeping",
+              "url": "https://artificialintelligenceact.eu/article/12/"
+            },
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c3-s3-a26",
+              "title": "III.S3.A26: Obligations of Deployers of High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/26/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t7-adoption",
+              "title": "Table 7: AI Adoption Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=57"
+            },
+            {
+              "key": "t7-nature",
+              "title": "Table 7: Nature and Use Cases of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            },
+            {
+              "key": "t7-performance",
+              "title": "Table 7: AI System Performance Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-8",
+              "title": "ISO 42001: AI system recording of event logs",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-11",
+              "title": "AU-11 Audit Record Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C462.0%2C0%5D"
+            },
+            {
+              "key": "au-12",
+              "title": "AU-12 Audit Record Generation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C122.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ir-4",
+              "title": "IR-4 Incident Handling",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A527%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C626.0%2C0%5D"
+            },
+            {
+              "key": "ir-5",
+              "title": "IR-5 Incident Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A539%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C387%2C0%5D"
+            },
+            {
+              "key": "ra-10",
+              "title": "RA-10 Threat Hunting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A812%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C110.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.agent-decisions-are-recorded.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for agent-decisions-are-recorded",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:05Z",
+        "observed_at": "2026-08-19T21:38:05Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.agent-decisions-are-recorded",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-eu",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.evidence-chain-is-tamper-evident",
+      "kind": "intent",
+      "title": "A log an agent can edit is not evidence. Each record carries the hash of the one before it, and the head is anchored to a timestamp authority with no stake i...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A log an agent can edit is not evidence. Each record carries the hash of the one before it, and the head is anchored to a timestamp authority with no stake in what it says \u2014 so editing the middle requires editing the end, and the end is countersigned."
+      }
+    },
+    {
+      "id": "constraint.pf.evidence-chain-is-tamper-evident",
+      "kind": "constraint",
+      "title": "evidence-chain-is-tamper-evident",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "hash_chained",
+      "checkability": "automated",
+      "assertion": "hash_chained on artifact_glob=provenance/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "provenance/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-DET-21"
+        ],
+        "control_titles": {
+          "AIR-DET-21": "Agent Decision Audit and Explainability"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a12",
+              "title": "III.S2.A12: Record-Keeping",
+              "url": "https://artificialintelligenceact.eu/article/12/"
+            },
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c3-s3-a26",
+              "title": "III.S3.A26: Obligations of Deployers of High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/26/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.evidence-chain-is-tamper-evident.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for evidence-chain-is-tamper-evident",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:05Z",
+        "observed_at": "2026-08-19T21:38:05Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.evidence-chain-is-tamper-evident",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-eu",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.sister-projects-are-isolated",
+      "kind": "intent",
+      "title": "Business logic does not transfer between entities, so an assumption carried from one sister company into another is a bug by construction. A project session ...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Business logic does not transfer between entities, so an assumption carried from one sister company into another is a bug by construction. A project session may not read or write another project, and may not write shared infra at all."
+      }
+    },
+    {
+      "id": "constraint.pf.sister-projects-are-isolated",
+      "kind": "constraint",
+      "title": "sister-projects-are-isolated",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "cross_tenant_denied",
+      "checkability": "automated",
+      "assertion": "cross_tenant_denied on artifact_glob=groups/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "groups/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-22"
+        ],
+        "control_titles": {
+          "AIR-PREV-22": "Multi-Agent Isolation and Segmentation"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00030",
+              "title": "ATR-2026-00030 Cross-Agent Attack Detection",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/agent-manipulation/ATR-2026-00030-cross-agent-attack.yaml"
+            },
+            {
+              "key": "ATR-2026-00076",
+              "title": "ATR-2026-00076 Insecure Inter-Agent Communication",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/agent-manipulation/ATR-2026-00076-inter-agent-message-spoofing.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "sc-3",
+              "title": "SC-3 Security Function Isolation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A950%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C217.0%2C0%5D"
+            },
+            {
+              "key": "sc-32",
+              "title": "SC-32 System Partitioning",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1031%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C227.0%2C0%5D"
+            },
+            {
+              "key": "sc-7",
+              "title": "SC-7 Boundary Protection",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A962%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C399.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.sister-projects-are-isolated.pf-gate",
+      "kind": "evidence",
+      "title": "pf gate for sister-projects-are-isolated",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:06Z",
+        "observed_at": "2026-08-19T21:38:06Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "path_verdict",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.sister-projects-are-isolated",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-eu",
+        "detail": "denylist present"
+      }
+    },
+    {
+      "id": "intent.pf.agent-authority-is-revocable",
+      "kind": "intent",
+      "title": "A control that cannot be switched off mid-incident is a control you find out about afterwards. Revocation is checked before intent is written, and an unreada...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A control that cannot be switched off mid-incident is a control you find out about afterwards. Revocation is checked before intent is written, and an unreadable revocation file fails closed."
+      }
+    },
+    {
+      "id": "constraint.pf.agent-authority-is-revocable",
+      "kind": "constraint",
+      "title": "agent-authority-is-revocable",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "revocable",
+      "checkability": "automated",
+      "assertion": "revocable on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-18"
+        ],
+        "control_titles": {
+          "AIR-PREV-18": "Agent Authority Least Privilege Framework"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00040",
+              "title": "ATR-2026-00040 Agent Privilege Escalation",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/privilege-escalation/ATR-2026-00040-privilege-escalation.yaml"
+            },
+            {
+              "key": "ATR-2026-00098",
+              "title": "ATR-2026-00098 Unauthorized Financial Action by Agent",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/excessive-autonomy/ATR-2026-00098-unauthorized-financial-action.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.agent-authority-is-revocable.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for agent-authority-is-revocable",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:06Z",
+        "observed_at": "2026-08-19T21:38:06Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.agent-authority-is-revocable",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-eu",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.high-impact-actions-need-a-human",
+      "kind": "intent",
+      "title": "Human oversight is a chain that shows the approval, not a document that asserts it. Approvals are append-only and bound to the action they approve, and an ac...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Human oversight is a chain that shows the approval, not a document that asserts it. Approvals are append-only and bound to the action they approve, and an actor approving their own action is a finding rather than an approval."
+      }
+    },
+    {
+      "id": "constraint.pf.high-impact-actions-need-a-human",
+      "kind": "constraint",
+      "title": "high-impact-actions-need-a-human",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "approval_recorded",
+      "checkability": "automated",
+      "assertion": "approval_recorded on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-DET-11"
+        ],
+        "control_titles": {
+          "AIR-DET-11": "Human Feedback Loop for AI Systems"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a14",
+              "title": "III.S2.A14: Human Oversight",
+              "url": "https://artificialintelligenceact.eu/article/14/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-3-3",
+              "title": "ISO 42001: Reporting of concerns",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-2",
+              "title": "ISO 42001: System documentation and information for users",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ca-2",
+              "title": "CA-2 Control Assessments",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A324%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C684%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ir-6",
+              "title": "IR-6 Incident Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A542%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "pm-26",
+              "title": "PM-26 Complaint Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A722%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C365.0%2C0%5D"
+            },
+            {
+              "key": "ra-5",
+              "title": "RA-5 Vulnerability Monitoring And Scanning",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A797%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C594.0%2C0%5D"
+            },
+            {
+              "key": "si-2",
+              "title": "SI-2 Flaw Remediation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1070%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.high-impact-actions-need-a-human.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for high-impact-actions-need-a-human",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:07Z",
+        "observed_at": "2026-08-19T21:38:07Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.high-impact-actions-need-a-human",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-eu",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.model-routing-is-declared",
+      "kind": "intent",
+      "title": "Which model answers which step is a declared table, not whatever the caller passed. An unregistered step is recorded as such, and the recorded verdict matche...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Which model answers which step is a declared table, not whatever the caller passed. An unregistered step is recorded as such, and the recorded verdict matches what actually happened rather than what policy would have preferred."
+      }
+    },
+    {
+      "id": "constraint.pf.model-routing-is-declared",
+      "kind": "constraint",
+      "title": "model-routing-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "routing_declared",
+      "checkability": "automated",
+      "assertion": "routing_declared on artifact_glob=**/agents/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/agents/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-10"
+        ],
+        "control_titles": {
+          "AIR-PREV-10": "AI Model Version Pinning"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-4",
+              "title": "ISO 42001: Tooling resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-3",
+              "title": "ISO 42001: Documentation of AI system design and development",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-5",
+              "title": "ISO 42001: AI system deployment",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "cm-2",
+              "title": "CM-2 Baseline Configuration",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A363%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "cm-3",
+              "title": "CM-3 Configuration Change Control",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A366%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C205.0%2C0%5D"
+            },
+            {
+              "key": "cm-4",
+              "title": "CM-4 Impact Analyses",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A375%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C509.0%2C0%5D"
+            },
+            {
+              "key": "cm-8",
+              "title": "CM-8 System Component Inventory",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A393%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C197.0%2C0%5D"
+            },
+            {
+              "key": "sa-10",
+              "title": "SA-10 Developer Configuration Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A890%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C211.0%2C0%5D"
+            },
+            {
+              "key": "sa-22",
+              "title": "SA-22 Unsupported System Components",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A941%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C497.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sr-4",
+              "title": "SR-4 Provenance",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1169%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C257.0%2C0%5D"
+            },
+            {
+              "key": "sr-8",
+              "title": "SR-8 Notification Agreements",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1184%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C620.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.model-routing-is-declared.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for model-routing-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:07Z",
+        "observed_at": "2026-08-19T21:38:07Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.model-routing-is-declared",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-eu",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.upstream-licences-are-reviewed",
+      "kind": "intent",
+      "title": "Every upstream this platform borrowed from carries a licence, and some of them constrain what we may ship. The review is written down per upstream and surfac...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Every upstream this platform borrowed from carries a licence, and some of them constrain what we may ship. The review is written down per upstream and surfaced in the listing, so a constraint is a fact in the registry rather than something someone once checked."
+      }
+    },
+    {
+      "id": "constraint.pf.upstream-licences-are-reviewed",
+      "kind": "constraint",
+      "title": "upstream-licences-are-reviewed",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "licence_reviewed",
+      "checkability": "automated",
+      "assertion": "licence_reviewed on artifact_glob=vendor/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "vendor/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-7"
+        ],
+        "control_titles": {
+          "AIR-PREV-7": "Legal and Contractual Frameworks for AI Systems"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t4-1",
+              "title": "Table 4.1: Assessment of Risk-Proportionate Controls",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=41"
+            },
+            {
+              "key": "t4-7",
+              "title": "Table 4.7: Legal Framework and Accountability",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=44"
+            },
+            {
+              "key": "t7-third-party",
+              "title": "Table 7: Third-Party Dependencies and Concentrations",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-10-2",
+              "title": "ISO 42001: Allocating responsibilities",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-10-3",
+              "title": "ISO 42001: Suppliers",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-2-3",
+              "title": "ISO 42001: Alignment with other organizational policies",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-5",
+              "title": "ISO 42001: Information for interested parties",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-20",
+              "title": "AC-20 Use Of External Systems",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A232%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C598.0%2C0%5D"
+            },
+            {
+              "key": "ca-3",
+              "title": "CA-3 Information Exchange",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A330%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C166.0%2C0%5D"
+            },
+            {
+              "key": "ir-6",
+              "title": "IR-6 Incident Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A542%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "pm-30",
+              "title": "PM-30 Supply Chain Risk Management Strategy",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A728%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C427.0%2C0%5D"
+            },
+            {
+              "key": "ps-7",
+              "title": "PS-7 External Personnel Security",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A752%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C623.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-9",
+              "title": "SA-9 External System Services",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A884%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C665.0%2C0%5D"
+            },
+            {
+              "key": "sr-2",
+              "title": "SR-2 Supply Chain Risk Management Plan",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1163%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C684.0%2C0%5D"
+            },
+            {
+              "key": "sr-3",
+              "title": "SR-3 Supply Chain Controls And Processes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1166%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C440.0%2C0%5D"
+            },
+            {
+              "key": "sr-5",
+              "title": "SR-5 Acquisition Strategies, Tools, And Methods",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1175%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C243.0%2C0%5D"
+            },
+            {
+              "key": "sr-8",
+              "title": "SR-8 Notification Agreements",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1184%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C620.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.upstream-licences-are-reviewed.pf-check",
+      "kind": "evidence",
+      "title": "pf check for upstream-licences-are-reviewed",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:07Z",
+        "observed_at": "2026-08-19T21:38:07Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "conformance_report",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.upstream-licences-are-reviewed",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-eu",
+        "detail": "0 error(s), 1 issue(s)"
+      }
+    },
+    {
+      "id": "intent.pf.control-baseline-is-declared",
+      "kind": "intent",
+      "title": "A risk register that names controls nobody enforces is a document. Each entity declares in `air.yaml` which controls it commits to; those are derived from th...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A risk register that names controls nobody enforces is a document. Each entity declares in `air.yaml` which controls it commits to; those are derived from the repository on every run and block the merge when they fail, while everything outside the baseline is reported and does not."
+      }
+    },
+    {
+      "id": "constraint.pf.control-baseline-is-declared",
+      "kind": "constraint",
+      "title": "control-baseline-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "baseline_declared",
+      "checkability": "automated",
+      "assertion": "baseline_declared on artifact_glob=**/air.yaml",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/air.yaml"
+        },
+        "params": {}
+      }
+    },
+    {
+      "id": "evidence.pf.control-baseline-is-declared.pf-air-coverage",
+      "kind": "evidence",
+      "title": "pf air coverage for control-baseline-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:08Z",
+        "observed_at": "2026-08-19T21:38:08Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "control_coverage_verdicts",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.control-baseline-is-declared",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-eu",
+        "detail": "pf air coverage not produced yet"
+      }
+    },
+    {
+      "id": "evidence.pf.control-baseline-is-declared.governance-air-register-md",
+      "kind": "evidence",
+      "title": "governance/air-register.md for control-baseline-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:20Z",
+        "observed_at": "2026-08-19T18:05:20Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "per-entity_risk_register",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.control-baseline-is-declared",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "globex/globex-eu",
+        "detail": "groups/globex/projects/globex-eu/governance/air-register.md"
+      }
+    },
+    {
       "id": "artifact.pf.pf.ontology.validate.money-without-currency",
       "kind": "artifact",
       "title": "pf.ontology.validate:money-without-currency",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "money-without-currency",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -726,18 +4045,18 @@
       "title": "pf.ontology.validate:class-without-identity",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "class-without-identity",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -749,18 +4068,18 @@
       "title": "pf.ontology.validate:illegal-edge",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "illegal-edge",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -772,18 +4091,18 @@
       "title": "pf.loops.registry:pii_audit",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T02:49:37Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "loop",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/loops/registry.py",
         "language": "python",
         "symbol": "pii_audit",
-        "digest": "git:293a23d6448c5fe70cee7c96a01f2690d8af47c2"
+        "digest": "git:e81ff725c18b4ff2a8187f5fb953a9dc003a56f4"
       },
       "extensions": {
         "exists": true
@@ -795,18 +4114,18 @@
       "title": "pf.kg.build:model-grain",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T02:04:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/kg/build.py",
         "language": "python",
         "symbol": "model-grain",
-        "digest": "git:2c8398b8a1246d27395ac2140ceba10eea0d3072"
+        "digest": "git:db169407ccb59827ce7f3c5932b2b4a0d40e1124"
       },
       "extensions": {
         "exists": true
@@ -818,18 +4137,18 @@
       "title": "pf.ontology.validate:metric-shaped-column",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "metric-shaped-column",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -841,17 +4160,17 @@
       "title": "platform/hooks/pre_tool_use.py",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T00:11:17Z",
+        "created_at": "2026-08-18T18:40:22Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "hook",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/hooks/pre_tool_use.py",
         "language": "python",
-        "digest": "git:2cb586ed58222bcb50e9cd0013d536cb2c9e6856"
+        "digest": "git:230bc9d9639eaa71c8c511affccb14881cdfc1f1"
       },
       "extensions": {
         "exists": true
@@ -863,14 +4182,14 @@
       "title": "platform/hooks/pre_commit.sh",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-12T16:06:37Z",
+        "created_at": "2026-08-12T14:06:37Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "hook",
       "language": "bash",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/hooks/pre_commit.sh",
         "language": "bash",
         "digest": "git:ce8e6f322ce15a546c16d2eb25bddf4fab5b6688"
@@ -885,18 +4204,18 @@
       "title": "pf.tools.recce:dagster_assets",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:50:23Z",
+        "created_at": "2026-08-17T23:50:05Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/tools/recce.py",
         "language": "python",
         "symbol": "dagster_assets",
-        "digest": "git:8a560994bb5a994b5a57b37a07f99114656b18a3"
+        "digest": "git:6d6c7a4515c5aa68b9642ca221805c28a15f4fc1"
       },
       "extensions": {
         "exists": true
@@ -908,18 +4227,18 @@
       "title": "pf.tools.recce:register_commands",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:50:23Z",
+        "created_at": "2026-08-17T23:50:05Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/tools/recce.py",
         "language": "python",
         "symbol": "register_commands",
-        "digest": "git:8a560994bb5a994b5a57b37a07f99114656b18a3"
+        "digest": "git:6d6c7a4515c5aa68b9642ca221805c28a15f4fc1"
       },
       "extensions": {
         "exists": true
@@ -931,18 +4250,18 @@
       "title": "pf.ontology.model:Role.review_intent",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T22:35:09Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/model.py",
         "language": "python",
         "symbol": "Role.review_intent",
-        "digest": "git:3e691a864da03459b04489a674bbba0a1839b1ea"
+        "digest": "git:513888ee8c2df8cfa1d09562ad3dc2793c4f741e"
       },
       "extensions": {
         "exists": true
@@ -954,18 +4273,106 @@
       "title": "pf.tools.recce:generate_config",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:50:23Z",
+        "created_at": "2026-08-17T23:50:05Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/tools/recce.py",
         "language": "python",
         "symbol": "generate_config",
-        "digest": "git:8a560994bb5a994b5a57b37a07f99114656b18a3"
+        "digest": "git:6d6c7a4515c5aa68b9642ca221805c28a15f4fc1"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.elementary.bootstrap-project",
+      "kind": "artifact",
+      "title": "pf.tools.elementary:bootstrap_project",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:03Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/elementary.py",
+        "language": "python",
+        "symbol": "bootstrap_project"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.elementary.ensure-package",
+      "kind": "artifact",
+      "title": "pf.tools.elementary:ensure_package",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:03Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/elementary.py",
+        "language": "python",
+        "symbol": "ensure_package"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.expectations.write-tests",
+      "kind": "artifact",
+      "title": "pf.tools.expectations:write_tests",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:03Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/expectations.py",
+        "language": "python",
+        "symbol": "write_tests"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.expectations.bootstrap-project",
+      "kind": "artifact",
+      "title": "pf.tools.expectations:bootstrap_project",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:04Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/expectations.py",
+        "language": "python",
+        "symbol": "bootstrap_project"
       },
       "extensions": {
         "exists": true
@@ -977,18 +4384,408 @@
       "title": "gate.yaml:denylist",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-17T00:38:30Z",
+        "created_at": "2026-08-18T18:40:22Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "configuration",
       "language": "yaml",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "gate.yaml",
         "language": "yaml",
         "symbol": "denylist",
-        "digest": "git:f0f6dc9c2d8e60c371d7df8c8a9af65e9571c965"
+        "digest": "git:7d51894f5fdae49fa67534d8359ac34a48175bc8"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.gate.yaml.platform-denylist",
+      "kind": "artifact",
+      "title": "gate.yaml:platform_denylist",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "configuration",
+      "language": "yaml",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "gate.yaml",
+        "language": "yaml",
+        "symbol": "platform_denylist",
+        "digest": "git:7d51894f5fdae49fa67534d8359ac34a48175bc8"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.loops.gate.check-path",
+      "kind": "artifact",
+      "title": "pf.loops.gate:check_path",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-15T05:28:10Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "loop",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/loops/gate.py",
+        "language": "python",
+        "symbol": "check_path",
+        "digest": "git:0e0d5d990b04901c47b39e09bf783eb4a8821183"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.spec.Tool.gate-sections",
+      "kind": "artifact",
+      "title": "pf.tools.spec:Tool.gate_sections",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-17T23:50:05Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/spec.py",
+        "language": "python",
+        "symbol": "Tool.gate_sections",
+        "digest": "git:3b36976709eb70b17628d2c2228e4e398ed2df05"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.decision",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:decision",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "decision",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.platform.hooks.post-tool-use.py",
+      "kind": "artifact",
+      "title": "platform/hooks/post_tool_use.py",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "hook",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/hooks/post_tool_use.py",
+        "language": "python",
+        "digest": "git:99dc8363fbb485907c66034f6c6fefdc51336650"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.chain.verify",
+      "kind": "artifact",
+      "title": "pf.provenance.chain:verify",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/chain.py",
+        "language": "python",
+        "symbol": "verify",
+        "digest": "git:07d2c60e49bda58cd6b9d51534b3417cec91777c"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.anchor.stamp-rfc3161",
+      "kind": "artifact",
+      "title": "pf.provenance.anchor:stamp_rfc3161",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/anchor.py",
+        "language": "python",
+        "symbol": "stamp_rfc3161",
+        "digest": "git:a38a0c14b0286745dbe157807967085d044af606"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.loops.gate.project-for",
+      "kind": "artifact",
+      "title": "pf.loops.gate:project_for",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-15T05:28:10Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "loop",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/loops/gate.py",
+        "language": "python",
+        "symbol": "project_for",
+        "digest": "git:0e0d5d990b04901c47b39e09bf783eb4a8821183"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.revoke",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:revoke",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "revoke",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.is-revoked",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:is_revoked",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "is_revoked",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.approve",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:approve",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "approve",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.audit.report",
+      "kind": "artifact",
+      "title": "pf.provenance.audit:report",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/audit.py",
+        "language": "python",
+        "symbol": "report",
+        "digest": "git:048a4041043b8b6d2628b0f97929752c079fb95e"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.agents.base.AGENTS",
+      "kind": "artifact",
+      "title": "pf.agents.base:AGENTS",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/agents/base.py",
+        "language": "python",
+        "symbol": "AGENTS",
+        "digest": "git:21365423e93b1c6427aa7dbf6dbb2823993e42c2"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.vendor.model.load-registry",
+      "kind": "artifact",
+      "title": "pf.vendor.model:load_registry",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-13T01:11:58Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/vendor/model.py",
+        "language": "python",
+        "symbol": "load_registry",
+        "digest": "git:3364fcfb711181efa434a9fe7024e4dcc01984df"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.vendor.verify.verify",
+      "kind": "artifact",
+      "title": "pf.vendor.verify:verify",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/vendor/verify.py",
+        "language": "python",
+        "symbol": "verify",
+        "digest": "git:4b39f17a26d3f030c4f2ef101c60a502c2f9ccfb"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.air.coverage.assess",
+      "kind": "artifact",
+      "title": "pf.air.coverage:assess",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/air/coverage.py",
+        "language": "python",
+        "symbol": "assess",
+        "digest": "git:fd67a5e7eeec7fdfe079c96e066992764601c00f"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.air.register.render-register",
+      "kind": "artifact",
+      "title": "pf.air.register:render_register",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/air/register.py",
+        "language": "python",
+        "symbol": "render_register",
+        "digest": "git:c45d0bbbe459fadea3ab3edfbf96beb6db505f25"
       },
       "extensions": {
         "exists": true
@@ -1002,7 +4799,7 @@
       "to": "intent.pf.money-requires-currency",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1013,7 +4810,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1022,8 +4819,8 @@
       "to": "artifact.pf.pf.ontology.validate.money-without-currency",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1032,8 +4829,8 @@
       "to": "evidence.pf.money-requires-currency.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:44:14Z",
-        "verified_at": "2026-08-16T23:44:14Z"
+        "created_at": "2026-08-19T21:38:00Z",
+        "verified_at": "2026-08-19T21:38:00Z"
       }
     },
     {
@@ -1042,7 +4839,7 @@
       "to": "intent.pf.entity-requires-identity",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1053,7 +4850,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1062,8 +4859,8 @@
       "to": "artifact.pf.pf.ontology.validate.class-without-identity",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1072,8 +4869,8 @@
       "to": "evidence.pf.entity-requires-identity.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:44:14Z",
-        "verified_at": "2026-08-16T23:44:14Z"
+        "created_at": "2026-08-19T21:38:00Z",
+        "verified_at": "2026-08-19T21:38:00Z"
       }
     },
     {
@@ -1082,7 +4879,7 @@
       "to": "intent.pf.link-must-be-in-topology",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1093,7 +4890,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1102,8 +4899,8 @@
       "to": "artifact.pf.pf.ontology.validate.illegal-edge",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1112,8 +4909,8 @@
       "to": "evidence.pf.link-must-be-in-topology.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:44:14Z",
-        "verified_at": "2026-08-16T23:44:14Z"
+        "created_at": "2026-08-19T21:38:00Z",
+        "verified_at": "2026-08-19T21:38:00Z"
       }
     },
     {
@@ -1122,7 +4919,7 @@
       "to": "intent.pf.pii-not-in-consumption",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1133,7 +4930,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1142,8 +4939,8 @@
       "to": "artifact.pf.pf.loops.registry.pii-audit",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1152,8 +4949,8 @@
       "to": "evidence.pf.pii-not-in-consumption.pf-loop-run-pii-audit",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:44:14Z",
-        "verified_at": "2026-08-16T23:44:14Z"
+        "created_at": "2026-08-19T21:38:01Z",
+        "verified_at": "2026-08-19T21:38:01Z"
       }
     },
     {
@@ -1162,8 +4959,8 @@
       "to": "evidence.pf.pii-not-in-consumption.state-md",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "verified_at": "2026-08-15T20:35:53Z"
+        "created_at": "2026-08-18T15:42:57Z",
+        "verified_at": "2026-08-18T15:42:57Z"
       }
     },
     {
@@ -1172,7 +4969,7 @@
       "to": "intent.pf.mart-declares-grain",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1183,7 +4980,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1192,8 +4989,8 @@
       "to": "artifact.pf.pf.kg.build.model-grain",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1202,8 +4999,8 @@
       "to": "evidence.pf.mart-declares-grain.kg-context-card-md",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:44:14Z",
-        "verified_at": "2026-08-16T23:44:14Z"
+        "created_at": "2026-08-19T21:37:59Z",
+        "verified_at": "2026-08-19T21:37:59Z"
       }
     },
     {
@@ -1212,7 +5009,7 @@
       "to": "intent.pf.metric-owns-aggregation",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1223,7 +5020,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1232,8 +5029,8 @@
       "to": "artifact.pf.pf.ontology.validate.metric-shaped-column",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1242,8 +5039,8 @@
       "to": "evidence.pf.metric-owns-aggregation.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:44:15Z",
-        "verified_at": "2026-08-16T23:44:15Z"
+        "created_at": "2026-08-19T21:38:01Z",
+        "verified_at": "2026-08-19T21:38:01Z"
       }
     },
     {
@@ -1252,7 +5049,7 @@
       "to": "intent.pf.change-declares-blast-radius",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1263,7 +5060,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1272,8 +5069,8 @@
       "to": "artifact.pf.platform.hooks.pre-tool-use.py",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1282,8 +5079,8 @@
       "to": "artifact.pf.platform.hooks.pre-commit.sh",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1292,8 +5089,8 @@
       "to": "evidence.pf.change-declares-blast-radius.impact-reports",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:44:15Z",
-        "verified_at": "2026-08-16T23:44:15Z"
+        "created_at": "2026-08-19T21:38:02Z",
+        "verified_at": "2026-08-19T21:38:02Z"
       }
     },
     {
@@ -1302,8 +5099,8 @@
       "to": "evidence.pf.change-declares-blast-radius.loop-ledger-json",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "verified_at": "2026-08-15T20:35:53Z"
+        "created_at": "2026-08-19T20:47:22Z",
+        "verified_at": "2026-08-19T20:47:22Z"
       }
     },
     {
@@ -1312,7 +5109,7 @@
       "to": "intent.pf.change-verified-against-baseline",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1323,7 +5120,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1332,8 +5129,8 @@
       "to": "artifact.pf.pf.tools.recce.dagster-assets",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1342,8 +5139,8 @@
       "to": "artifact.pf.pf.tools.recce.register-commands",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1352,8 +5149,8 @@
       "to": "evidence.pf.change-verified-against-baseline.pf-tool-recce-run",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T22:57:13Z",
-        "verified_at": "2026-08-16T22:57:13Z"
+        "created_at": "2026-08-19T21:38:02Z",
+        "verified_at": "2026-08-19T21:38:02Z"
       }
     },
     {
@@ -1362,7 +5159,7 @@
       "to": "intent.pf.review-artifacts-exclude-pii",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1373,7 +5170,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1382,8 +5179,8 @@
       "to": "artifact.pf.pf.ontology.model.Role.review-intent",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1392,8 +5189,8 @@
       "to": "artifact.pf.pf.tools.recce.generate-config",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1402,8 +5199,118 @@
       "to": "evidence.pf.review-artifacts-exclude-pii.pf-tool-recce-config",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-15T20:38:47Z",
-        "verified_at": "2026-08-15T20:38:47Z"
+        "created_at": "2026-08-18T15:42:57Z",
+        "verified_at": "2026-08-18T15:42:57Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.derived-from.intent.pf.builds-record-observability",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "intent.pf.builds-record-observability",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.implemented-by.artifact.pf.pf.tools.elementary.bootstrap-project",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "artifact.pf.pf.tools.elementary.bootstrap-project",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.implemented-by.artifact.pf.pf.tools.elementary.ensure-package",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "artifact.pf.pf.tools.elementary.ensure-package",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.verified-by.evidence.pf.builds-record-observability.pf-tool-elementary-report",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "evidence.pf.builds-record-observability.pf-tool-elementary-report",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:03Z",
+        "verified_at": "2026-08-19T21:38:03Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.verified-by.evidence.pf.builds-record-observability.loop-ledger-json",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "evidence.pf.builds-record-observability.loop-ledger-json",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T20:47:22Z",
+        "verified_at": "2026-08-19T20:47:22Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.derived-from.intent.pf.quality-floor-derived-from-ontology",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "intent.pf.quality-floor-derived-from-ontology",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.implemented-by.artifact.pf.pf.tools.expectations.write-tests",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "artifact.pf.pf.tools.expectations.write-tests",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.implemented-by.artifact.pf.pf.tools.expectations.bootstrap-project",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "artifact.pf.pf.tools.expectations.bootstrap-project",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.verified-by.evidence.pf.quality-floor-derived-from-ontology.pf-tool-expectations-run",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "evidence.pf.quality-floor-derived-from-ontology.pf-tool-expectations-run",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:04Z",
+        "verified_at": "2026-08-19T21:38:04Z"
       }
     },
     {
@@ -1412,7 +5319,7 @@
       "to": "intent.pf.secrets-never-in-context",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1423,7 +5330,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1432,8 +5339,8 @@
       "to": "artifact.pf.gate.yaml.denylist",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1442,8 +5349,8 @@
       "to": "artifact.pf.platform.hooks.pre-tool-use.py",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1452,8 +5359,528 @@
       "to": "evidence.pf.secrets-never-in-context.pf-gate",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:44:15Z",
-        "verified_at": "2026-08-16T23:44:15Z"
+        "created_at": "2026-08-19T21:38:04Z",
+        "verified_at": "2026-08-19T21:38:04Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.derived-from.intent.pf.agent-authority-is-least-privilege",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "intent.pf.agent-authority-is-least-privilege",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.implemented-by.artifact.pf.gate.yaml.denylist",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "artifact.pf.gate.yaml.denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.implemented-by.artifact.pf.gate.yaml.platform-denylist",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "artifact.pf.gate.yaml.platform-denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.implemented-by.artifact.pf.pf.loops.gate.check-path",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "artifact.pf.pf.loops.gate.check-path",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.verified-by.evidence.pf.agent-authority-is-least-privilege.pf-gate",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "evidence.pf.agent-authority-is-least-privilege.pf-gate",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:04Z",
+        "verified_at": "2026-08-19T21:38:04Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.derived-from.intent.pf.tool-contribution-may-only-tighten",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "intent.pf.tool-contribution-may-only-tighten",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.implemented-by.artifact.pf.pf.tools.spec.Tool.gate-sections",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "artifact.pf.pf.tools.spec.Tool.gate-sections",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.verified-by.evidence.pf.tool-contribution-may-only-tighten.pf-check",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "evidence.pf.tool-contribution-may-only-tighten.pf-check",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:05Z",
+        "verified_at": "2026-08-19T21:38:05Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.derived-from.intent.pf.agent-decisions-are-recorded",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "intent.pf.agent-decisions-are-recorded",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.implemented-by.artifact.pf.pf.provenance.ledger.decision",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "artifact.pf.pf.provenance.ledger.decision",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.implemented-by.artifact.pf.platform.hooks.pre-tool-use.py",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "artifact.pf.platform.hooks.pre-tool-use.py",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.implemented-by.artifact.pf.platform.hooks.post-tool-use.py",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "artifact.pf.platform.hooks.post-tool-use.py",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.verified-by.evidence.pf.agent-decisions-are-recorded.pf-provenance-verify",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "evidence.pf.agent-decisions-are-recorded.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:05Z",
+        "verified_at": "2026-08-19T21:38:05Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.derived-from.intent.pf.evidence-chain-is-tamper-evident",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "intent.pf.evidence-chain-is-tamper-evident",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.implemented-by.artifact.pf.pf.provenance.chain.verify",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "artifact.pf.pf.provenance.chain.verify",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.implemented-by.artifact.pf.pf.provenance.anchor.stamp-rfc3161",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "artifact.pf.pf.provenance.anchor.stamp-rfc3161",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.implemented-by.artifact.pf.gate.yaml.denylist",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "artifact.pf.gate.yaml.denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.verified-by.evidence.pf.evidence-chain-is-tamper-evident.pf-provenance-verify",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "evidence.pf.evidence-chain-is-tamper-evident.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:05Z",
+        "verified_at": "2026-08-19T21:38:05Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.derived-from.intent.pf.sister-projects-are-isolated",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "intent.pf.sister-projects-are-isolated",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.implemented-by.artifact.pf.gate.yaml.platform-denylist",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "artifact.pf.gate.yaml.platform-denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.implemented-by.artifact.pf.pf.loops.gate.project-for",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "artifact.pf.pf.loops.gate.project-for",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.verified-by.evidence.pf.sister-projects-are-isolated.pf-gate",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "evidence.pf.sister-projects-are-isolated.pf-gate",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:06Z",
+        "verified_at": "2026-08-19T21:38:06Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.derived-from.intent.pf.agent-authority-is-revocable",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "intent.pf.agent-authority-is-revocable",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.implemented-by.artifact.pf.pf.provenance.ledger.revoke",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "artifact.pf.pf.provenance.ledger.revoke",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.implemented-by.artifact.pf.pf.provenance.ledger.is-revoked",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "artifact.pf.pf.provenance.ledger.is-revoked",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.verified-by.evidence.pf.agent-authority-is-revocable.pf-provenance-verify",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "evidence.pf.agent-authority-is-revocable.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:06Z",
+        "verified_at": "2026-08-19T21:38:06Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.derived-from.intent.pf.high-impact-actions-need-a-human",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "intent.pf.high-impact-actions-need-a-human",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.implemented-by.artifact.pf.pf.provenance.ledger.approve",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "artifact.pf.pf.provenance.ledger.approve",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.implemented-by.artifact.pf.pf.provenance.audit.report",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "artifact.pf.pf.provenance.audit.report",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.verified-by.evidence.pf.high-impact-actions-need-a-human.pf-provenance-verify",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "evidence.pf.high-impact-actions-need-a-human.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:07Z",
+        "verified_at": "2026-08-19T21:38:07Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.derived-from.intent.pf.model-routing-is-declared",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "intent.pf.model-routing-is-declared",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.implemented-by.artifact.pf.pf.agents.base.AGENTS",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "artifact.pf.pf.agents.base.AGENTS",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.verified-by.evidence.pf.model-routing-is-declared.pf-provenance-verify",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "evidence.pf.model-routing-is-declared.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:07Z",
+        "verified_at": "2026-08-19T21:38:07Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.derived-from.intent.pf.upstream-licences-are-reviewed",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "intent.pf.upstream-licences-are-reviewed",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.implemented-by.artifact.pf.pf.vendor.model.load-registry",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "artifact.pf.pf.vendor.model.load-registry",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.implemented-by.artifact.pf.pf.vendor.verify.verify",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "artifact.pf.pf.vendor.verify.verify",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.verified-by.evidence.pf.upstream-licences-are-reviewed.pf-check",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "evidence.pf.upstream-licences-are-reviewed.pf-check",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:07Z",
+        "verified_at": "2026-08-19T21:38:07Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.derived-from.intent.pf.control-baseline-is-declared",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "intent.pf.control-baseline-is-declared",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.implemented-by.artifact.pf.pf.air.coverage.assess",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "artifact.pf.pf.air.coverage.assess",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.implemented-by.artifact.pf.pf.air.register.render-register",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "artifact.pf.pf.air.register.render-register",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.verified-by.evidence.pf.control-baseline-is-declared.pf-air-coverage",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "evidence.pf.control-baseline-is-declared.pf-air-coverage",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:08Z",
+        "verified_at": "2026-08-19T21:38:08Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.verified-by.evidence.pf.control-baseline-is-declared.governance-air-register-md",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "evidence.pf.control-baseline-is-declared.governance-air-register-md",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:20Z",
+        "verified_at": "2026-08-19T18:05:20Z"
       }
     }
   ],

--- a/groups/jaffle/projects/jaffle-shop/governance/otop.json
+++ b/groups/jaffle/projects/jaffle-shop/governance/otop.json
@@ -4,9 +4,9 @@
     "id": "otop.pf.jaffle.jaffle-shop",
     "title": "Policy and evidence \u2014 jaffle/jaffle-shop",
     "repository": "https://github.com/Atomz-org/data-platform.git",
-    "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+    "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
     "metadata": {
-      "created_at": "2026-08-18T22:31:17Z",
+      "created_at": "2026-08-19T21:38:43Z",
       "actor": "pf.projections.otop"
     }
   },
@@ -17,13 +17,13 @@
       "title": "Agentic Data Platform governance policy",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
         "scope": "jaffle/jaffle-shop",
         "source": "platform/src/pf/ontology/policy.yaml",
-        "rules": 20
+        "rules": 22
       }
     },
     {
@@ -32,7 +32,7 @@
       "title": "A monetary amount without its currency is not a number, it is a bug waiting for a second entity to be onboarded.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -45,7 +45,7 @@
       "title": "money-requires-currency",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -202,8 +202,8 @@
       "title": "pf check for money-requires-currency",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-18T22:31:09Z",
-        "observed_at": "2026-08-18T22:31:09Z",
+        "created_at": "2026-08-19T21:38:35Z",
+        "observed_at": "2026-08-19T21:38:35Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -227,7 +227,7 @@
       "title": "A class with no identity property cannot participate in a derived join, so every BI and MDL projection of it is a guess.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -240,7 +240,7 @@
       "title": "entity-requires-identity",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -396,8 +396,8 @@
       "title": "pf check for entity-requires-identity",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-18T22:31:09Z",
-        "observed_at": "2026-08-18T22:31:09Z",
+        "created_at": "2026-08-19T21:38:35Z",
+        "observed_at": "2026-08-19T21:38:35Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -421,7 +421,7 @@
       "title": "A foreign key pointing at a class the topology does not relate to is an undeclared join. Undeclared joins are how two teams compute different revenue from th...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -434,7 +434,7 @@
       "title": "link-must-be-in-topology",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -588,8 +588,8 @@
       "title": "pf check for link-must-be-in-topology",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-18T22:31:09Z",
-        "observed_at": "2026-08-18T22:31:09Z",
+        "created_at": "2026-08-19T21:38:36Z",
+        "observed_at": "2026-08-19T21:38:36Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -613,7 +613,7 @@
       "title": "PII may land in raw and staging. It must not reach a mart or an exposure without a masking policy or an explicit, recorded waiver.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -626,7 +626,7 @@
       "title": "pii-not-in-consumption",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -801,8 +801,8 @@
       "title": "pf loop run pii-audit for pii-not-in-consumption",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-18T22:31:10Z",
-        "observed_at": "2026-08-18T22:31:10Z",
+        "created_at": "2026-08-19T21:38:36Z",
+        "observed_at": "2026-08-19T21:38:36Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "PII_findings",
@@ -851,7 +851,7 @@
       "title": "Grain is the one fact a downstream consumer cannot infer and cannot survive guessing. An undeclared grain is how a join silently fans out.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -864,7 +864,7 @@
       "title": "mart-declares-grain",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "SHOULD",
@@ -980,12 +980,12 @@
       "title": "kg/context_card.md for mart-declares-grain",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-18T22:31:10Z",
-        "observed_at": "2026-08-18T22:31:10Z",
+        "created_at": "2026-08-19T21:38:33Z",
+        "observed_at": "2026-08-19T21:38:33Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "project_index",
-      "result": "unknown",
+      "result": "pass",
       "subjects": [
         {
           "id": "constraint.pf.mart-declares-grain",
@@ -996,7 +996,7 @@
       "provenance": {
         "actor": "pf.projections.otop",
         "scope": "jaffle/jaffle-shop",
-        "detail": "kg/context_card.md not produced yet"
+        "detail": "groups/jaffle/projects/jaffle-shop/kg/context_card.md"
       }
     },
     {
@@ -1005,7 +1005,7 @@
       "title": "Aggregation policy \u2014 which statuses count, which timestamp, which filter \u2014 belongs to exactly one metric definition. A mart column named `revenue` is a secon...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -1018,7 +1018,7 @@
       "title": "metric-owns-aggregation",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "SHOULD",
@@ -1140,8 +1140,8 @@
       "title": "pf check for metric-owns-aggregation",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-18T22:31:11Z",
-        "observed_at": "2026-08-18T22:31:11Z",
+        "created_at": "2026-08-19T21:38:37Z",
+        "observed_at": "2026-08-19T21:38:37Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -1165,7 +1165,7 @@
       "title": "A model or column change must report what it breaks before it lands, including the human who owns each affected exposure.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -1178,7 +1178,7 @@
       "title": "change-declares-blast-radius",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -1351,8 +1351,8 @@
       "title": "impact_reports for change-declares-blast-radius",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-18T22:31:11Z",
-        "observed_at": "2026-08-18T22:31:11Z",
+        "created_at": "2026-08-19T21:38:37Z",
+        "observed_at": "2026-08-19T21:38:37Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "blast_radius_history",
@@ -1376,8 +1376,8 @@
       "title": "loop-ledger.json for change-declares-blast-radius",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-18T15:42:57Z",
-        "observed_at": "2026-08-18T15:42:57Z",
+        "created_at": "2026-08-19T20:47:22Z",
+        "observed_at": "2026-08-19T20:47:22Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "run_history",
@@ -1401,7 +1401,7 @@
       "title": "A blast radius is a prediction made from lineage. Lineage cannot say whether the numbers actually moved, so a change to a mart must also be compared against ...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -1414,7 +1414,7 @@
       "title": "change-verified-against-baseline",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "SHOULD",
@@ -1523,8 +1523,8 @@
       "title": "pf tool recce run for change-verified-against-baseline",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-18T22:31:12Z",
-        "observed_at": "2026-08-18T22:31:12Z",
+        "created_at": "2026-08-19T21:38:38Z",
+        "observed_at": "2026-08-19T21:38:38Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "data_diff_against_baseline",
@@ -1548,7 +1548,7 @@
       "title": "A value-level diff writes the rows it compared into the review tool's state file, which is durable and shared. Diffing a column whose role is PII therefore p...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -1561,7 +1561,7 @@
       "title": "review-artifacts-exclude-pii",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -1790,12 +1790,580 @@
       }
     },
     {
+      "id": "intent.pf.builds-record-observability",
+      "kind": "intent",
+      "title": "A dbt build that leaves no queryable record cannot be triaged; failures get diagnosed from whichever log happened to survive. Every build must record its run...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A dbt build that leaves no queryable record cannot be triaged; failures get diagnosed from whichever log happened to survive. Every build must record its run and test results into the warehouse with history \u2014 for every test framework at once \u2014 so \"is this new, recurring, or flaky?\" is a query, not an archaeology dig."
+      }
+    },
+    {
+      "id": "constraint.pf.builds-record-observability",
+      "kind": "constraint",
+      "title": "builds-record-observability",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "observability_recorded",
+      "checkability": "automated",
+      "assertion": "observability_recorded on artifact_glob=**/transform/packages.yml",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/transform/packages.yml"
+        },
+        "params": {},
+        "controls": [
+          "AIR-DET-4",
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-DET-4": "AI System Observability",
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t7-adoption",
+              "title": "Table 7: AI Adoption Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=57"
+            },
+            {
+              "key": "t7-nature",
+              "title": "Table 7: Nature and Use Cases of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            },
+            {
+              "key": "t7-performance",
+              "title": "Table 7: AI System Performance Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-8",
+              "title": "ISO 42001: AI system recording of event logs",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "au-11",
+              "title": "AU-11 Audit Record Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C462.0%2C0%5D"
+            },
+            {
+              "key": "au-12",
+              "title": "AU-12 Audit Record Generation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C122.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "ir-4",
+              "title": "IR-4 Incident Handling",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A527%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C626.0%2C0%5D"
+            },
+            {
+              "key": "ir-5",
+              "title": "IR-5 Incident Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A539%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C387%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-10",
+              "title": "RA-10 Threat Hunting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A812%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C110.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.builds-record-observability.pf-tool-elementary-report",
+      "kind": "evidence",
+      "title": "pf tool elementary report for builds-record-observability",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:39Z",
+        "observed_at": "2026-08-19T21:38:39Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "observability_report_over_recorded_history",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.builds-record-observability",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "jaffle/jaffle-shop",
+        "detail": "pf tool elementary report not produced yet"
+      }
+    },
+    {
+      "id": "evidence.pf.builds-record-observability.loop-ledger-json",
+      "kind": "evidence",
+      "title": "loop-ledger.json for builds-record-observability",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T20:47:22Z",
+        "observed_at": "2026-08-19T20:47:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "run_history",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.builds-record-observability",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "jaffle/jaffle-shop",
+        "detail": "loop-ledger.json"
+      }
+    },
+    {
+      "id": "intent.pf.quality-floor-derived-from-ontology",
+      "kind": "intent",
+      "title": "Hand-written test coverage decays to whichever models someone remembered. The floor \u2014 an annotated mart is never empty, a declared identity identifies \u2014 must...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Hand-written test coverage decays to whichever models someone remembered. The floor \u2014 an annotated mart is never empty, a declared identity identifies \u2014 must be derived from the ontology roles, so coverage is a function of annotation rather than of memory, and a wrong test is a wrong role rather than a stale file."
+      }
+    },
+    {
+      "id": "constraint.pf.quality-floor-derived-from-ontology",
+      "kind": "constraint",
+      "title": "quality-floor-derived-from-ontology",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "tests_derived_from_roles",
+      "checkability": "automated",
+      "assertion": "tests_derived_from_roles on artifact_glob=**/transform/tests/expectations/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/transform/tests/expectations/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-6",
+          "AIR-PREV-5"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity",
+          "AIR-PREV-5": "System Acceptance Testing"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            },
+            {
+              "key": "c3-s2-a15",
+              "title": "III.S2.A15: Accuracy, Robustness and Cybersecurity",
+              "url": "https://artificialintelligenceact.eu/article/15/"
+            },
+            {
+              "key": "c3-s2-a9",
+              "title": "III.S2.A9: Risk Management System",
+              "url": "https://artificialintelligenceact.eu/article/9/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-1",
+              "title": "Table 4.1: Assessment of Risk-Proportionate Controls",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=41"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-4",
+              "title": "ISO 42001: AI system verification and validation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-5",
+              "title": "ISO 42001: AI system deployment",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-2",
+              "title": "CA-2 Control Assessments",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A324%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C684%2C0%5D"
+            },
+            {
+              "key": "ca-6",
+              "title": "CA-6 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A339%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "cm-4",
+              "title": "CM-4 Impact Analyses",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A375%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C509.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-11",
+              "title": "SA-11 Developer Testing And Evaluation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A899%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C601.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-2",
+              "title": "SI-2 Flaw Remediation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1070%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-6",
+              "title": "SI-6 Security And Privacy Function Verification",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1103%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C475.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.quality-floor-derived-from-ontology.pf-tool-expectations-run",
+      "kind": "evidence",
+      "title": "pf tool expectations run for quality-floor-derived-from-ontology",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:39Z",
+        "observed_at": "2026-08-19T21:38:39Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "quality_floor_verdicts",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.quality-floor-derived-from-ontology",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "jaffle/jaffle-shop",
+        "detail": "pf tool expectations run not produced yet"
+      }
+    },
+    {
       "id": "intent.pf.secrets-never-in-context",
       "kind": "intent",
       "title": "A credential placed in a prompt, a model file or a committed artefact is durably persisted and replayed into every later session.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -1808,7 +2376,7 @@
       "title": "secrets-never-in-context",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -1954,8 +2522,8 @@
       "title": "pf gate for secrets-never-in-context",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-18T22:31:13Z",
-        "observed_at": "2026-08-18T22:31:13Z",
+        "created_at": "2026-08-19T21:38:39Z",
+        "observed_at": "2026-08-19T21:38:39Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "path_verdict",
@@ -1979,7 +2547,7 @@
       "title": "An agent reaches the filesystem through one path gate, and the paths it may never write are declared rather than remembered. Least privilege that lives in a ...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -1992,7 +2560,7 @@
       "title": "agent-authority-is-least-privilege",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -2079,8 +2647,8 @@
       "title": "pf gate for agent-authority-is-least-privilege",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-18T22:31:13Z",
-        "observed_at": "2026-08-18T22:31:13Z",
+        "created_at": "2026-08-19T21:38:40Z",
+        "observed_at": "2026-08-19T21:38:40Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "path_verdict",
@@ -2104,7 +2672,7 @@
       "title": "A tool contributes gate rules, and a plugin system that can widen the policy judging it is not a policy. `Tool.gate_sections()` rejects a contribution to any...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -2117,7 +2685,7 @@
       "title": "tool-contribution-may-only-tighten",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -2205,8 +2773,8 @@
       "title": "pf check for tool-contribution-may-only-tighten",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-18T22:31:13Z",
-        "observed_at": "2026-08-18T22:31:13Z",
+        "created_at": "2026-08-19T21:38:40Z",
+        "observed_at": "2026-08-19T21:38:40Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -2230,7 +2798,7 @@
       "title": "Every tool call an agent makes is written down before it happens and after it happens, and the gate's verdict is recorded for allows as well as denies. \"No r...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -2243,7 +2811,7 @@
       "title": "agent-decisions-are-recorded",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -2440,8 +3008,8 @@
       "title": "pf provenance verify for agent-decisions-are-recorded",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-18T22:31:14Z",
-        "observed_at": "2026-08-18T22:31:14Z",
+        "created_at": "2026-08-19T21:38:41Z",
+        "observed_at": "2026-08-19T21:38:41Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "ledger_audit",
@@ -2465,7 +3033,7 @@
       "title": "A log an agent can edit is not evidence. Each record carries the hash of the one before it, and the head is anchored to a timestamp authority with no stake i...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -2478,7 +3046,7 @@
       "title": "evidence-chain-is-tamper-evident",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -2607,8 +3175,8 @@
       "title": "pf provenance verify for evidence-chain-is-tamper-evident",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-18T22:31:14Z",
-        "observed_at": "2026-08-18T22:31:14Z",
+        "created_at": "2026-08-19T21:38:41Z",
+        "observed_at": "2026-08-19T21:38:41Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "ledger_audit",
@@ -2632,7 +3200,7 @@
       "title": "Business logic does not transfer between entities, so an assumption carried from one sister company into another is a bug by construction. A project session ...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -2645,7 +3213,7 @@
       "title": "sister-projects-are-isolated",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -2727,8 +3295,8 @@
       "title": "pf gate for sister-projects-are-isolated",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-18T22:31:15Z",
-        "observed_at": "2026-08-18T22:31:15Z",
+        "created_at": "2026-08-19T21:38:41Z",
+        "observed_at": "2026-08-19T21:38:41Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "path_verdict",
@@ -2752,7 +3320,7 @@
       "title": "A control that cannot be switched off mid-incident is a control you find out about afterwards. Revocation is checked before intent is written, and an unreada...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -2765,7 +3333,7 @@
       "title": "agent-authority-is-revocable",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -2852,8 +3420,8 @@
       "title": "pf provenance verify for agent-authority-is-revocable",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-18T22:31:15Z",
-        "observed_at": "2026-08-18T22:31:15Z",
+        "created_at": "2026-08-19T21:38:42Z",
+        "observed_at": "2026-08-19T21:38:42Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "ledger_audit",
@@ -2877,7 +3445,7 @@
       "title": "Human oversight is a chain that shows the approval, not a document that asserts it. Approvals are append-only and bound to the action they approve, and an ac...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -2890,7 +3458,7 @@
       "title": "high-impact-actions-need-a-human",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -3019,8 +3587,8 @@
       "title": "pf provenance verify for high-impact-actions-need-a-human",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-18T22:31:16Z",
-        "observed_at": "2026-08-18T22:31:16Z",
+        "created_at": "2026-08-19T21:38:42Z",
+        "observed_at": "2026-08-19T21:38:42Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "ledger_audit",
@@ -3044,7 +3612,7 @@
       "title": "Which model answers which step is a declared table, not whatever the caller passed. An unregistered step is recorded as such, and the recorded verdict matche...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -3057,7 +3625,7 @@
       "title": "model-routing-is-declared",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "SHOULD",
@@ -3174,8 +3742,8 @@
       "title": "pf provenance verify for model-routing-is-declared",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-18T22:31:16Z",
-        "observed_at": "2026-08-18T22:31:16Z",
+        "created_at": "2026-08-19T21:38:42Z",
+        "observed_at": "2026-08-19T21:38:42Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "ledger_audit",
@@ -3199,7 +3767,7 @@
       "title": "Every upstream this platform borrowed from carries a licence, and some of them constrain what we may ship. The review is written down per upstream and surfac...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -3212,7 +3780,7 @@
       "title": "upstream-licences-are-reviewed",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "SHOULD",
@@ -3344,8 +3912,8 @@
       "title": "pf check for upstream-licences-are-reviewed",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-18T22:31:16Z",
-        "observed_at": "2026-08-18T22:31:16Z",
+        "created_at": "2026-08-19T21:38:43Z",
+        "observed_at": "2026-08-19T21:38:43Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -3369,7 +3937,7 @@
       "title": "A risk register that names controls nobody enforces is a document. Each entity declares in `air.yaml` which controls it commits to; those are derived from th...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -3382,7 +3950,7 @@
       "title": "control-baseline-is-declared",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -3404,8 +3972,8 @@
       "title": "pf air coverage for control-baseline-is-declared",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-18T22:31:17Z",
-        "observed_at": "2026-08-18T22:31:17Z",
+        "created_at": "2026-08-19T21:38:43Z",
+        "observed_at": "2026-08-19T21:38:43Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "control_coverage_verdicts",
@@ -3429,8 +3997,8 @@
       "title": "governance/air-register.md for control-baseline-is-declared",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-18T22:31:06Z",
-        "observed_at": "2026-08-18T22:31:06Z",
+        "created_at": "2026-08-19T18:05:20Z",
+        "observed_at": "2026-08-19T18:05:20Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "per-entity_risk_register",
@@ -3461,7 +4029,7 @@
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "money-without-currency",
@@ -3484,7 +4052,7 @@
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "class-without-identity",
@@ -3507,7 +4075,7 @@
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "illegal-edge",
@@ -3530,7 +4098,7 @@
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/loops/registry.py",
         "language": "python",
         "symbol": "pii_audit",
@@ -3553,7 +4121,7 @@
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/kg/build.py",
         "language": "python",
         "symbol": "model-grain",
@@ -3576,7 +4144,7 @@
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "metric-shaped-column",
@@ -3599,7 +4167,7 @@
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/hooks/pre_tool_use.py",
         "language": "python",
         "digest": "git:230bc9d9639eaa71c8c511affccb14881cdfc1f1"
@@ -3621,7 +4189,7 @@
       "language": "bash",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/hooks/pre_commit.sh",
         "language": "bash",
         "digest": "git:ce8e6f322ce15a546c16d2eb25bddf4fab5b6688"
@@ -3643,7 +4211,7 @@
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/tools/recce.py",
         "language": "python",
         "symbol": "dagster_assets",
@@ -3666,7 +4234,7 @@
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/tools/recce.py",
         "language": "python",
         "symbol": "register_commands",
@@ -3682,18 +4250,18 @@
       "title": "pf.ontology.model:Role.review_intent",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-17T21:24:35Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/model.py",
         "language": "python",
         "symbol": "Role.review_intent",
-        "digest": "git:36f14fdd9731d72624292b2a1fa34ca89c5f9d25"
+        "digest": "git:513888ee8c2df8cfa1d09562ad3dc2793c4f741e"
       },
       "extensions": {
         "exists": true
@@ -3712,11 +4280,99 @@
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/tools/recce.py",
         "language": "python",
         "symbol": "generate_config",
         "digest": "git:6d6c7a4515c5aa68b9642ca221805c28a15f4fc1"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.elementary.bootstrap-project",
+      "kind": "artifact",
+      "title": "pf.tools.elementary:bootstrap_project",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:38Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/elementary.py",
+        "language": "python",
+        "symbol": "bootstrap_project"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.elementary.ensure-package",
+      "kind": "artifact",
+      "title": "pf.tools.elementary:ensure_package",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:39Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/elementary.py",
+        "language": "python",
+        "symbol": "ensure_package"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.expectations.write-tests",
+      "kind": "artifact",
+      "title": "pf.tools.expectations:write_tests",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:39Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/expectations.py",
+        "language": "python",
+        "symbol": "write_tests"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.expectations.bootstrap-project",
+      "kind": "artifact",
+      "title": "pf.tools.expectations:bootstrap_project",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:39Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/expectations.py",
+        "language": "python",
+        "symbol": "bootstrap_project"
       },
       "extensions": {
         "exists": true
@@ -3735,7 +4391,7 @@
       "language": "yaml",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "gate.yaml",
         "language": "yaml",
         "symbol": "denylist",
@@ -3758,7 +4414,7 @@
       "language": "yaml",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "gate.yaml",
         "language": "yaml",
         "symbol": "platform_denylist",
@@ -3781,7 +4437,7 @@
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/loops/gate.py",
         "language": "python",
         "symbol": "check_path",
@@ -3804,7 +4460,7 @@
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/tools/spec.py",
         "language": "python",
         "symbol": "Tool.gate_sections",
@@ -3827,7 +4483,7 @@
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/provenance/ledger.py",
         "language": "python",
         "symbol": "decision",
@@ -3850,7 +4506,7 @@
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/hooks/post_tool_use.py",
         "language": "python",
         "digest": "git:99dc8363fbb485907c66034f6c6fefdc51336650"
@@ -3872,7 +4528,7 @@
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/provenance/chain.py",
         "language": "python",
         "symbol": "verify",
@@ -3895,7 +4551,7 @@
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/provenance/anchor.py",
         "language": "python",
         "symbol": "stamp_rfc3161",
@@ -3918,7 +4574,7 @@
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/loops/gate.py",
         "language": "python",
         "symbol": "project_for",
@@ -3941,7 +4597,7 @@
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/provenance/ledger.py",
         "language": "python",
         "symbol": "revoke",
@@ -3964,7 +4620,7 @@
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/provenance/ledger.py",
         "language": "python",
         "symbol": "is_revoked",
@@ -3987,7 +4643,7 @@
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/provenance/ledger.py",
         "language": "python",
         "symbol": "approve",
@@ -4010,7 +4666,7 @@
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/provenance/audit.py",
         "language": "python",
         "symbol": "report",
@@ -4033,7 +4689,7 @@
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/agents/base.py",
         "language": "python",
         "symbol": "AGENTS",
@@ -4056,7 +4712,7 @@
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/vendor/model.py",
         "language": "python",
         "symbol": "load_registry",
@@ -4072,18 +4728,18 @@
       "title": "pf.vendor.verify:verify",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T01:17:31Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/vendor/verify.py",
         "language": "python",
         "symbol": "verify",
-        "digest": "git:7bc3a5e3ae0c06777c30449ee84ed6f4613bb3c7"
+        "digest": "git:4b39f17a26d3f030c4f2ef101c60a502c2f9ccfb"
       },
       "extensions": {
         "exists": true
@@ -4095,17 +4751,18 @@
       "title": "pf.air.coverage:assess",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-18T22:31:17Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/air/coverage.py",
         "language": "python",
-        "symbol": "assess"
+        "symbol": "assess",
+        "digest": "git:fd67a5e7eeec7fdfe079c96e066992764601c00f"
       },
       "extensions": {
         "exists": true
@@ -4117,17 +4774,18 @@
       "title": "pf.air.register:render_register",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-18T22:31:17Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "4fb29e6631ce8560163eeb2ca6d73c504e6c32f9",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/air/register.py",
         "language": "python",
-        "symbol": "render_register"
+        "symbol": "render_register",
+        "digest": "git:c45d0bbbe459fadea3ab3edfbf96beb6db505f25"
       },
       "extensions": {
         "exists": true
@@ -4141,7 +4799,7 @@
       "to": "intent.pf.money-requires-currency",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -4152,7 +4810,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4161,8 +4819,8 @@
       "to": "artifact.pf.pf.ontology.validate.money-without-currency",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4171,8 +4829,8 @@
       "to": "evidence.pf.money-requires-currency.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-18T22:31:09Z",
-        "verified_at": "2026-08-18T22:31:09Z"
+        "created_at": "2026-08-19T21:38:35Z",
+        "verified_at": "2026-08-19T21:38:35Z"
       }
     },
     {
@@ -4181,7 +4839,7 @@
       "to": "intent.pf.entity-requires-identity",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -4192,7 +4850,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4201,8 +4859,8 @@
       "to": "artifact.pf.pf.ontology.validate.class-without-identity",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4211,8 +4869,8 @@
       "to": "evidence.pf.entity-requires-identity.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-18T22:31:09Z",
-        "verified_at": "2026-08-18T22:31:09Z"
+        "created_at": "2026-08-19T21:38:35Z",
+        "verified_at": "2026-08-19T21:38:35Z"
       }
     },
     {
@@ -4221,7 +4879,7 @@
       "to": "intent.pf.link-must-be-in-topology",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -4232,7 +4890,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4241,8 +4899,8 @@
       "to": "artifact.pf.pf.ontology.validate.illegal-edge",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4251,8 +4909,8 @@
       "to": "evidence.pf.link-must-be-in-topology.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-18T22:31:09Z",
-        "verified_at": "2026-08-18T22:31:09Z"
+        "created_at": "2026-08-19T21:38:36Z",
+        "verified_at": "2026-08-19T21:38:36Z"
       }
     },
     {
@@ -4261,7 +4919,7 @@
       "to": "intent.pf.pii-not-in-consumption",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -4272,7 +4930,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4281,8 +4939,8 @@
       "to": "artifact.pf.pf.loops.registry.pii-audit",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4291,8 +4949,8 @@
       "to": "evidence.pf.pii-not-in-consumption.pf-loop-run-pii-audit",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-18T22:31:10Z",
-        "verified_at": "2026-08-18T22:31:10Z"
+        "created_at": "2026-08-19T21:38:36Z",
+        "verified_at": "2026-08-19T21:38:36Z"
       }
     },
     {
@@ -4311,7 +4969,7 @@
       "to": "intent.pf.mart-declares-grain",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -4322,7 +4980,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4331,8 +4989,8 @@
       "to": "artifact.pf.pf.kg.build.model-grain",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4341,8 +4999,8 @@
       "to": "evidence.pf.mart-declares-grain.kg-context-card-md",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-18T22:31:10Z",
-        "verified_at": "2026-08-18T22:31:10Z"
+        "created_at": "2026-08-19T21:38:33Z",
+        "verified_at": "2026-08-19T21:38:33Z"
       }
     },
     {
@@ -4351,7 +5009,7 @@
       "to": "intent.pf.metric-owns-aggregation",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -4362,7 +5020,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4371,8 +5029,8 @@
       "to": "artifact.pf.pf.ontology.validate.metric-shaped-column",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4381,8 +5039,8 @@
       "to": "evidence.pf.metric-owns-aggregation.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-18T22:31:11Z",
-        "verified_at": "2026-08-18T22:31:11Z"
+        "created_at": "2026-08-19T21:38:37Z",
+        "verified_at": "2026-08-19T21:38:37Z"
       }
     },
     {
@@ -4391,7 +5049,7 @@
       "to": "intent.pf.change-declares-blast-radius",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -4402,7 +5060,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4411,8 +5069,8 @@
       "to": "artifact.pf.platform.hooks.pre-tool-use.py",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4421,8 +5079,8 @@
       "to": "artifact.pf.platform.hooks.pre-commit.sh",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4431,8 +5089,8 @@
       "to": "evidence.pf.change-declares-blast-radius.impact-reports",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-18T22:31:11Z",
-        "verified_at": "2026-08-18T22:31:11Z"
+        "created_at": "2026-08-19T21:38:37Z",
+        "verified_at": "2026-08-19T21:38:37Z"
       }
     },
     {
@@ -4441,8 +5099,8 @@
       "to": "evidence.pf.change-declares-blast-radius.loop-ledger-json",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-18T15:42:57Z",
-        "verified_at": "2026-08-18T15:42:57Z"
+        "created_at": "2026-08-19T20:47:22Z",
+        "verified_at": "2026-08-19T20:47:22Z"
       }
     },
     {
@@ -4451,7 +5109,7 @@
       "to": "intent.pf.change-verified-against-baseline",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -4462,7 +5120,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4471,8 +5129,8 @@
       "to": "artifact.pf.pf.tools.recce.dagster-assets",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4481,8 +5139,8 @@
       "to": "artifact.pf.pf.tools.recce.register-commands",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4491,8 +5149,8 @@
       "to": "evidence.pf.change-verified-against-baseline.pf-tool-recce-run",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-18T22:31:12Z",
-        "verified_at": "2026-08-18T22:31:12Z"
+        "created_at": "2026-08-19T21:38:38Z",
+        "verified_at": "2026-08-19T21:38:38Z"
       }
     },
     {
@@ -4501,7 +5159,7 @@
       "to": "intent.pf.review-artifacts-exclude-pii",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -4512,7 +5170,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4521,8 +5179,8 @@
       "to": "artifact.pf.pf.ontology.model.Role.review-intent",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4531,8 +5189,8 @@
       "to": "artifact.pf.pf.tools.recce.generate-config",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4546,12 +5204,122 @@
       }
     },
     {
+      "id": "rel.constraint.pf.builds-record-observability.derived-from.intent.pf.builds-record-observability",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "intent.pf.builds-record-observability",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.implemented-by.artifact.pf.pf.tools.elementary.bootstrap-project",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "artifact.pf.pf.tools.elementary.bootstrap-project",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.implemented-by.artifact.pf.pf.tools.elementary.ensure-package",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "artifact.pf.pf.tools.elementary.ensure-package",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.verified-by.evidence.pf.builds-record-observability.pf-tool-elementary-report",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "evidence.pf.builds-record-observability.pf-tool-elementary-report",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:39Z",
+        "verified_at": "2026-08-19T21:38:39Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.verified-by.evidence.pf.builds-record-observability.loop-ledger-json",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "evidence.pf.builds-record-observability.loop-ledger-json",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T20:47:22Z",
+        "verified_at": "2026-08-19T20:47:22Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.derived-from.intent.pf.quality-floor-derived-from-ontology",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "intent.pf.quality-floor-derived-from-ontology",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.implemented-by.artifact.pf.pf.tools.expectations.write-tests",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "artifact.pf.pf.tools.expectations.write-tests",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.implemented-by.artifact.pf.pf.tools.expectations.bootstrap-project",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "artifact.pf.pf.tools.expectations.bootstrap-project",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.verified-by.evidence.pf.quality-floor-derived-from-ontology.pf-tool-expectations-run",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "evidence.pf.quality-floor-derived-from-ontology.pf-tool-expectations-run",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:38:39Z",
+        "verified_at": "2026-08-19T21:38:39Z"
+      }
+    },
+    {
       "id": "rel.constraint.pf.secrets-never-in-context.derived-from.intent.pf.secrets-never-in-context",
       "from": "constraint.pf.secrets-never-in-context",
       "to": "intent.pf.secrets-never-in-context",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -4562,7 +5330,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4571,8 +5339,8 @@
       "to": "artifact.pf.gate.yaml.denylist",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4581,8 +5349,8 @@
       "to": "artifact.pf.platform.hooks.pre-tool-use.py",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4591,8 +5359,8 @@
       "to": "evidence.pf.secrets-never-in-context.pf-gate",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-18T22:31:13Z",
-        "verified_at": "2026-08-18T22:31:13Z"
+        "created_at": "2026-08-19T21:38:39Z",
+        "verified_at": "2026-08-19T21:38:39Z"
       }
     },
     {
@@ -4601,7 +5369,7 @@
       "to": "intent.pf.agent-authority-is-least-privilege",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -4612,7 +5380,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4621,8 +5389,8 @@
       "to": "artifact.pf.gate.yaml.denylist",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4631,8 +5399,8 @@
       "to": "artifact.pf.gate.yaml.platform-denylist",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4641,8 +5409,8 @@
       "to": "artifact.pf.pf.loops.gate.check-path",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4651,8 +5419,8 @@
       "to": "evidence.pf.agent-authority-is-least-privilege.pf-gate",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-18T22:31:13Z",
-        "verified_at": "2026-08-18T22:31:13Z"
+        "created_at": "2026-08-19T21:38:40Z",
+        "verified_at": "2026-08-19T21:38:40Z"
       }
     },
     {
@@ -4661,7 +5429,7 @@
       "to": "intent.pf.tool-contribution-may-only-tighten",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -4672,7 +5440,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4681,8 +5449,8 @@
       "to": "artifact.pf.pf.tools.spec.Tool.gate-sections",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4691,8 +5459,8 @@
       "to": "evidence.pf.tool-contribution-may-only-tighten.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-18T22:31:13Z",
-        "verified_at": "2026-08-18T22:31:13Z"
+        "created_at": "2026-08-19T21:38:40Z",
+        "verified_at": "2026-08-19T21:38:40Z"
       }
     },
     {
@@ -4701,7 +5469,7 @@
       "to": "intent.pf.agent-decisions-are-recorded",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -4712,7 +5480,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4721,8 +5489,8 @@
       "to": "artifact.pf.pf.provenance.ledger.decision",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4731,8 +5499,8 @@
       "to": "artifact.pf.platform.hooks.pre-tool-use.py",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4741,8 +5509,8 @@
       "to": "artifact.pf.platform.hooks.post-tool-use.py",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4751,8 +5519,8 @@
       "to": "evidence.pf.agent-decisions-are-recorded.pf-provenance-verify",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-18T22:31:14Z",
-        "verified_at": "2026-08-18T22:31:14Z"
+        "created_at": "2026-08-19T21:38:41Z",
+        "verified_at": "2026-08-19T21:38:41Z"
       }
     },
     {
@@ -4761,7 +5529,7 @@
       "to": "intent.pf.evidence-chain-is-tamper-evident",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -4772,7 +5540,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4781,8 +5549,8 @@
       "to": "artifact.pf.pf.provenance.chain.verify",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4791,8 +5559,8 @@
       "to": "artifact.pf.pf.provenance.anchor.stamp-rfc3161",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4801,8 +5569,8 @@
       "to": "artifact.pf.gate.yaml.denylist",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4811,8 +5579,8 @@
       "to": "evidence.pf.evidence-chain-is-tamper-evident.pf-provenance-verify",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-18T22:31:14Z",
-        "verified_at": "2026-08-18T22:31:14Z"
+        "created_at": "2026-08-19T21:38:41Z",
+        "verified_at": "2026-08-19T21:38:41Z"
       }
     },
     {
@@ -4821,7 +5589,7 @@
       "to": "intent.pf.sister-projects-are-isolated",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -4832,7 +5600,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4841,8 +5609,8 @@
       "to": "artifact.pf.gate.yaml.platform-denylist",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4851,8 +5619,8 @@
       "to": "artifact.pf.pf.loops.gate.project-for",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4861,8 +5629,8 @@
       "to": "evidence.pf.sister-projects-are-isolated.pf-gate",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-18T22:31:15Z",
-        "verified_at": "2026-08-18T22:31:15Z"
+        "created_at": "2026-08-19T21:38:41Z",
+        "verified_at": "2026-08-19T21:38:41Z"
       }
     },
     {
@@ -4871,7 +5639,7 @@
       "to": "intent.pf.agent-authority-is-revocable",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -4882,7 +5650,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4891,8 +5659,8 @@
       "to": "artifact.pf.pf.provenance.ledger.revoke",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4901,8 +5669,8 @@
       "to": "artifact.pf.pf.provenance.ledger.is-revoked",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4911,8 +5679,8 @@
       "to": "evidence.pf.agent-authority-is-revocable.pf-provenance-verify",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-18T22:31:15Z",
-        "verified_at": "2026-08-18T22:31:15Z"
+        "created_at": "2026-08-19T21:38:42Z",
+        "verified_at": "2026-08-19T21:38:42Z"
       }
     },
     {
@@ -4921,7 +5689,7 @@
       "to": "intent.pf.high-impact-actions-need-a-human",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -4932,7 +5700,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4941,8 +5709,8 @@
       "to": "artifact.pf.pf.provenance.ledger.approve",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4951,8 +5719,8 @@
       "to": "artifact.pf.pf.provenance.audit.report",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4961,8 +5729,8 @@
       "to": "evidence.pf.high-impact-actions-need-a-human.pf-provenance-verify",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-18T22:31:16Z",
-        "verified_at": "2026-08-18T22:31:16Z"
+        "created_at": "2026-08-19T21:38:42Z",
+        "verified_at": "2026-08-19T21:38:42Z"
       }
     },
     {
@@ -4971,7 +5739,7 @@
       "to": "intent.pf.model-routing-is-declared",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -4982,7 +5750,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -4991,8 +5759,8 @@
       "to": "artifact.pf.pf.agents.base.AGENTS",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -5001,8 +5769,8 @@
       "to": "evidence.pf.model-routing-is-declared.pf-provenance-verify",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-18T22:31:16Z",
-        "verified_at": "2026-08-18T22:31:16Z"
+        "created_at": "2026-08-19T21:38:42Z",
+        "verified_at": "2026-08-19T21:38:42Z"
       }
     },
     {
@@ -5011,7 +5779,7 @@
       "to": "intent.pf.upstream-licences-are-reviewed",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -5022,7 +5790,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -5031,8 +5799,8 @@
       "to": "artifact.pf.pf.vendor.model.load-registry",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -5041,8 +5809,8 @@
       "to": "artifact.pf.pf.vendor.verify.verify",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -5051,8 +5819,8 @@
       "to": "evidence.pf.upstream-licences-are-reviewed.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-18T22:31:16Z",
-        "verified_at": "2026-08-18T22:31:16Z"
+        "created_at": "2026-08-19T21:38:43Z",
+        "verified_at": "2026-08-19T21:38:43Z"
       }
     },
     {
@@ -5061,7 +5829,7 @@
       "to": "intent.pf.control-baseline-is-declared",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -5072,7 +5840,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -5081,8 +5849,8 @@
       "to": "artifact.pf.pf.air.coverage.assess",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -5091,8 +5859,8 @@
       "to": "artifact.pf.pf.air.register.render-register",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T20:01:06Z",
-        "implemented_at": "2026-08-13T20:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -5101,8 +5869,8 @@
       "to": "evidence.pf.control-baseline-is-declared.pf-air-coverage",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-18T22:31:17Z",
-        "verified_at": "2026-08-18T22:31:17Z"
+        "created_at": "2026-08-19T21:38:43Z",
+        "verified_at": "2026-08-19T21:38:43Z"
       }
     },
     {
@@ -5111,8 +5879,8 @@
       "to": "evidence.pf.control-baseline-is-declared.governance-air-register-md",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-18T22:31:06Z",
-        "verified_at": "2026-08-18T22:31:06Z"
+        "created_at": "2026-08-19T18:05:20Z",
+        "verified_at": "2026-08-19T18:05:20Z"
       }
     }
   ],

--- a/groups/zenith/projects/zenith-de/governance/otop.json
+++ b/groups/zenith/projects/zenith-de/governance/otop.json
@@ -4,9 +4,9 @@
     "id": "otop.pf.zenith.zenith-de",
     "title": "Policy and evidence \u2014 zenith/zenith-de",
     "repository": "https://github.com/Atomz-org/data-platform.git",
-    "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+    "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
     "metadata": {
-      "created_at": "2026-08-16T23:47:31Z",
+      "created_at": "2026-08-19T21:39:08Z",
       "actor": "pf.projections.otop"
     }
   },
@@ -17,13 +17,13 @@
       "title": "Agentic Data Platform governance policy",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
         "scope": "zenith/zenith-de",
         "source": "platform/src/pf/ontology/policy.yaml",
-        "rules": 10
+        "rules": 22
       }
     },
     {
@@ -32,7 +32,7 @@
       "title": "A monetary amount without its currency is not a number, it is a bug waiting for a second entity to be onboarded.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -45,7 +45,7 @@
       "title": "money-requires-currency",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -61,6 +61,138 @@
         "params": {
           "sibling": "currency_code",
           "scope": "resource"
+        },
+        "controls": [
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -70,8 +202,8 @@
       "title": "pf check for money-requires-currency",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:47:29Z",
-        "observed_at": "2026-08-16T23:47:29Z",
+        "created_at": "2026-08-19T21:39:00Z",
+        "observed_at": "2026-08-19T21:39:00Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -95,7 +227,7 @@
       "title": "A class with no identity property cannot participate in a derived join, so every BI and MDL projection of it is a guess.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -108,7 +240,7 @@
       "title": "entity-requires-identity",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -123,6 +255,138 @@
         },
         "params": {
           "exclude_abstract": true
+        },
+        "controls": [
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -132,8 +396,8 @@
       "title": "pf check for entity-requires-identity",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:47:30Z",
-        "observed_at": "2026-08-16T23:47:30Z",
+        "created_at": "2026-08-19T21:39:00Z",
+        "observed_at": "2026-08-19T21:39:00Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -157,7 +421,7 @@
       "title": "A foreign key pointing at a class the topology does not relate to is an undeclared join. Undeclared joins are how two teams compute different revenue from th...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -170,7 +434,7 @@
       "title": "link-must-be-in-topology",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -183,7 +447,139 @@
         "applies_to": {
           "annotation": "links"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -192,8 +588,8 @@
       "title": "pf check for link-must-be-in-topology",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:47:30Z",
-        "observed_at": "2026-08-16T23:47:30Z",
+        "created_at": "2026-08-19T21:39:01Z",
+        "observed_at": "2026-08-19T21:39:01Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -217,7 +613,7 @@
       "title": "PII may land in raw and staging. It must not reach a mart or an exposure without a masking policy or an explicit, recorded waiver.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -230,7 +626,7 @@
       "title": "pii-not-in-consumption",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -249,6 +645,153 @@
             "semantic",
             "consumption"
           ]
+        },
+        "controls": [
+          "AIR-DET-16",
+          "AIR-PREV-12"
+        ],
+        "control_titles": {
+          "AIR-DET-16": "Preserving Source Data Access Controls in AI Systems",
+          "AIR-PREV-12": "Role-Based Access Control for AI Data"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-3-2",
+              "title": "ISO 42001: AI roles and responsibilities",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-3",
+              "title": "ISO 42001: Acquisition of data",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-9-2",
+              "title": "ISO 42001: Processes for responsible use of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-21",
+              "title": "AC-21 Information Sharing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A238%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C521.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ca-8",
+              "title": "CA-8 Penetration Testing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A351%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "cm-12",
+              "title": "CM-12 Information Location",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ia-2",
+              "title": "IA-2 Identification And Authentication (organizational Users)",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A467%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ia-4",
+              "title": "IA-4 Identifier Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A479%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C422.0%2C0%5D"
+            },
+            {
+              "key": "ia-5",
+              "title": "IA-5 Authenticator Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A485%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -258,8 +801,8 @@
       "title": "pf loop run pii-audit for pii-not-in-consumption",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:47:30Z",
-        "observed_at": "2026-08-16T23:47:30Z",
+        "created_at": "2026-08-19T21:39:01Z",
+        "observed_at": "2026-08-19T21:39:01Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "PII_findings",
@@ -283,8 +826,8 @@
       "title": "STATE.md for pii-not-in-consumption",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "observed_at": "2026-08-15T20:35:53Z",
+        "created_at": "2026-08-18T15:42:57Z",
+        "observed_at": "2026-08-18T15:42:57Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "open_findings",
@@ -308,7 +851,7 @@
       "title": "Grain is the one fact a downstream consumer cannot infer and cannot survive guessing. An undeclared grain is how a join silently fans out.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -321,7 +864,7 @@
       "title": "mart-declares-grain",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "SHOULD",
@@ -336,6 +879,98 @@
         },
         "params": {
           "field": "grain"
+        },
+        "controls": [
+          "AIR-DET-13"
+        ],
+        "control_titles": {
+          "AIR-DET-13": "Providing Citations and Source Traceability for AI-Generated Information"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t5-1",
+              "title": "Table 5.1: Disclosure of AI Use in Products and Services to End-Users",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=49"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-1-2",
+              "title": "ISO 42001: Objectives for responsible development of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-7",
+              "title": "ISO 42001: AI system technical documentation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-2",
+              "title": "ISO 42001: System documentation and information for users",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-10",
+              "title": "AU-10 Non-repudiation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A301%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-8",
+              "title": "SA-8 Security And Privacy Engineering Principles",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A842%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -345,8 +980,8 @@
       "title": "kg/context_card.md for mart-declares-grain",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:47:29Z",
-        "observed_at": "2026-08-16T23:47:29Z",
+        "created_at": "2026-08-19T21:39:00Z",
+        "observed_at": "2026-08-19T21:39:00Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "project_index",
@@ -370,7 +1005,7 @@
       "title": "Aggregation policy \u2014 which statuses count, which timestamp, which filter \u2014 belongs to exactly one metric definition. A mart column named `revenue` is a secon...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -383,7 +1018,7 @@
       "title": "metric-owns-aggregation",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "SHOULD",
@@ -404,6 +1039,98 @@
             "churn_rate",
             "ltv"
           ]
+        },
+        "controls": [
+          "AIR-DET-13"
+        ],
+        "control_titles": {
+          "AIR-DET-13": "Providing Citations and Source Traceability for AI-Generated Information"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t5-1",
+              "title": "Table 5.1: Disclosure of AI Use in Products and Services to End-Users",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=49"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-1-2",
+              "title": "ISO 42001: Objectives for responsible development of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-7",
+              "title": "ISO 42001: AI system technical documentation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-2",
+              "title": "ISO 42001: System documentation and information for users",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-10",
+              "title": "AU-10 Non-repudiation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A301%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-8",
+              "title": "SA-8 Security And Privacy Engineering Principles",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A842%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -413,8 +1140,8 @@
       "title": "pf check for metric-owns-aggregation",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:47:30Z",
-        "observed_at": "2026-08-16T23:47:30Z",
+        "created_at": "2026-08-19T21:39:02Z",
+        "observed_at": "2026-08-19T21:39:02Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -438,7 +1165,7 @@
       "title": "A model or column change must report what it breaks before it lands, including the human who owns each affected exposure.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -451,7 +1178,7 @@
       "title": "change-declares-blast-radius",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -464,7 +1191,158 @@
         "applies_to": {
           "artifact_glob": "**/transform/models/**"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-DET-21",
+          "AIR-PREV-18"
+        ],
+        "control_titles": {
+          "AIR-DET-21": "Agent Decision Audit and Explainability",
+          "AIR-PREV-18": "Agent Authority Least Privilege Framework"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00040",
+              "title": "ATR-2026-00040 Agent Privilege Escalation",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/privilege-escalation/ATR-2026-00040-privilege-escalation.yaml"
+            },
+            {
+              "key": "ATR-2026-00098",
+              "title": "ATR-2026-00098 Unauthorized Financial Action by Agent",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/excessive-autonomy/ATR-2026-00098-unauthorized-financial-action.yaml"
+            }
+          ],
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a12",
+              "title": "III.S2.A12: Record-Keeping",
+              "url": "https://artificialintelligenceact.eu/article/12/"
+            },
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c3-s3-a26",
+              "title": "III.S3.A26: Obligations of Deployers of High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/26/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -473,8 +1351,8 @@
       "title": "impact_reports for change-declares-blast-radius",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:47:30Z",
-        "observed_at": "2026-08-16T23:47:30Z",
+        "created_at": "2026-08-19T21:39:02Z",
+        "observed_at": "2026-08-19T21:39:02Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "blast_radius_history",
@@ -498,8 +1376,8 @@
       "title": "loop-ledger.json for change-declares-blast-radius",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "observed_at": "2026-08-15T20:35:53Z",
+        "created_at": "2026-08-19T20:47:22Z",
+        "observed_at": "2026-08-19T20:47:22Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "run_history",
@@ -523,7 +1401,7 @@
       "title": "A blast radius is a prediction made from lineage. Lineage cannot say whether the numbers actually moved, so a change to a mart must also be compared against ...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -536,7 +1414,7 @@
       "title": "change-verified-against-baseline",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "SHOULD",
@@ -549,7 +1427,94 @@
         "applies_to": {
           "artifact_glob": "**/transform/models/marts/**"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-PREV-5"
+        ],
+        "control_titles": {
+          "AIR-PREV-5": "System Acceptance Testing"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a15",
+              "title": "III.S2.A15: Accuracy, Robustness and Cybersecurity",
+              "url": "https://artificialintelligenceact.eu/article/15/"
+            },
+            {
+              "key": "c3-s2-a9",
+              "title": "III.S2.A9: Risk Management System",
+              "url": "https://artificialintelligenceact.eu/article/9/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-1",
+              "title": "Table 4.1: Assessment of Risk-Proportionate Controls",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=41"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-4",
+              "title": "ISO 42001: AI system verification and validation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-5",
+              "title": "ISO 42001: AI system deployment",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ca-2",
+              "title": "CA-2 Control Assessments",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A324%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C684%2C0%5D"
+            },
+            {
+              "key": "ca-6",
+              "title": "CA-6 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A339%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "cm-4",
+              "title": "CM-4 Impact Analyses",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A375%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C509.0%2C0%5D"
+            },
+            {
+              "key": "sa-11",
+              "title": "SA-11 Developer Testing And Evaluation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A899%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C601.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-2",
+              "title": "SI-2 Flaw Remediation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1070%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-6",
+              "title": "SI-6 Security And Privacy Function Verification",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1103%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C475.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -558,12 +1523,12 @@
       "title": "pf tool recce run for change-verified-against-baseline",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:57:34Z",
-        "observed_at": "2026-08-16T22:57:34Z",
+        "created_at": "2026-08-19T21:39:03Z",
+        "observed_at": "2026-08-19T21:39:03Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "data_diff_against_baseline",
-      "result": "pass",
+      "result": "unknown",
       "subjects": [
         {
           "id": "constraint.pf.change-verified-against-baseline",
@@ -574,7 +1539,7 @@
       "provenance": {
         "actor": "pf.projections.otop",
         "scope": "zenith/zenith-de",
-        "detail": "groups/zenith/projects/zenith-de/transform/recce_state.json"
+        "detail": "no baseline captured"
       }
     },
     {
@@ -583,7 +1548,7 @@
       "title": "A value-level diff writes the rows it compared into the review tool's state file, which is durable and shared. Diffing a column whose role is PII therefore p...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -596,7 +1561,7 @@
       "title": "review-artifacts-exclude-pii",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -609,7 +1574,194 @@
         "applies_to": {
           "artifact_glob": "**/transform/recce.yml"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-DET-1",
+          "AIR-PREV-12"
+        ],
+        "control_titles": {
+          "AIR-DET-1": "AI Data Leakage Prevention and Detection",
+          "AIR-PREV-12": "Role-Based Access Control for AI Data"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-3-2",
+              "title": "ISO 42001: AI roles and responsibilities",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-5-2",
+              "title": "ISO 42001: AI system impact assessment process",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-20",
+              "title": "AC-20 Use Of External Systems",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A232%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C598.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-13",
+              "title": "AU-13 Monitoring For Information Disclosure",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A310%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C556.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-3",
+              "title": "CA-3 Information Exchange",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A330%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C166.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-12",
+              "title": "CM-12 Information Location",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ia-2",
+              "title": "IA-2 Identification And Authentication (organizational Users)",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A467%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ia-4",
+              "title": "IA-4 Identifier Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A479%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C422.0%2C0%5D"
+            },
+            {
+              "key": "ia-5",
+              "title": "IA-5 Authenticator Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A485%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "ir-4",
+              "title": "IR-4 Incident Handling",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A527%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C626.0%2C0%5D"
+            },
+            {
+              "key": "ir-9",
+              "title": "IR-9 Information Spillage Response",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A548%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C135.0%2C0%5D"
+            },
+            {
+              "key": "mp-6",
+              "title": "MP-6 Media Sanitization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A593%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C314.0%2C0%5D"
+            },
+            {
+              "key": "sa-9",
+              "title": "SA-9 External System Services",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A884%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C665.0%2C0%5D"
+            },
+            {
+              "key": "sc-28",
+              "title": "SC-28 Protection Of Information AT Rest",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1019%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C191.0%2C0%5D"
+            },
+            {
+              "key": "sc-7",
+              "title": "SC-7 Boundary Protection",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A962%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C399.0%2C0%5D"
+            },
+            {
+              "key": "sc-8",
+              "title": "SC-8 Transmission Confidentiality And Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A983%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C223.0%2C0%5D"
+            },
+            {
+              "key": "si-20",
+              "title": "SI-20 Tainting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1151%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C232.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -618,8 +1770,8 @@
       "title": "pf tool recce config for review-artifacts-exclude-pii",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T20:38:47Z",
-        "observed_at": "2026-08-15T20:38:47Z",
+        "created_at": "2026-08-18T15:42:57Z",
+        "observed_at": "2026-08-18T15:42:57Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "derived_review_checks",
@@ -638,12 +1790,580 @@
       }
     },
     {
+      "id": "intent.pf.builds-record-observability",
+      "kind": "intent",
+      "title": "A dbt build that leaves no queryable record cannot be triaged; failures get diagnosed from whichever log happened to survive. Every build must record its run...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A dbt build that leaves no queryable record cannot be triaged; failures get diagnosed from whichever log happened to survive. Every build must record its run and test results into the warehouse with history \u2014 for every test framework at once \u2014 so \"is this new, recurring, or flaky?\" is a query, not an archaeology dig."
+      }
+    },
+    {
+      "id": "constraint.pf.builds-record-observability",
+      "kind": "constraint",
+      "title": "builds-record-observability",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "observability_recorded",
+      "checkability": "automated",
+      "assertion": "observability_recorded on artifact_glob=**/transform/packages.yml",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/transform/packages.yml"
+        },
+        "params": {},
+        "controls": [
+          "AIR-DET-4",
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-DET-4": "AI System Observability",
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t7-adoption",
+              "title": "Table 7: AI Adoption Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=57"
+            },
+            {
+              "key": "t7-nature",
+              "title": "Table 7: Nature and Use Cases of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            },
+            {
+              "key": "t7-performance",
+              "title": "Table 7: AI System Performance Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-8",
+              "title": "ISO 42001: AI system recording of event logs",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "au-11",
+              "title": "AU-11 Audit Record Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C462.0%2C0%5D"
+            },
+            {
+              "key": "au-12",
+              "title": "AU-12 Audit Record Generation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C122.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "ir-4",
+              "title": "IR-4 Incident Handling",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A527%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C626.0%2C0%5D"
+            },
+            {
+              "key": "ir-5",
+              "title": "IR-5 Incident Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A539%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C387%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-10",
+              "title": "RA-10 Threat Hunting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A812%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C110.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.builds-record-observability.pf-tool-elementary-report",
+      "kind": "evidence",
+      "title": "pf tool elementary report for builds-record-observability",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:04Z",
+        "observed_at": "2026-08-19T21:39:04Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "observability_report_over_recorded_history",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.builds-record-observability",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-de",
+        "detail": "pf tool elementary report not produced yet"
+      }
+    },
+    {
+      "id": "evidence.pf.builds-record-observability.loop-ledger-json",
+      "kind": "evidence",
+      "title": "loop-ledger.json for builds-record-observability",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T20:47:22Z",
+        "observed_at": "2026-08-19T20:47:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "run_history",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.builds-record-observability",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-de",
+        "detail": "loop-ledger.json"
+      }
+    },
+    {
+      "id": "intent.pf.quality-floor-derived-from-ontology",
+      "kind": "intent",
+      "title": "Hand-written test coverage decays to whichever models someone remembered. The floor \u2014 an annotated mart is never empty, a declared identity identifies \u2014 must...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Hand-written test coverage decays to whichever models someone remembered. The floor \u2014 an annotated mart is never empty, a declared identity identifies \u2014 must be derived from the ontology roles, so coverage is a function of annotation rather than of memory, and a wrong test is a wrong role rather than a stale file."
+      }
+    },
+    {
+      "id": "constraint.pf.quality-floor-derived-from-ontology",
+      "kind": "constraint",
+      "title": "quality-floor-derived-from-ontology",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "tests_derived_from_roles",
+      "checkability": "automated",
+      "assertion": "tests_derived_from_roles on artifact_glob=**/transform/tests/expectations/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/transform/tests/expectations/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-6",
+          "AIR-PREV-5"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity",
+          "AIR-PREV-5": "System Acceptance Testing"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            },
+            {
+              "key": "c3-s2-a15",
+              "title": "III.S2.A15: Accuracy, Robustness and Cybersecurity",
+              "url": "https://artificialintelligenceact.eu/article/15/"
+            },
+            {
+              "key": "c3-s2-a9",
+              "title": "III.S2.A9: Risk Management System",
+              "url": "https://artificialintelligenceact.eu/article/9/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-1",
+              "title": "Table 4.1: Assessment of Risk-Proportionate Controls",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=41"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-4",
+              "title": "ISO 42001: AI system verification and validation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-5",
+              "title": "ISO 42001: AI system deployment",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-2",
+              "title": "CA-2 Control Assessments",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A324%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C684%2C0%5D"
+            },
+            {
+              "key": "ca-6",
+              "title": "CA-6 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A339%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "cm-4",
+              "title": "CM-4 Impact Analyses",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A375%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C509.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-11",
+              "title": "SA-11 Developer Testing And Evaluation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A899%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C601.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-2",
+              "title": "SI-2 Flaw Remediation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1070%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-6",
+              "title": "SI-6 Security And Privacy Function Verification",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1103%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C475.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.quality-floor-derived-from-ontology.pf-tool-expectations-run",
+      "kind": "evidence",
+      "title": "pf tool expectations run for quality-floor-derived-from-ontology",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:04Z",
+        "observed_at": "2026-08-19T21:39:04Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "quality_floor_verdicts",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.quality-floor-derived-from-ontology",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-de",
+        "detail": "pf tool expectations run not produced yet"
+      }
+    },
+    {
       "id": "intent.pf.secrets-never-in-context",
       "kind": "intent",
       "title": "A credential placed in a prompt, a model file or a committed artefact is durably persisted and replayed into every later session.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -656,7 +2376,7 @@
       "title": "secrets-never-in-context",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -669,7 +2389,131 @@
         "applies_to": {
           "artifact_glob": "**/secrets.toml"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-PREV-23",
+          "AIR-DET-16"
+        ],
+        "control_titles": {
+          "AIR-PREV-23": "Agentic System Credential Protection Framework",
+          "AIR-DET-16": "Preserving Source Data Access Controls in AI Systems"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00113",
+              "title": "ATR-2026-00113 Credential Theft via Agent Channel",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/context-exfiltration/ATR-2026-00113-credential-theft.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-3",
+              "title": "ISO 42001: Acquisition of data",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-9-2",
+              "title": "ISO 42001: Processes for responsible use of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-21",
+              "title": "AC-21 Information Sharing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A238%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C521.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ca-8",
+              "title": "CA-8 Penetration Testing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A351%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ia-5",
+              "title": "IA-5 Authenticator Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A485%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "sc-28",
+              "title": "SC-28 Protection Of Information AT Rest",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1019%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C191.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -678,8 +2522,8 @@
       "title": "pf gate for secrets-never-in-context",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:47:31Z",
-        "observed_at": "2026-08-16T23:47:31Z",
+        "created_at": "2026-08-19T21:39:04Z",
+        "observed_at": "2026-08-19T21:39:04Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "path_verdict",
@@ -698,23 +2542,1498 @@
       }
     },
     {
+      "id": "intent.pf.agent-authority-is-least-privilege",
+      "kind": "intent",
+      "title": "An agent reaches the filesystem through one path gate, and the paths it may never write are declared rather than remembered. Least privilege that lives in a ...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "An agent reaches the filesystem through one path gate, and the paths it may never write are declared rather than remembered. Least privilege that lives in a prompt is a request; in a denylist it is a control."
+      }
+    },
+    {
+      "id": "constraint.pf.agent-authority-is-least-privilege",
+      "kind": "constraint",
+      "title": "agent-authority-is-least-privilege",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "path_denied",
+      "checkability": "automated",
+      "assertion": "path_denied on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-18"
+        ],
+        "control_titles": {
+          "AIR-PREV-18": "Agent Authority Least Privilege Framework"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00040",
+              "title": "ATR-2026-00040 Agent Privilege Escalation",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/privilege-escalation/ATR-2026-00040-privilege-escalation.yaml"
+            },
+            {
+              "key": "ATR-2026-00098",
+              "title": "ATR-2026-00098 Unauthorized Financial Action by Agent",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/excessive-autonomy/ATR-2026-00098-unauthorized-financial-action.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.agent-authority-is-least-privilege.pf-gate",
+      "kind": "evidence",
+      "title": "pf gate for agent-authority-is-least-privilege",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:05Z",
+        "observed_at": "2026-08-19T21:39:05Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "path_verdict",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.agent-authority-is-least-privilege",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-de",
+        "detail": "denylist present"
+      }
+    },
+    {
+      "id": "intent.pf.tool-contribution-may-only-tighten",
+      "kind": "intent",
+      "title": "A tool contributes gate rules, and a plugin system that can widen the policy judging it is not a policy. `Tool.gate_sections()` rejects a contribution to any...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A tool contributes gate rules, and a plugin system that can widen the policy judging it is not a policy. `Tool.gate_sections()` rejects a contribution to any loosening section at construction, so an unsafe tool fails at import rather than silently permitting more."
+      }
+    },
+    {
+      "id": "constraint.pf.tool-contribution-may-only-tighten",
+      "kind": "constraint",
+      "title": "tool-contribution-may-only-tighten",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "tightening_only",
+      "checkability": "automated",
+      "assertion": "tightening_only (sections=['denylist', 'platform_denylist', 'impact_required']) on artifact_glob=gate.capabilities.yaml",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "gate.capabilities.yaml"
+        },
+        "params": {
+          "sections": [
+            "denylist",
+            "platform_denylist",
+            "impact_required"
+          ]
+        },
+        "controls": [
+          "AIR-PREV-19"
+        ],
+        "control_titles": {
+          "AIR-PREV-19": "Tool Chain Validation and Sanitization"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00011",
+              "title": "ATR-2026-00011 Instruction Injection via Tool Output",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00011-tool-output-injection.yaml"
+            },
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00013",
+              "title": "ATR-2026-00013 Tool-Driven Server-Side Request Forgery",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00013-tool-ssrf.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "sc-4",
+              "title": "SC-4 Information In Shared System Resources",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A956%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-15",
+              "title": "SI-15 Information Output Filtering",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1136%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C355.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.tool-contribution-may-only-tighten.pf-check",
+      "kind": "evidence",
+      "title": "pf check for tool-contribution-may-only-tighten",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:05Z",
+        "observed_at": "2026-08-19T21:39:05Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "conformance_report",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.tool-contribution-may-only-tighten",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-de",
+        "detail": "0 error(s), 1 issue(s)"
+      }
+    },
+    {
+      "id": "intent.pf.agent-decisions-are-recorded",
+      "kind": "intent",
+      "title": "Every tool call an agent makes is written down before it happens and after it happens, and the gate's verdict is recorded for allows as well as denies. \"No r...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Every tool call an agent makes is written down before it happens and after it happens, and the gate's verdict is recorded for allows as well as denies. \"No rule applied\" and \"a rule allowed it\" are different facts, and only a record that carries both can answer what an agent was permitted to do."
+      }
+    },
+    {
+      "id": "constraint.pf.agent-decisions-are-recorded",
+      "kind": "constraint",
+      "title": "agent-decisions-are-recorded",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "action_recorded",
+      "checkability": "automated",
+      "assertion": "action_recorded (stages=['intent', 'decision', 'execution']) on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {
+          "stages": [
+            "intent",
+            "decision",
+            "execution"
+          ]
+        },
+        "controls": [
+          "AIR-DET-21",
+          "AIR-DET-4"
+        ],
+        "control_titles": {
+          "AIR-DET-21": "Agent Decision Audit and Explainability",
+          "AIR-DET-4": "AI System Observability"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a12",
+              "title": "III.S2.A12: Record-Keeping",
+              "url": "https://artificialintelligenceact.eu/article/12/"
+            },
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c3-s3-a26",
+              "title": "III.S3.A26: Obligations of Deployers of High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/26/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t7-adoption",
+              "title": "Table 7: AI Adoption Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=57"
+            },
+            {
+              "key": "t7-nature",
+              "title": "Table 7: Nature and Use Cases of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            },
+            {
+              "key": "t7-performance",
+              "title": "Table 7: AI System Performance Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-8",
+              "title": "ISO 42001: AI system recording of event logs",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-11",
+              "title": "AU-11 Audit Record Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C462.0%2C0%5D"
+            },
+            {
+              "key": "au-12",
+              "title": "AU-12 Audit Record Generation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C122.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ir-4",
+              "title": "IR-4 Incident Handling",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A527%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C626.0%2C0%5D"
+            },
+            {
+              "key": "ir-5",
+              "title": "IR-5 Incident Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A539%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C387%2C0%5D"
+            },
+            {
+              "key": "ra-10",
+              "title": "RA-10 Threat Hunting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A812%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C110.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.agent-decisions-are-recorded.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for agent-decisions-are-recorded",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:06Z",
+        "observed_at": "2026-08-19T21:39:06Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.agent-decisions-are-recorded",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-de",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.evidence-chain-is-tamper-evident",
+      "kind": "intent",
+      "title": "A log an agent can edit is not evidence. Each record carries the hash of the one before it, and the head is anchored to a timestamp authority with no stake i...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A log an agent can edit is not evidence. Each record carries the hash of the one before it, and the head is anchored to a timestamp authority with no stake in what it says \u2014 so editing the middle requires editing the end, and the end is countersigned."
+      }
+    },
+    {
+      "id": "constraint.pf.evidence-chain-is-tamper-evident",
+      "kind": "constraint",
+      "title": "evidence-chain-is-tamper-evident",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "hash_chained",
+      "checkability": "automated",
+      "assertion": "hash_chained on artifact_glob=provenance/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "provenance/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-DET-21"
+        ],
+        "control_titles": {
+          "AIR-DET-21": "Agent Decision Audit and Explainability"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a12",
+              "title": "III.S2.A12: Record-Keeping",
+              "url": "https://artificialintelligenceact.eu/article/12/"
+            },
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c3-s3-a26",
+              "title": "III.S3.A26: Obligations of Deployers of High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/26/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.evidence-chain-is-tamper-evident.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for evidence-chain-is-tamper-evident",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:06Z",
+        "observed_at": "2026-08-19T21:39:06Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.evidence-chain-is-tamper-evident",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-de",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.sister-projects-are-isolated",
+      "kind": "intent",
+      "title": "Business logic does not transfer between entities, so an assumption carried from one sister company into another is a bug by construction. A project session ...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Business logic does not transfer between entities, so an assumption carried from one sister company into another is a bug by construction. A project session may not read or write another project, and may not write shared infra at all."
+      }
+    },
+    {
+      "id": "constraint.pf.sister-projects-are-isolated",
+      "kind": "constraint",
+      "title": "sister-projects-are-isolated",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "cross_tenant_denied",
+      "checkability": "automated",
+      "assertion": "cross_tenant_denied on artifact_glob=groups/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "groups/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-22"
+        ],
+        "control_titles": {
+          "AIR-PREV-22": "Multi-Agent Isolation and Segmentation"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00030",
+              "title": "ATR-2026-00030 Cross-Agent Attack Detection",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/agent-manipulation/ATR-2026-00030-cross-agent-attack.yaml"
+            },
+            {
+              "key": "ATR-2026-00076",
+              "title": "ATR-2026-00076 Insecure Inter-Agent Communication",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/agent-manipulation/ATR-2026-00076-inter-agent-message-spoofing.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "sc-3",
+              "title": "SC-3 Security Function Isolation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A950%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C217.0%2C0%5D"
+            },
+            {
+              "key": "sc-32",
+              "title": "SC-32 System Partitioning",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1031%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C227.0%2C0%5D"
+            },
+            {
+              "key": "sc-7",
+              "title": "SC-7 Boundary Protection",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A962%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C399.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.sister-projects-are-isolated.pf-gate",
+      "kind": "evidence",
+      "title": "pf gate for sister-projects-are-isolated",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:06Z",
+        "observed_at": "2026-08-19T21:39:06Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "path_verdict",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.sister-projects-are-isolated",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-de",
+        "detail": "denylist present"
+      }
+    },
+    {
+      "id": "intent.pf.agent-authority-is-revocable",
+      "kind": "intent",
+      "title": "A control that cannot be switched off mid-incident is a control you find out about afterwards. Revocation is checked before intent is written, and an unreada...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A control that cannot be switched off mid-incident is a control you find out about afterwards. Revocation is checked before intent is written, and an unreadable revocation file fails closed."
+      }
+    },
+    {
+      "id": "constraint.pf.agent-authority-is-revocable",
+      "kind": "constraint",
+      "title": "agent-authority-is-revocable",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "revocable",
+      "checkability": "automated",
+      "assertion": "revocable on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-18"
+        ],
+        "control_titles": {
+          "AIR-PREV-18": "Agent Authority Least Privilege Framework"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00040",
+              "title": "ATR-2026-00040 Agent Privilege Escalation",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/privilege-escalation/ATR-2026-00040-privilege-escalation.yaml"
+            },
+            {
+              "key": "ATR-2026-00098",
+              "title": "ATR-2026-00098 Unauthorized Financial Action by Agent",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/excessive-autonomy/ATR-2026-00098-unauthorized-financial-action.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.agent-authority-is-revocable.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for agent-authority-is-revocable",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:07Z",
+        "observed_at": "2026-08-19T21:39:07Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.agent-authority-is-revocable",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-de",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.high-impact-actions-need-a-human",
+      "kind": "intent",
+      "title": "Human oversight is a chain that shows the approval, not a document that asserts it. Approvals are append-only and bound to the action they approve, and an ac...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Human oversight is a chain that shows the approval, not a document that asserts it. Approvals are append-only and bound to the action they approve, and an actor approving their own action is a finding rather than an approval."
+      }
+    },
+    {
+      "id": "constraint.pf.high-impact-actions-need-a-human",
+      "kind": "constraint",
+      "title": "high-impact-actions-need-a-human",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "approval_recorded",
+      "checkability": "automated",
+      "assertion": "approval_recorded on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-DET-11"
+        ],
+        "control_titles": {
+          "AIR-DET-11": "Human Feedback Loop for AI Systems"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a14",
+              "title": "III.S2.A14: Human Oversight",
+              "url": "https://artificialintelligenceact.eu/article/14/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-3-3",
+              "title": "ISO 42001: Reporting of concerns",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-2",
+              "title": "ISO 42001: System documentation and information for users",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ca-2",
+              "title": "CA-2 Control Assessments",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A324%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C684%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ir-6",
+              "title": "IR-6 Incident Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A542%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "pm-26",
+              "title": "PM-26 Complaint Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A722%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C365.0%2C0%5D"
+            },
+            {
+              "key": "ra-5",
+              "title": "RA-5 Vulnerability Monitoring And Scanning",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A797%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C594.0%2C0%5D"
+            },
+            {
+              "key": "si-2",
+              "title": "SI-2 Flaw Remediation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1070%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.high-impact-actions-need-a-human.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for high-impact-actions-need-a-human",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:07Z",
+        "observed_at": "2026-08-19T21:39:07Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.high-impact-actions-need-a-human",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-de",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.model-routing-is-declared",
+      "kind": "intent",
+      "title": "Which model answers which step is a declared table, not whatever the caller passed. An unregistered step is recorded as such, and the recorded verdict matche...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Which model answers which step is a declared table, not whatever the caller passed. An unregistered step is recorded as such, and the recorded verdict matches what actually happened rather than what policy would have preferred."
+      }
+    },
+    {
+      "id": "constraint.pf.model-routing-is-declared",
+      "kind": "constraint",
+      "title": "model-routing-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "routing_declared",
+      "checkability": "automated",
+      "assertion": "routing_declared on artifact_glob=**/agents/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/agents/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-10"
+        ],
+        "control_titles": {
+          "AIR-PREV-10": "AI Model Version Pinning"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-4",
+              "title": "ISO 42001: Tooling resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-3",
+              "title": "ISO 42001: Documentation of AI system design and development",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-5",
+              "title": "ISO 42001: AI system deployment",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "cm-2",
+              "title": "CM-2 Baseline Configuration",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A363%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "cm-3",
+              "title": "CM-3 Configuration Change Control",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A366%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C205.0%2C0%5D"
+            },
+            {
+              "key": "cm-4",
+              "title": "CM-4 Impact Analyses",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A375%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C509.0%2C0%5D"
+            },
+            {
+              "key": "cm-8",
+              "title": "CM-8 System Component Inventory",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A393%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C197.0%2C0%5D"
+            },
+            {
+              "key": "sa-10",
+              "title": "SA-10 Developer Configuration Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A890%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C211.0%2C0%5D"
+            },
+            {
+              "key": "sa-22",
+              "title": "SA-22 Unsupported System Components",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A941%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C497.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sr-4",
+              "title": "SR-4 Provenance",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1169%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C257.0%2C0%5D"
+            },
+            {
+              "key": "sr-8",
+              "title": "SR-8 Notification Agreements",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1184%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C620.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.model-routing-is-declared.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for model-routing-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:08Z",
+        "observed_at": "2026-08-19T21:39:08Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.model-routing-is-declared",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-de",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.upstream-licences-are-reviewed",
+      "kind": "intent",
+      "title": "Every upstream this platform borrowed from carries a licence, and some of them constrain what we may ship. The review is written down per upstream and surfac...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Every upstream this platform borrowed from carries a licence, and some of them constrain what we may ship. The review is written down per upstream and surfaced in the listing, so a constraint is a fact in the registry rather than something someone once checked."
+      }
+    },
+    {
+      "id": "constraint.pf.upstream-licences-are-reviewed",
+      "kind": "constraint",
+      "title": "upstream-licences-are-reviewed",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "licence_reviewed",
+      "checkability": "automated",
+      "assertion": "licence_reviewed on artifact_glob=vendor/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "vendor/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-7"
+        ],
+        "control_titles": {
+          "AIR-PREV-7": "Legal and Contractual Frameworks for AI Systems"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t4-1",
+              "title": "Table 4.1: Assessment of Risk-Proportionate Controls",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=41"
+            },
+            {
+              "key": "t4-7",
+              "title": "Table 4.7: Legal Framework and Accountability",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=44"
+            },
+            {
+              "key": "t7-third-party",
+              "title": "Table 7: Third-Party Dependencies and Concentrations",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-10-2",
+              "title": "ISO 42001: Allocating responsibilities",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-10-3",
+              "title": "ISO 42001: Suppliers",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-2-3",
+              "title": "ISO 42001: Alignment with other organizational policies",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-5",
+              "title": "ISO 42001: Information for interested parties",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-20",
+              "title": "AC-20 Use Of External Systems",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A232%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C598.0%2C0%5D"
+            },
+            {
+              "key": "ca-3",
+              "title": "CA-3 Information Exchange",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A330%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C166.0%2C0%5D"
+            },
+            {
+              "key": "ir-6",
+              "title": "IR-6 Incident Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A542%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "pm-30",
+              "title": "PM-30 Supply Chain Risk Management Strategy",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A728%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C427.0%2C0%5D"
+            },
+            {
+              "key": "ps-7",
+              "title": "PS-7 External Personnel Security",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A752%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C623.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-9",
+              "title": "SA-9 External System Services",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A884%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C665.0%2C0%5D"
+            },
+            {
+              "key": "sr-2",
+              "title": "SR-2 Supply Chain Risk Management Plan",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1163%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C684.0%2C0%5D"
+            },
+            {
+              "key": "sr-3",
+              "title": "SR-3 Supply Chain Controls And Processes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1166%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C440.0%2C0%5D"
+            },
+            {
+              "key": "sr-5",
+              "title": "SR-5 Acquisition Strategies, Tools, And Methods",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1175%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C243.0%2C0%5D"
+            },
+            {
+              "key": "sr-8",
+              "title": "SR-8 Notification Agreements",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1184%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C620.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.upstream-licences-are-reviewed.pf-check",
+      "kind": "evidence",
+      "title": "pf check for upstream-licences-are-reviewed",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:08Z",
+        "observed_at": "2026-08-19T21:39:08Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "conformance_report",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.upstream-licences-are-reviewed",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-de",
+        "detail": "0 error(s), 1 issue(s)"
+      }
+    },
+    {
+      "id": "intent.pf.control-baseline-is-declared",
+      "kind": "intent",
+      "title": "A risk register that names controls nobody enforces is a document. Each entity declares in `air.yaml` which controls it commits to; those are derived from th...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A risk register that names controls nobody enforces is a document. Each entity declares in `air.yaml` which controls it commits to; those are derived from the repository on every run and block the merge when they fail, while everything outside the baseline is reported and does not."
+      }
+    },
+    {
+      "id": "constraint.pf.control-baseline-is-declared",
+      "kind": "constraint",
+      "title": "control-baseline-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "baseline_declared",
+      "checkability": "automated",
+      "assertion": "baseline_declared on artifact_glob=**/air.yaml",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/air.yaml"
+        },
+        "params": {}
+      }
+    },
+    {
+      "id": "evidence.pf.control-baseline-is-declared.pf-air-coverage",
+      "kind": "evidence",
+      "title": "pf air coverage for control-baseline-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:08Z",
+        "observed_at": "2026-08-19T21:39:08Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "control_coverage_verdicts",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.control-baseline-is-declared",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-de",
+        "detail": "pf air coverage not produced yet"
+      }
+    },
+    {
+      "id": "evidence.pf.control-baseline-is-declared.governance-air-register-md",
+      "kind": "evidence",
+      "title": "governance/air-register.md for control-baseline-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:20Z",
+        "observed_at": "2026-08-19T18:05:20Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "per-entity_risk_register",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.control-baseline-is-declared",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-de",
+        "detail": "groups/zenith/projects/zenith-de/governance/air-register.md"
+      }
+    },
+    {
       "id": "artifact.pf.pf.ontology.validate.money-without-currency",
       "kind": "artifact",
       "title": "pf.ontology.validate:money-without-currency",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "money-without-currency",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -726,18 +4045,18 @@
       "title": "pf.ontology.validate:class-without-identity",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "class-without-identity",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -749,18 +4068,18 @@
       "title": "pf.ontology.validate:illegal-edge",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "illegal-edge",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -772,18 +4091,18 @@
       "title": "pf.loops.registry:pii_audit",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T02:49:37Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "loop",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/loops/registry.py",
         "language": "python",
         "symbol": "pii_audit",
-        "digest": "git:293a23d6448c5fe70cee7c96a01f2690d8af47c2"
+        "digest": "git:e81ff725c18b4ff2a8187f5fb953a9dc003a56f4"
       },
       "extensions": {
         "exists": true
@@ -795,18 +4114,18 @@
       "title": "pf.kg.build:model-grain",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T02:04:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/kg/build.py",
         "language": "python",
         "symbol": "model-grain",
-        "digest": "git:2c8398b8a1246d27395ac2140ceba10eea0d3072"
+        "digest": "git:db169407ccb59827ce7f3c5932b2b4a0d40e1124"
       },
       "extensions": {
         "exists": true
@@ -818,18 +4137,18 @@
       "title": "pf.ontology.validate:metric-shaped-column",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "metric-shaped-column",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -841,17 +4160,17 @@
       "title": "platform/hooks/pre_tool_use.py",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T00:11:17Z",
+        "created_at": "2026-08-18T18:40:22Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "hook",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/hooks/pre_tool_use.py",
         "language": "python",
-        "digest": "git:2cb586ed58222bcb50e9cd0013d536cb2c9e6856"
+        "digest": "git:230bc9d9639eaa71c8c511affccb14881cdfc1f1"
       },
       "extensions": {
         "exists": true
@@ -863,14 +4182,14 @@
       "title": "platform/hooks/pre_commit.sh",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-12T16:06:37Z",
+        "created_at": "2026-08-12T14:06:37Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "hook",
       "language": "bash",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/hooks/pre_commit.sh",
         "language": "bash",
         "digest": "git:ce8e6f322ce15a546c16d2eb25bddf4fab5b6688"
@@ -885,18 +4204,18 @@
       "title": "pf.tools.recce:dagster_assets",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:50:23Z",
+        "created_at": "2026-08-17T23:50:05Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/tools/recce.py",
         "language": "python",
         "symbol": "dagster_assets",
-        "digest": "git:8a560994bb5a994b5a57b37a07f99114656b18a3"
+        "digest": "git:6d6c7a4515c5aa68b9642ca221805c28a15f4fc1"
       },
       "extensions": {
         "exists": true
@@ -908,18 +4227,18 @@
       "title": "pf.tools.recce:register_commands",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:50:23Z",
+        "created_at": "2026-08-17T23:50:05Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/tools/recce.py",
         "language": "python",
         "symbol": "register_commands",
-        "digest": "git:8a560994bb5a994b5a57b37a07f99114656b18a3"
+        "digest": "git:6d6c7a4515c5aa68b9642ca221805c28a15f4fc1"
       },
       "extensions": {
         "exists": true
@@ -931,18 +4250,18 @@
       "title": "pf.ontology.model:Role.review_intent",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T22:35:09Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/model.py",
         "language": "python",
         "symbol": "Role.review_intent",
-        "digest": "git:3e691a864da03459b04489a674bbba0a1839b1ea"
+        "digest": "git:513888ee8c2df8cfa1d09562ad3dc2793c4f741e"
       },
       "extensions": {
         "exists": true
@@ -954,18 +4273,106 @@
       "title": "pf.tools.recce:generate_config",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:50:23Z",
+        "created_at": "2026-08-17T23:50:05Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/tools/recce.py",
         "language": "python",
         "symbol": "generate_config",
-        "digest": "git:8a560994bb5a994b5a57b37a07f99114656b18a3"
+        "digest": "git:6d6c7a4515c5aa68b9642ca221805c28a15f4fc1"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.elementary.bootstrap-project",
+      "kind": "artifact",
+      "title": "pf.tools.elementary:bootstrap_project",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:04Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/elementary.py",
+        "language": "python",
+        "symbol": "bootstrap_project"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.elementary.ensure-package",
+      "kind": "artifact",
+      "title": "pf.tools.elementary:ensure_package",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:04Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/elementary.py",
+        "language": "python",
+        "symbol": "ensure_package"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.expectations.write-tests",
+      "kind": "artifact",
+      "title": "pf.tools.expectations:write_tests",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:04Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/expectations.py",
+        "language": "python",
+        "symbol": "write_tests"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.expectations.bootstrap-project",
+      "kind": "artifact",
+      "title": "pf.tools.expectations:bootstrap_project",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:04Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/expectations.py",
+        "language": "python",
+        "symbol": "bootstrap_project"
       },
       "extensions": {
         "exists": true
@@ -977,18 +4384,408 @@
       "title": "gate.yaml:denylist",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-17T00:38:30Z",
+        "created_at": "2026-08-18T18:40:22Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "configuration",
       "language": "yaml",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "gate.yaml",
         "language": "yaml",
         "symbol": "denylist",
-        "digest": "git:f0f6dc9c2d8e60c371d7df8c8a9af65e9571c965"
+        "digest": "git:7d51894f5fdae49fa67534d8359ac34a48175bc8"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.gate.yaml.platform-denylist",
+      "kind": "artifact",
+      "title": "gate.yaml:platform_denylist",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "configuration",
+      "language": "yaml",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "gate.yaml",
+        "language": "yaml",
+        "symbol": "platform_denylist",
+        "digest": "git:7d51894f5fdae49fa67534d8359ac34a48175bc8"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.loops.gate.check-path",
+      "kind": "artifact",
+      "title": "pf.loops.gate:check_path",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-15T05:28:10Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "loop",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/loops/gate.py",
+        "language": "python",
+        "symbol": "check_path",
+        "digest": "git:0e0d5d990b04901c47b39e09bf783eb4a8821183"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.spec.Tool.gate-sections",
+      "kind": "artifact",
+      "title": "pf.tools.spec:Tool.gate_sections",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-17T23:50:05Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/spec.py",
+        "language": "python",
+        "symbol": "Tool.gate_sections",
+        "digest": "git:3b36976709eb70b17628d2c2228e4e398ed2df05"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.decision",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:decision",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "decision",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.platform.hooks.post-tool-use.py",
+      "kind": "artifact",
+      "title": "platform/hooks/post_tool_use.py",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "hook",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/hooks/post_tool_use.py",
+        "language": "python",
+        "digest": "git:99dc8363fbb485907c66034f6c6fefdc51336650"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.chain.verify",
+      "kind": "artifact",
+      "title": "pf.provenance.chain:verify",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/chain.py",
+        "language": "python",
+        "symbol": "verify",
+        "digest": "git:07d2c60e49bda58cd6b9d51534b3417cec91777c"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.anchor.stamp-rfc3161",
+      "kind": "artifact",
+      "title": "pf.provenance.anchor:stamp_rfc3161",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/anchor.py",
+        "language": "python",
+        "symbol": "stamp_rfc3161",
+        "digest": "git:a38a0c14b0286745dbe157807967085d044af606"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.loops.gate.project-for",
+      "kind": "artifact",
+      "title": "pf.loops.gate:project_for",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-15T05:28:10Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "loop",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/loops/gate.py",
+        "language": "python",
+        "symbol": "project_for",
+        "digest": "git:0e0d5d990b04901c47b39e09bf783eb4a8821183"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.revoke",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:revoke",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "revoke",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.is-revoked",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:is_revoked",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "is_revoked",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.approve",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:approve",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "approve",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.audit.report",
+      "kind": "artifact",
+      "title": "pf.provenance.audit:report",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/audit.py",
+        "language": "python",
+        "symbol": "report",
+        "digest": "git:048a4041043b8b6d2628b0f97929752c079fb95e"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.agents.base.AGENTS",
+      "kind": "artifact",
+      "title": "pf.agents.base:AGENTS",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/agents/base.py",
+        "language": "python",
+        "symbol": "AGENTS",
+        "digest": "git:21365423e93b1c6427aa7dbf6dbb2823993e42c2"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.vendor.model.load-registry",
+      "kind": "artifact",
+      "title": "pf.vendor.model:load_registry",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-13T01:11:58Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/vendor/model.py",
+        "language": "python",
+        "symbol": "load_registry",
+        "digest": "git:3364fcfb711181efa434a9fe7024e4dcc01984df"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.vendor.verify.verify",
+      "kind": "artifact",
+      "title": "pf.vendor.verify:verify",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/vendor/verify.py",
+        "language": "python",
+        "symbol": "verify",
+        "digest": "git:4b39f17a26d3f030c4f2ef101c60a502c2f9ccfb"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.air.coverage.assess",
+      "kind": "artifact",
+      "title": "pf.air.coverage:assess",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/air/coverage.py",
+        "language": "python",
+        "symbol": "assess",
+        "digest": "git:fd67a5e7eeec7fdfe079c96e066992764601c00f"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.air.register.render-register",
+      "kind": "artifact",
+      "title": "pf.air.register:render_register",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/air/register.py",
+        "language": "python",
+        "symbol": "render_register",
+        "digest": "git:c45d0bbbe459fadea3ab3edfbf96beb6db505f25"
       },
       "extensions": {
         "exists": true
@@ -1002,7 +4799,7 @@
       "to": "intent.pf.money-requires-currency",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1013,7 +4810,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1022,8 +4819,8 @@
       "to": "artifact.pf.pf.ontology.validate.money-without-currency",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1032,8 +4829,8 @@
       "to": "evidence.pf.money-requires-currency.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:47:29Z",
-        "verified_at": "2026-08-16T23:47:29Z"
+        "created_at": "2026-08-19T21:39:00Z",
+        "verified_at": "2026-08-19T21:39:00Z"
       }
     },
     {
@@ -1042,7 +4839,7 @@
       "to": "intent.pf.entity-requires-identity",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1053,7 +4850,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1062,8 +4859,8 @@
       "to": "artifact.pf.pf.ontology.validate.class-without-identity",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1072,8 +4869,8 @@
       "to": "evidence.pf.entity-requires-identity.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:47:30Z",
-        "verified_at": "2026-08-16T23:47:30Z"
+        "created_at": "2026-08-19T21:39:00Z",
+        "verified_at": "2026-08-19T21:39:00Z"
       }
     },
     {
@@ -1082,7 +4879,7 @@
       "to": "intent.pf.link-must-be-in-topology",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1093,7 +4890,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1102,8 +4899,8 @@
       "to": "artifact.pf.pf.ontology.validate.illegal-edge",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1112,8 +4909,8 @@
       "to": "evidence.pf.link-must-be-in-topology.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:47:30Z",
-        "verified_at": "2026-08-16T23:47:30Z"
+        "created_at": "2026-08-19T21:39:01Z",
+        "verified_at": "2026-08-19T21:39:01Z"
       }
     },
     {
@@ -1122,7 +4919,7 @@
       "to": "intent.pf.pii-not-in-consumption",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1133,7 +4930,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1142,8 +4939,8 @@
       "to": "artifact.pf.pf.loops.registry.pii-audit",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1152,8 +4949,8 @@
       "to": "evidence.pf.pii-not-in-consumption.pf-loop-run-pii-audit",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:47:30Z",
-        "verified_at": "2026-08-16T23:47:30Z"
+        "created_at": "2026-08-19T21:39:01Z",
+        "verified_at": "2026-08-19T21:39:01Z"
       }
     },
     {
@@ -1162,8 +4959,8 @@
       "to": "evidence.pf.pii-not-in-consumption.state-md",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "verified_at": "2026-08-15T20:35:53Z"
+        "created_at": "2026-08-18T15:42:57Z",
+        "verified_at": "2026-08-18T15:42:57Z"
       }
     },
     {
@@ -1172,7 +4969,7 @@
       "to": "intent.pf.mart-declares-grain",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1183,7 +4980,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1192,8 +4989,8 @@
       "to": "artifact.pf.pf.kg.build.model-grain",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1202,8 +4999,8 @@
       "to": "evidence.pf.mart-declares-grain.kg-context-card-md",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:47:29Z",
-        "verified_at": "2026-08-16T23:47:29Z"
+        "created_at": "2026-08-19T21:39:00Z",
+        "verified_at": "2026-08-19T21:39:00Z"
       }
     },
     {
@@ -1212,7 +5009,7 @@
       "to": "intent.pf.metric-owns-aggregation",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1223,7 +5020,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1232,8 +5029,8 @@
       "to": "artifact.pf.pf.ontology.validate.metric-shaped-column",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1242,8 +5039,8 @@
       "to": "evidence.pf.metric-owns-aggregation.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:47:30Z",
-        "verified_at": "2026-08-16T23:47:30Z"
+        "created_at": "2026-08-19T21:39:02Z",
+        "verified_at": "2026-08-19T21:39:02Z"
       }
     },
     {
@@ -1252,7 +5049,7 @@
       "to": "intent.pf.change-declares-blast-radius",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1263,7 +5060,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1272,8 +5069,8 @@
       "to": "artifact.pf.platform.hooks.pre-tool-use.py",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1282,8 +5079,8 @@
       "to": "artifact.pf.platform.hooks.pre-commit.sh",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1292,8 +5089,8 @@
       "to": "evidence.pf.change-declares-blast-radius.impact-reports",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:47:30Z",
-        "verified_at": "2026-08-16T23:47:30Z"
+        "created_at": "2026-08-19T21:39:02Z",
+        "verified_at": "2026-08-19T21:39:02Z"
       }
     },
     {
@@ -1302,8 +5099,8 @@
       "to": "evidence.pf.change-declares-blast-radius.loop-ledger-json",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "verified_at": "2026-08-15T20:35:53Z"
+        "created_at": "2026-08-19T20:47:22Z",
+        "verified_at": "2026-08-19T20:47:22Z"
       }
     },
     {
@@ -1312,7 +5109,7 @@
       "to": "intent.pf.change-verified-against-baseline",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1323,7 +5120,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1332,8 +5129,8 @@
       "to": "artifact.pf.pf.tools.recce.dagster-assets",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1342,8 +5139,8 @@
       "to": "artifact.pf.pf.tools.recce.register-commands",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1352,8 +5149,8 @@
       "to": "evidence.pf.change-verified-against-baseline.pf-tool-recce-run",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T22:57:34Z",
-        "verified_at": "2026-08-16T22:57:34Z"
+        "created_at": "2026-08-19T21:39:03Z",
+        "verified_at": "2026-08-19T21:39:03Z"
       }
     },
     {
@@ -1362,7 +5159,7 @@
       "to": "intent.pf.review-artifacts-exclude-pii",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1373,7 +5170,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1382,8 +5179,8 @@
       "to": "artifact.pf.pf.ontology.model.Role.review-intent",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1392,8 +5189,8 @@
       "to": "artifact.pf.pf.tools.recce.generate-config",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1402,8 +5199,118 @@
       "to": "evidence.pf.review-artifacts-exclude-pii.pf-tool-recce-config",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-15T20:38:47Z",
-        "verified_at": "2026-08-15T20:38:47Z"
+        "created_at": "2026-08-18T15:42:57Z",
+        "verified_at": "2026-08-18T15:42:57Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.derived-from.intent.pf.builds-record-observability",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "intent.pf.builds-record-observability",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.implemented-by.artifact.pf.pf.tools.elementary.bootstrap-project",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "artifact.pf.pf.tools.elementary.bootstrap-project",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.implemented-by.artifact.pf.pf.tools.elementary.ensure-package",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "artifact.pf.pf.tools.elementary.ensure-package",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.verified-by.evidence.pf.builds-record-observability.pf-tool-elementary-report",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "evidence.pf.builds-record-observability.pf-tool-elementary-report",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:04Z",
+        "verified_at": "2026-08-19T21:39:04Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.verified-by.evidence.pf.builds-record-observability.loop-ledger-json",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "evidence.pf.builds-record-observability.loop-ledger-json",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T20:47:22Z",
+        "verified_at": "2026-08-19T20:47:22Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.derived-from.intent.pf.quality-floor-derived-from-ontology",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "intent.pf.quality-floor-derived-from-ontology",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.implemented-by.artifact.pf.pf.tools.expectations.write-tests",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "artifact.pf.pf.tools.expectations.write-tests",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.implemented-by.artifact.pf.pf.tools.expectations.bootstrap-project",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "artifact.pf.pf.tools.expectations.bootstrap-project",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.verified-by.evidence.pf.quality-floor-derived-from-ontology.pf-tool-expectations-run",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "evidence.pf.quality-floor-derived-from-ontology.pf-tool-expectations-run",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:04Z",
+        "verified_at": "2026-08-19T21:39:04Z"
       }
     },
     {
@@ -1412,7 +5319,7 @@
       "to": "intent.pf.secrets-never-in-context",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1423,7 +5330,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1432,8 +5339,8 @@
       "to": "artifact.pf.gate.yaml.denylist",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1442,8 +5349,8 @@
       "to": "artifact.pf.platform.hooks.pre-tool-use.py",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1452,8 +5359,528 @@
       "to": "evidence.pf.secrets-never-in-context.pf-gate",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:47:31Z",
-        "verified_at": "2026-08-16T23:47:31Z"
+        "created_at": "2026-08-19T21:39:04Z",
+        "verified_at": "2026-08-19T21:39:04Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.derived-from.intent.pf.agent-authority-is-least-privilege",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "intent.pf.agent-authority-is-least-privilege",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.implemented-by.artifact.pf.gate.yaml.denylist",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "artifact.pf.gate.yaml.denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.implemented-by.artifact.pf.gate.yaml.platform-denylist",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "artifact.pf.gate.yaml.platform-denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.implemented-by.artifact.pf.pf.loops.gate.check-path",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "artifact.pf.pf.loops.gate.check-path",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.verified-by.evidence.pf.agent-authority-is-least-privilege.pf-gate",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "evidence.pf.agent-authority-is-least-privilege.pf-gate",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:05Z",
+        "verified_at": "2026-08-19T21:39:05Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.derived-from.intent.pf.tool-contribution-may-only-tighten",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "intent.pf.tool-contribution-may-only-tighten",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.implemented-by.artifact.pf.pf.tools.spec.Tool.gate-sections",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "artifact.pf.pf.tools.spec.Tool.gate-sections",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.verified-by.evidence.pf.tool-contribution-may-only-tighten.pf-check",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "evidence.pf.tool-contribution-may-only-tighten.pf-check",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:05Z",
+        "verified_at": "2026-08-19T21:39:05Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.derived-from.intent.pf.agent-decisions-are-recorded",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "intent.pf.agent-decisions-are-recorded",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.implemented-by.artifact.pf.pf.provenance.ledger.decision",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "artifact.pf.pf.provenance.ledger.decision",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.implemented-by.artifact.pf.platform.hooks.pre-tool-use.py",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "artifact.pf.platform.hooks.pre-tool-use.py",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.implemented-by.artifact.pf.platform.hooks.post-tool-use.py",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "artifact.pf.platform.hooks.post-tool-use.py",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.verified-by.evidence.pf.agent-decisions-are-recorded.pf-provenance-verify",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "evidence.pf.agent-decisions-are-recorded.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:06Z",
+        "verified_at": "2026-08-19T21:39:06Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.derived-from.intent.pf.evidence-chain-is-tamper-evident",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "intent.pf.evidence-chain-is-tamper-evident",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.implemented-by.artifact.pf.pf.provenance.chain.verify",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "artifact.pf.pf.provenance.chain.verify",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.implemented-by.artifact.pf.pf.provenance.anchor.stamp-rfc3161",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "artifact.pf.pf.provenance.anchor.stamp-rfc3161",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.implemented-by.artifact.pf.gate.yaml.denylist",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "artifact.pf.gate.yaml.denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.verified-by.evidence.pf.evidence-chain-is-tamper-evident.pf-provenance-verify",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "evidence.pf.evidence-chain-is-tamper-evident.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:06Z",
+        "verified_at": "2026-08-19T21:39:06Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.derived-from.intent.pf.sister-projects-are-isolated",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "intent.pf.sister-projects-are-isolated",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.implemented-by.artifact.pf.gate.yaml.platform-denylist",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "artifact.pf.gate.yaml.platform-denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.implemented-by.artifact.pf.pf.loops.gate.project-for",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "artifact.pf.pf.loops.gate.project-for",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.verified-by.evidence.pf.sister-projects-are-isolated.pf-gate",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "evidence.pf.sister-projects-are-isolated.pf-gate",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:06Z",
+        "verified_at": "2026-08-19T21:39:06Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.derived-from.intent.pf.agent-authority-is-revocable",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "intent.pf.agent-authority-is-revocable",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.implemented-by.artifact.pf.pf.provenance.ledger.revoke",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "artifact.pf.pf.provenance.ledger.revoke",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.implemented-by.artifact.pf.pf.provenance.ledger.is-revoked",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "artifact.pf.pf.provenance.ledger.is-revoked",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.verified-by.evidence.pf.agent-authority-is-revocable.pf-provenance-verify",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "evidence.pf.agent-authority-is-revocable.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:07Z",
+        "verified_at": "2026-08-19T21:39:07Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.derived-from.intent.pf.high-impact-actions-need-a-human",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "intent.pf.high-impact-actions-need-a-human",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.implemented-by.artifact.pf.pf.provenance.ledger.approve",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "artifact.pf.pf.provenance.ledger.approve",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.implemented-by.artifact.pf.pf.provenance.audit.report",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "artifact.pf.pf.provenance.audit.report",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.verified-by.evidence.pf.high-impact-actions-need-a-human.pf-provenance-verify",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "evidence.pf.high-impact-actions-need-a-human.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:07Z",
+        "verified_at": "2026-08-19T21:39:07Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.derived-from.intent.pf.model-routing-is-declared",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "intent.pf.model-routing-is-declared",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.implemented-by.artifact.pf.pf.agents.base.AGENTS",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "artifact.pf.pf.agents.base.AGENTS",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.verified-by.evidence.pf.model-routing-is-declared.pf-provenance-verify",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "evidence.pf.model-routing-is-declared.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:08Z",
+        "verified_at": "2026-08-19T21:39:08Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.derived-from.intent.pf.upstream-licences-are-reviewed",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "intent.pf.upstream-licences-are-reviewed",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.implemented-by.artifact.pf.pf.vendor.model.load-registry",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "artifact.pf.pf.vendor.model.load-registry",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.implemented-by.artifact.pf.pf.vendor.verify.verify",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "artifact.pf.pf.vendor.verify.verify",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.verified-by.evidence.pf.upstream-licences-are-reviewed.pf-check",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "evidence.pf.upstream-licences-are-reviewed.pf-check",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:08Z",
+        "verified_at": "2026-08-19T21:39:08Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.derived-from.intent.pf.control-baseline-is-declared",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "intent.pf.control-baseline-is-declared",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.implemented-by.artifact.pf.pf.air.coverage.assess",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "artifact.pf.pf.air.coverage.assess",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.implemented-by.artifact.pf.pf.air.register.render-register",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "artifact.pf.pf.air.register.render-register",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.verified-by.evidence.pf.control-baseline-is-declared.pf-air-coverage",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "evidence.pf.control-baseline-is-declared.pf-air-coverage",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:08Z",
+        "verified_at": "2026-08-19T21:39:08Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.verified-by.evidence.pf.control-baseline-is-declared.governance-air-register-md",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "evidence.pf.control-baseline-is-declared.governance-air-register-md",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:20Z",
+        "verified_at": "2026-08-19T18:05:20Z"
       }
     }
   ],

--- a/groups/zenith/projects/zenith-uk/governance/otop.json
+++ b/groups/zenith/projects/zenith-uk/governance/otop.json
@@ -4,9 +4,9 @@
     "id": "otop.pf.zenith.zenith-uk",
     "title": "Policy and evidence \u2014 zenith/zenith-uk",
     "repository": "https://github.com/Atomz-org/data-platform.git",
-    "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+    "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
     "metadata": {
-      "created_at": "2026-08-16T23:47:39Z",
+      "created_at": "2026-08-19T21:39:32Z",
       "actor": "pf.projections.otop"
     }
   },
@@ -17,13 +17,13 @@
       "title": "Agentic Data Platform governance policy",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
         "scope": "zenith/zenith-uk",
         "source": "platform/src/pf/ontology/policy.yaml",
-        "rules": 10
+        "rules": 22
       }
     },
     {
@@ -32,7 +32,7 @@
       "title": "A monetary amount without its currency is not a number, it is a bug waiting for a second entity to be onboarded.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -45,7 +45,7 @@
       "title": "money-requires-currency",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -61,6 +61,138 @@
         "params": {
           "sibling": "currency_code",
           "scope": "resource"
+        },
+        "controls": [
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -70,8 +202,8 @@
       "title": "pf check for money-requires-currency",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:47:37Z",
-        "observed_at": "2026-08-16T23:47:37Z",
+        "created_at": "2026-08-19T21:39:24Z",
+        "observed_at": "2026-08-19T21:39:24Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -95,7 +227,7 @@
       "title": "A class with no identity property cannot participate in a derived join, so every BI and MDL projection of it is a guess.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -108,7 +240,7 @@
       "title": "entity-requires-identity",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -123,6 +255,138 @@
         },
         "params": {
           "exclude_abstract": true
+        },
+        "controls": [
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -132,8 +396,8 @@
       "title": "pf check for entity-requires-identity",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:47:37Z",
-        "observed_at": "2026-08-16T23:47:37Z",
+        "created_at": "2026-08-19T21:39:24Z",
+        "observed_at": "2026-08-19T21:39:24Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -157,7 +421,7 @@
       "title": "A foreign key pointing at a class the topology does not relate to is an undeclared join. Undeclared joins are how two teams compute different revenue from th...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -170,7 +434,7 @@
       "title": "link-must-be-in-topology",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -183,7 +447,139 @@
         "applies_to": {
           "annotation": "links"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -192,8 +588,8 @@
       "title": "pf check for link-must-be-in-topology",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:47:37Z",
-        "observed_at": "2026-08-16T23:47:37Z",
+        "created_at": "2026-08-19T21:39:24Z",
+        "observed_at": "2026-08-19T21:39:24Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -217,7 +613,7 @@
       "title": "PII may land in raw and staging. It must not reach a mart or an exposure without a masking policy or an explicit, recorded waiver.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -230,7 +626,7 @@
       "title": "pii-not-in-consumption",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -249,6 +645,153 @@
             "semantic",
             "consumption"
           ]
+        },
+        "controls": [
+          "AIR-DET-16",
+          "AIR-PREV-12"
+        ],
+        "control_titles": {
+          "AIR-DET-16": "Preserving Source Data Access Controls in AI Systems",
+          "AIR-PREV-12": "Role-Based Access Control for AI Data"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-3-2",
+              "title": "ISO 42001: AI roles and responsibilities",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-3",
+              "title": "ISO 42001: Acquisition of data",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-9-2",
+              "title": "ISO 42001: Processes for responsible use of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-21",
+              "title": "AC-21 Information Sharing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A238%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C521.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ca-8",
+              "title": "CA-8 Penetration Testing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A351%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "cm-12",
+              "title": "CM-12 Information Location",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ia-2",
+              "title": "IA-2 Identification And Authentication (organizational Users)",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A467%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ia-4",
+              "title": "IA-4 Identifier Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A479%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C422.0%2C0%5D"
+            },
+            {
+              "key": "ia-5",
+              "title": "IA-5 Authenticator Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A485%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -258,8 +801,8 @@
       "title": "pf loop run pii-audit for pii-not-in-consumption",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:47:38Z",
-        "observed_at": "2026-08-16T23:47:38Z",
+        "created_at": "2026-08-19T21:39:25Z",
+        "observed_at": "2026-08-19T21:39:25Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "PII_findings",
@@ -283,8 +826,8 @@
       "title": "STATE.md for pii-not-in-consumption",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "observed_at": "2026-08-15T20:35:53Z",
+        "created_at": "2026-08-18T15:42:57Z",
+        "observed_at": "2026-08-18T15:42:57Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "open_findings",
@@ -308,7 +851,7 @@
       "title": "Grain is the one fact a downstream consumer cannot infer and cannot survive guessing. An undeclared grain is how a join silently fans out.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -321,7 +864,7 @@
       "title": "mart-declares-grain",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "SHOULD",
@@ -336,6 +879,98 @@
         },
         "params": {
           "field": "grain"
+        },
+        "controls": [
+          "AIR-DET-13"
+        ],
+        "control_titles": {
+          "AIR-DET-13": "Providing Citations and Source Traceability for AI-Generated Information"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t5-1",
+              "title": "Table 5.1: Disclosure of AI Use in Products and Services to End-Users",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=49"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-1-2",
+              "title": "ISO 42001: Objectives for responsible development of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-7",
+              "title": "ISO 42001: AI system technical documentation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-2",
+              "title": "ISO 42001: System documentation and information for users",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-10",
+              "title": "AU-10 Non-repudiation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A301%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-8",
+              "title": "SA-8 Security And Privacy Engineering Principles",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A842%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -345,8 +980,8 @@
       "title": "kg/context_card.md for mart-declares-grain",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:47:37Z",
-        "observed_at": "2026-08-16T23:47:37Z",
+        "created_at": "2026-08-19T21:39:23Z",
+        "observed_at": "2026-08-19T21:39:23Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "project_index",
@@ -370,7 +1005,7 @@
       "title": "Aggregation policy \u2014 which statuses count, which timestamp, which filter \u2014 belongs to exactly one metric definition. A mart column named `revenue` is a secon...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -383,7 +1018,7 @@
       "title": "metric-owns-aggregation",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "SHOULD",
@@ -404,6 +1039,98 @@
             "churn_rate",
             "ltv"
           ]
+        },
+        "controls": [
+          "AIR-DET-13"
+        ],
+        "control_titles": {
+          "AIR-DET-13": "Providing Citations and Source Traceability for AI-Generated Information"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t5-1",
+              "title": "Table 5.1: Disclosure of AI Use in Products and Services to End-Users",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=49"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-1-2",
+              "title": "ISO 42001: Objectives for responsible development of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-7",
+              "title": "ISO 42001: AI system technical documentation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-2",
+              "title": "ISO 42001: System documentation and information for users",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-10",
+              "title": "AU-10 Non-repudiation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A301%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-8",
+              "title": "SA-8 Security And Privacy Engineering Principles",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A842%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
         }
       }
     },
@@ -413,8 +1140,8 @@
       "title": "pf check for metric-owns-aggregation",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:47:38Z",
-        "observed_at": "2026-08-16T23:47:38Z",
+        "created_at": "2026-08-19T21:39:26Z",
+        "observed_at": "2026-08-19T21:39:26Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "conformance_report",
@@ -438,7 +1165,7 @@
       "title": "A model or column change must report what it breaks before it lands, including the human who owns each affected exposure.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -451,7 +1178,7 @@
       "title": "change-declares-blast-radius",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -464,7 +1191,158 @@
         "applies_to": {
           "artifact_glob": "**/transform/models/**"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-DET-21",
+          "AIR-PREV-18"
+        ],
+        "control_titles": {
+          "AIR-DET-21": "Agent Decision Audit and Explainability",
+          "AIR-PREV-18": "Agent Authority Least Privilege Framework"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00040",
+              "title": "ATR-2026-00040 Agent Privilege Escalation",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/privilege-escalation/ATR-2026-00040-privilege-escalation.yaml"
+            },
+            {
+              "key": "ATR-2026-00098",
+              "title": "ATR-2026-00098 Unauthorized Financial Action by Agent",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/excessive-autonomy/ATR-2026-00098-unauthorized-financial-action.yaml"
+            }
+          ],
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a12",
+              "title": "III.S2.A12: Record-Keeping",
+              "url": "https://artificialintelligenceact.eu/article/12/"
+            },
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c3-s3-a26",
+              "title": "III.S3.A26: Obligations of Deployers of High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/26/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -473,8 +1351,8 @@
       "title": "impact_reports for change-declares-blast-radius",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:47:38Z",
-        "observed_at": "2026-08-16T23:47:38Z",
+        "created_at": "2026-08-19T21:39:26Z",
+        "observed_at": "2026-08-19T21:39:26Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "blast_radius_history",
@@ -498,8 +1376,8 @@
       "title": "loop-ledger.json for change-declares-blast-radius",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "observed_at": "2026-08-15T20:35:53Z",
+        "created_at": "2026-08-19T20:47:22Z",
+        "observed_at": "2026-08-19T20:47:22Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "run_history",
@@ -523,7 +1401,7 @@
       "title": "A blast radius is a prediction made from lineage. Lineage cannot say whether the numbers actually moved, so a change to a mart must also be compared against ...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -536,7 +1414,7 @@
       "title": "change-verified-against-baseline",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "SHOULD",
@@ -549,7 +1427,94 @@
         "applies_to": {
           "artifact_glob": "**/transform/models/marts/**"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-PREV-5"
+        ],
+        "control_titles": {
+          "AIR-PREV-5": "System Acceptance Testing"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a15",
+              "title": "III.S2.A15: Accuracy, Robustness and Cybersecurity",
+              "url": "https://artificialintelligenceact.eu/article/15/"
+            },
+            {
+              "key": "c3-s2-a9",
+              "title": "III.S2.A9: Risk Management System",
+              "url": "https://artificialintelligenceact.eu/article/9/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-1",
+              "title": "Table 4.1: Assessment of Risk-Proportionate Controls",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=41"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-4",
+              "title": "ISO 42001: AI system verification and validation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-5",
+              "title": "ISO 42001: AI system deployment",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ca-2",
+              "title": "CA-2 Control Assessments",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A324%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C684%2C0%5D"
+            },
+            {
+              "key": "ca-6",
+              "title": "CA-6 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A339%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "cm-4",
+              "title": "CM-4 Impact Analyses",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A375%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C509.0%2C0%5D"
+            },
+            {
+              "key": "sa-11",
+              "title": "SA-11 Developer Testing And Evaluation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A899%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C601.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-2",
+              "title": "SI-2 Flaw Remediation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1070%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-6",
+              "title": "SI-6 Security And Privacy Function Verification",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1103%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C475.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -558,12 +1523,12 @@
       "title": "pf tool recce run for change-verified-against-baseline",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:57:40Z",
-        "observed_at": "2026-08-16T22:57:40Z",
+        "created_at": "2026-08-19T21:39:27Z",
+        "observed_at": "2026-08-19T21:39:27Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "data_diff_against_baseline",
-      "result": "pass",
+      "result": "unknown",
       "subjects": [
         {
           "id": "constraint.pf.change-verified-against-baseline",
@@ -574,7 +1539,7 @@
       "provenance": {
         "actor": "pf.projections.otop",
         "scope": "zenith/zenith-uk",
-        "detail": "groups/zenith/projects/zenith-uk/transform/recce_state.json"
+        "detail": "no baseline captured"
       }
     },
     {
@@ -583,7 +1548,7 @@
       "title": "A value-level diff writes the rows it compared into the review tool's state file, which is durable and shared. Diffing a column whose role is PII therefore p...",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -596,7 +1561,7 @@
       "title": "review-artifacts-exclude-pii",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -609,7 +1574,194 @@
         "applies_to": {
           "artifact_glob": "**/transform/recce.yml"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-DET-1",
+          "AIR-PREV-12"
+        ],
+        "control_titles": {
+          "AIR-DET-1": "AI Data Leakage Prevention and Detection",
+          "AIR-PREV-12": "Role-Based Access Control for AI Data"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-3-2",
+              "title": "ISO 42001: AI roles and responsibilities",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-5-2",
+              "title": "ISO 42001: AI system impact assessment process",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-20",
+              "title": "AC-20 Use Of External Systems",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A232%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C598.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-13",
+              "title": "AU-13 Monitoring For Information Disclosure",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A310%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C556.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-3",
+              "title": "CA-3 Information Exchange",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A330%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C166.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-12",
+              "title": "CM-12 Information Location",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ia-2",
+              "title": "IA-2 Identification And Authentication (organizational Users)",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A467%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ia-4",
+              "title": "IA-4 Identifier Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A479%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C422.0%2C0%5D"
+            },
+            {
+              "key": "ia-5",
+              "title": "IA-5 Authenticator Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A485%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "ir-4",
+              "title": "IR-4 Incident Handling",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A527%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C626.0%2C0%5D"
+            },
+            {
+              "key": "ir-9",
+              "title": "IR-9 Information Spillage Response",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A548%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C135.0%2C0%5D"
+            },
+            {
+              "key": "mp-6",
+              "title": "MP-6 Media Sanitization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A593%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C314.0%2C0%5D"
+            },
+            {
+              "key": "sa-9",
+              "title": "SA-9 External System Services",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A884%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C665.0%2C0%5D"
+            },
+            {
+              "key": "sc-28",
+              "title": "SC-28 Protection Of Information AT Rest",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1019%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C191.0%2C0%5D"
+            },
+            {
+              "key": "sc-7",
+              "title": "SC-7 Boundary Protection",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A962%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C399.0%2C0%5D"
+            },
+            {
+              "key": "sc-8",
+              "title": "SC-8 Transmission Confidentiality And Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A983%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C223.0%2C0%5D"
+            },
+            {
+              "key": "si-20",
+              "title": "SI-20 Tainting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1151%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C232.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -618,8 +1770,8 @@
       "title": "pf tool recce config for review-artifacts-exclude-pii",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T20:38:47Z",
-        "observed_at": "2026-08-15T20:38:47Z",
+        "created_at": "2026-08-18T15:42:57Z",
+        "observed_at": "2026-08-18T15:42:57Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "derived_review_checks",
@@ -638,12 +1790,580 @@
       }
     },
     {
+      "id": "intent.pf.builds-record-observability",
+      "kind": "intent",
+      "title": "A dbt build that leaves no queryable record cannot be triaged; failures get diagnosed from whichever log happened to survive. Every build must record its run...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A dbt build that leaves no queryable record cannot be triaged; failures get diagnosed from whichever log happened to survive. Every build must record its run and test results into the warehouse with history \u2014 for every test framework at once \u2014 so \"is this new, recurring, or flaky?\" is a query, not an archaeology dig."
+      }
+    },
+    {
+      "id": "constraint.pf.builds-record-observability",
+      "kind": "constraint",
+      "title": "builds-record-observability",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "observability_recorded",
+      "checkability": "automated",
+      "assertion": "observability_recorded on artifact_glob=**/transform/packages.yml",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/transform/packages.yml"
+        },
+        "params": {},
+        "controls": [
+          "AIR-DET-4",
+          "AIR-PREV-6"
+        ],
+        "control_titles": {
+          "AIR-DET-4": "AI System Observability",
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t7-adoption",
+              "title": "Table 7: AI Adoption Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=57"
+            },
+            {
+              "key": "t7-nature",
+              "title": "Table 7: Nature and Use Cases of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            },
+            {
+              "key": "t7-performance",
+              "title": "Table 7: AI System Performance Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-8",
+              "title": "ISO 42001: AI system recording of event logs",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "au-11",
+              "title": "AU-11 Audit Record Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C462.0%2C0%5D"
+            },
+            {
+              "key": "au-12",
+              "title": "AU-12 Audit Record Generation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C122.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "ir-4",
+              "title": "IR-4 Incident Handling",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A527%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C626.0%2C0%5D"
+            },
+            {
+              "key": "ir-5",
+              "title": "IR-5 Incident Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A539%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C387%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-10",
+              "title": "RA-10 Threat Hunting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A812%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C110.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.builds-record-observability.pf-tool-elementary-report",
+      "kind": "evidence",
+      "title": "pf tool elementary report for builds-record-observability",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:28Z",
+        "observed_at": "2026-08-19T21:39:28Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "observability_report_over_recorded_history",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.builds-record-observability",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-uk",
+        "detail": "pf tool elementary report not produced yet"
+      }
+    },
+    {
+      "id": "evidence.pf.builds-record-observability.loop-ledger-json",
+      "kind": "evidence",
+      "title": "loop-ledger.json for builds-record-observability",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T20:47:22Z",
+        "observed_at": "2026-08-19T20:47:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "run_history",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.builds-record-observability",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-uk",
+        "detail": "loop-ledger.json"
+      }
+    },
+    {
+      "id": "intent.pf.quality-floor-derived-from-ontology",
+      "kind": "intent",
+      "title": "Hand-written test coverage decays to whichever models someone remembered. The floor \u2014 an annotated mart is never empty, a declared identity identifies \u2014 must...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Hand-written test coverage decays to whichever models someone remembered. The floor \u2014 an annotated mart is never empty, a declared identity identifies \u2014 must be derived from the ontology roles, so coverage is a function of annotation rather than of memory, and a wrong test is a wrong role rather than a stale file."
+      }
+    },
+    {
+      "id": "constraint.pf.quality-floor-derived-from-ontology",
+      "kind": "constraint",
+      "title": "quality-floor-derived-from-ontology",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "tests_derived_from_roles",
+      "checkability": "automated",
+      "assertion": "tests_derived_from_roles on artifact_glob=**/transform/tests/expectations/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/transform/tests/expectations/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-6",
+          "AIR-PREV-5"
+        ],
+        "control_titles": {
+          "AIR-PREV-6": "Data Quality & Classification/Sensitivity",
+          "AIR-PREV-5": "System Acceptance Testing"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a10",
+              "title": "III.S2.A10: Data and Data Governance",
+              "url": "https://artificialintelligenceact.eu/article/10/"
+            },
+            {
+              "key": "c3-s2-a15",
+              "title": "III.S2.A15: Accuracy, Robustness and Cybersecurity",
+              "url": "https://artificialintelligenceact.eu/article/15/"
+            },
+            {
+              "key": "c3-s2-a9",
+              "title": "III.S2.A9: Risk Management System",
+              "url": "https://artificialintelligenceact.eu/article/9/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t4-1",
+              "title": "Table 4.1: Assessment of Risk-Proportionate Controls",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=41"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-3",
+              "title": "ISO 42001: Data resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-4",
+              "title": "ISO 42001: AI system verification and validation",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-5",
+              "title": "ISO 42001: AI system deployment",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-4",
+              "title": "ISO 42001: Quality of data for AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-1",
+              "title": "AC-1 Policy And Procedures",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A127%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C659.0%2C0%5D"
+            },
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "at-3",
+              "title": "AT-3 Role-based Training",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A259%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C533.0%2C0%5D"
+            },
+            {
+              "key": "ca-2",
+              "title": "CA-2 Control Assessments",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A324%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C684%2C0%5D"
+            },
+            {
+              "key": "ca-6",
+              "title": "CA-6 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A339%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "cm-13",
+              "title": "CM-13 Data Action Mapping",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A411%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C155.0%2C0%5D"
+            },
+            {
+              "key": "cm-4",
+              "title": "CM-4 Impact Analyses",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A375%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C509.0%2C0%5D"
+            },
+            {
+              "key": "pm-11",
+              "title": "PM-11 Mission And Business Process Definition",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A695%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C189.0%2C0%5D"
+            },
+            {
+              "key": "pm-22",
+              "title": "PM-22 Personally Identifiable Information Quality Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C464.0%2C0%5D"
+            },
+            {
+              "key": "pm-23",
+              "title": "PM-23 Data Governance Body",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A719%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C562.0%2C0%5D"
+            },
+            {
+              "key": "ra-2",
+              "title": "RA-2 Security Categorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A788%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-11",
+              "title": "SA-11 Developer Testing And Evaluation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A899%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C601.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-12",
+              "title": "SI-12 Information Management And Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1124%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C134.0%2C0%5D"
+            },
+            {
+              "key": "si-18",
+              "title": "SI-18 Personally Identifiable Information Quality Operations",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1139%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C451.0%2C0%5D"
+            },
+            {
+              "key": "si-2",
+              "title": "SI-2 Flaw Remediation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1070%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-6",
+              "title": "SI-6 Security And Privacy Function Verification",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1103%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C475.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.quality-floor-derived-from-ontology.pf-tool-expectations-run",
+      "kind": "evidence",
+      "title": "pf tool expectations run for quality-floor-derived-from-ontology",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:28Z",
+        "observed_at": "2026-08-19T21:39:28Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "quality_floor_verdicts",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.quality-floor-derived-from-ontology",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-uk",
+        "detail": "pf tool expectations run not produced yet"
+      }
+    },
+    {
       "id": "intent.pf.secrets-never-in-context",
       "kind": "intent",
       "title": "A credential placed in a prompt, a model file or a committed artefact is durably persisted and replayed into every later session.",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "extensions": {
@@ -656,7 +2376,7 @@
       "title": "secrets-never-in-context",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "modality": "MUST",
@@ -669,7 +2389,131 @@
         "applies_to": {
           "artifact_glob": "**/secrets.toml"
         },
-        "params": {}
+        "params": {},
+        "controls": [
+          "AIR-PREV-23",
+          "AIR-DET-16"
+        ],
+        "control_titles": {
+          "AIR-PREV-23": "Agentic System Credential Protection Framework",
+          "AIR-DET-16": "Preserving Source Data Access Controls in AI Systems"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00113",
+              "title": "ATR-2026-00113 Credential Theft via Agent Channel",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/context-exfiltration/ATR-2026-00113-credential-theft.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-4",
+              "title": "Table 3.4: Data Governance",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=35"
+            },
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-7-2",
+              "title": "ISO 42001: Data for development and enhancement of AI system",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-7-3",
+              "title": "ISO 42001: Acquisition of data",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-9-2",
+              "title": "ISO 42001: Processes for responsible use of AI systems",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-16",
+              "title": "AC-16 Security And Privacy Attributes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A205%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C238.0%2C0%5D"
+            },
+            {
+              "key": "ac-21",
+              "title": "AC-21 Information Sharing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A238%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C521.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ca-8",
+              "title": "CA-8 Penetration Testing",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A351%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ia-5",
+              "title": "IA-5 Authenticator Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A485%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "sc-28",
+              "title": "SC-28 Protection Of Information AT Rest",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1019%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C191.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
       }
     },
     {
@@ -678,8 +2522,8 @@
       "title": "pf gate for secrets-never-in-context",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T23:47:39Z",
-        "observed_at": "2026-08-16T23:47:39Z",
+        "created_at": "2026-08-19T21:39:28Z",
+        "observed_at": "2026-08-19T21:39:28Z",
         "actor": "pf.projections.otop"
       },
       "evidence_type": "path_verdict",
@@ -698,23 +2542,1498 @@
       }
     },
     {
+      "id": "intent.pf.agent-authority-is-least-privilege",
+      "kind": "intent",
+      "title": "An agent reaches the filesystem through one path gate, and the paths it may never write are declared rather than remembered. Least privilege that lives in a ...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "An agent reaches the filesystem through one path gate, and the paths it may never write are declared rather than remembered. Least privilege that lives in a prompt is a request; in a denylist it is a control."
+      }
+    },
+    {
+      "id": "constraint.pf.agent-authority-is-least-privilege",
+      "kind": "constraint",
+      "title": "agent-authority-is-least-privilege",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "path_denied",
+      "checkability": "automated",
+      "assertion": "path_denied on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-18"
+        ],
+        "control_titles": {
+          "AIR-PREV-18": "Agent Authority Least Privilege Framework"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00040",
+              "title": "ATR-2026-00040 Agent Privilege Escalation",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/privilege-escalation/ATR-2026-00040-privilege-escalation.yaml"
+            },
+            {
+              "key": "ATR-2026-00098",
+              "title": "ATR-2026-00098 Unauthorized Financial Action by Agent",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/excessive-autonomy/ATR-2026-00098-unauthorized-financial-action.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.agent-authority-is-least-privilege.pf-gate",
+      "kind": "evidence",
+      "title": "pf gate for agent-authority-is-least-privilege",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:29Z",
+        "observed_at": "2026-08-19T21:39:29Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "path_verdict",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.agent-authority-is-least-privilege",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-uk",
+        "detail": "denylist present"
+      }
+    },
+    {
+      "id": "intent.pf.tool-contribution-may-only-tighten",
+      "kind": "intent",
+      "title": "A tool contributes gate rules, and a plugin system that can widen the policy judging it is not a policy. `Tool.gate_sections()` rejects a contribution to any...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A tool contributes gate rules, and a plugin system that can widen the policy judging it is not a policy. `Tool.gate_sections()` rejects a contribution to any loosening section at construction, so an unsafe tool fails at import rather than silently permitting more."
+      }
+    },
+    {
+      "id": "constraint.pf.tool-contribution-may-only-tighten",
+      "kind": "constraint",
+      "title": "tool-contribution-may-only-tighten",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "tightening_only",
+      "checkability": "automated",
+      "assertion": "tightening_only (sections=['denylist', 'platform_denylist', 'impact_required']) on artifact_glob=gate.capabilities.yaml",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "gate.capabilities.yaml"
+        },
+        "params": {
+          "sections": [
+            "denylist",
+            "platform_denylist",
+            "impact_required"
+          ]
+        },
+        "controls": [
+          "AIR-PREV-19"
+        ],
+        "control_titles": {
+          "AIR-PREV-19": "Tool Chain Validation and Sanitization"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00011",
+              "title": "ATR-2026-00011 Instruction Injection via Tool Output",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00011-tool-output-injection.yaml"
+            },
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00013",
+              "title": "ATR-2026-00013 Tool-Driven Server-Side Request Forgery",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00013-tool-ssrf.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t4-4",
+              "title": "Table 4.4: Supply Chain Risk Assessment",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=43"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "sc-4",
+              "title": "SC-4 Information In Shared System Resources",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A956%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C524.0%2C0%5D"
+            },
+            {
+              "key": "si-10",
+              "title": "SI-10 Information Input Validation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C262.0%2C0%5D"
+            },
+            {
+              "key": "si-15",
+              "title": "SI-15 Information Output Filtering",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1136%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C355.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.tool-contribution-may-only-tighten.pf-check",
+      "kind": "evidence",
+      "title": "pf check for tool-contribution-may-only-tighten",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:29Z",
+        "observed_at": "2026-08-19T21:39:29Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "conformance_report",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.tool-contribution-may-only-tighten",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-uk",
+        "detail": "0 error(s), 1 issue(s)"
+      }
+    },
+    {
+      "id": "intent.pf.agent-decisions-are-recorded",
+      "kind": "intent",
+      "title": "Every tool call an agent makes is written down before it happens and after it happens, and the gate's verdict is recorded for allows as well as denies. \"No r...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Every tool call an agent makes is written down before it happens and after it happens, and the gate's verdict is recorded for allows as well as denies. \"No rule applied\" and \"a rule allowed it\" are different facts, and only a record that carries both can answer what an agent was permitted to do."
+      }
+    },
+    {
+      "id": "constraint.pf.agent-decisions-are-recorded",
+      "kind": "constraint",
+      "title": "agent-decisions-are-recorded",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "action_recorded",
+      "checkability": "automated",
+      "assertion": "action_recorded (stages=['intent', 'decision', 'execution']) on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {
+          "stages": [
+            "intent",
+            "decision",
+            "execution"
+          ]
+        },
+        "controls": [
+          "AIR-DET-21",
+          "AIR-DET-4"
+        ],
+        "control_titles": {
+          "AIR-DET-21": "Agent Decision Audit and Explainability",
+          "AIR-DET-4": "AI System Observability"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a12",
+              "title": "III.S2.A12: Record-Keeping",
+              "url": "https://artificialintelligenceact.eu/article/12/"
+            },
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c3-s3-a26",
+              "title": "III.S3.A26: Obligations of Deployers of High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/26/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t7-adoption",
+              "title": "Table 7: AI Adoption Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=57"
+            },
+            {
+              "key": "t7-nature",
+              "title": "Table 7: Nature and Use Cases of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            },
+            {
+              "key": "t7-performance",
+              "title": "Table 7: AI System Performance Indicators",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-8",
+              "title": "ISO 42001: AI system recording of event logs",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-11",
+              "title": "AU-11 Audit Record Retention",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C462.0%2C0%5D"
+            },
+            {
+              "key": "au-12",
+              "title": "AU-12 Audit Record Generation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A304%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C122.0%2C0%5D"
+            },
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ir-4",
+              "title": "IR-4 Incident Handling",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A527%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C626.0%2C0%5D"
+            },
+            {
+              "key": "ir-5",
+              "title": "IR-5 Incident Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A539%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C387%2C0%5D"
+            },
+            {
+              "key": "ra-10",
+              "title": "RA-10 Threat Hunting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A812%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C110.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            },
+            {
+              "key": "si-7",
+              "title": "SI-7 Software, Firmware, And Information Integrity",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1106%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C536.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.agent-decisions-are-recorded.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for agent-decisions-are-recorded",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:30Z",
+        "observed_at": "2026-08-19T21:39:30Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.agent-decisions-are-recorded",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-uk",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.evidence-chain-is-tamper-evident",
+      "kind": "intent",
+      "title": "A log an agent can edit is not evidence. Each record carries the hash of the one before it, and the head is anchored to a timestamp authority with no stake i...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A log an agent can edit is not evidence. Each record carries the hash of the one before it, and the head is anchored to a timestamp authority with no stake in what it says \u2014 so editing the middle requires editing the end, and the end is countersigned."
+      }
+    },
+    {
+      "id": "constraint.pf.evidence-chain-is-tamper-evident",
+      "kind": "constraint",
+      "title": "evidence-chain-is-tamper-evident",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "hash_chained",
+      "checkability": "automated",
+      "assertion": "hash_chained on artifact_glob=provenance/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "provenance/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-DET-21"
+        ],
+        "control_titles": {
+          "AIR-DET-21": "Agent Decision Audit and Explainability"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a12",
+              "title": "III.S2.A12: Record-Keeping",
+              "url": "https://artificialintelligenceact.eu/article/12/"
+            },
+            {
+              "key": "c3-s2-a13",
+              "title": "III.S2.A13: Transparency and Provision of Information to Deployers",
+              "url": "https://artificialintelligenceact.eu/article/13/"
+            },
+            {
+              "key": "c3-s3-a26",
+              "title": "III.S3.A26: Obligations of Deployers of High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/26/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            },
+            {
+              "key": "c9-s4-a86",
+              "title": "IX.S4.A86: Right to Explanation of Individual Decision-Making",
+              "url": "https://artificialintelligenceact.eu/article/86/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-recordkeeping",
+              "title": "Table 2: Recordkeeping & Audit Trail",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=28"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-1",
+              "title": "Table 6.1: Documentation of AI Lifecycle Oversight",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            },
+            {
+              "key": "t6-4",
+              "title": "Table 6.4: Documentation of Explainability of AI Outputs",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            },
+            {
+              "key": "t6-5",
+              "title": "Table 6.5: Records on Incidents Relating to AI Products or Services",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=55"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "au-3",
+              "title": "AU-3 Content Of Audit Records",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A274%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C539.0%2C0%5D"
+            },
+            {
+              "key": "au-6",
+              "title": "AU-6 Audit Record Review, Analysis, And Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A283%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C512.0%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.evidence-chain-is-tamper-evident.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for evidence-chain-is-tamper-evident",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:30Z",
+        "observed_at": "2026-08-19T21:39:30Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.evidence-chain-is-tamper-evident",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-uk",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.sister-projects-are-isolated",
+      "kind": "intent",
+      "title": "Business logic does not transfer between entities, so an assumption carried from one sister company into another is a bug by construction. A project session ...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Business logic does not transfer between entities, so an assumption carried from one sister company into another is a bug by construction. A project session may not read or write another project, and may not write shared infra at all."
+      }
+    },
+    {
+      "id": "constraint.pf.sister-projects-are-isolated",
+      "kind": "constraint",
+      "title": "sister-projects-are-isolated",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "cross_tenant_denied",
+      "checkability": "automated",
+      "assertion": "cross_tenant_denied on artifact_glob=groups/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "groups/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-22"
+        ],
+        "control_titles": {
+          "AIR-PREV-22": "Multi-Agent Isolation and Segmentation"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00030",
+              "title": "ATR-2026-00030 Cross-Agent Attack Detection",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/agent-manipulation/ATR-2026-00030-cross-agent-attack.yaml"
+            },
+            {
+              "key": "ATR-2026-00076",
+              "title": "ATR-2026-00076 Insecure Inter-Agent Communication",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/agent-manipulation/ATR-2026-00076-inter-agent-message-spoofing.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t2-cybersecurity",
+              "title": "Table 2: Cybersecurity & Data Privacy/Protection",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=27"
+            },
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-4",
+              "title": "AC-4 Information Flow Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C350.0%2C0%5D"
+            },
+            {
+              "key": "sc-3",
+              "title": "SC-3 Security Function Isolation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A950%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C217.0%2C0%5D"
+            },
+            {
+              "key": "sc-32",
+              "title": "SC-32 System Partitioning",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1031%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C227.0%2C0%5D"
+            },
+            {
+              "key": "sc-7",
+              "title": "SC-7 Boundary Protection",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A962%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C399.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.sister-projects-are-isolated.pf-gate",
+      "kind": "evidence",
+      "title": "pf gate for sister-projects-are-isolated",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:30Z",
+        "observed_at": "2026-08-19T21:39:30Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "path_verdict",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.sister-projects-are-isolated",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-uk",
+        "detail": "denylist present"
+      }
+    },
+    {
+      "id": "intent.pf.agent-authority-is-revocable",
+      "kind": "intent",
+      "title": "A control that cannot be switched off mid-incident is a control you find out about afterwards. Revocation is checked before intent is written, and an unreada...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A control that cannot be switched off mid-incident is a control you find out about afterwards. Revocation is checked before intent is written, and an unreadable revocation file fails closed."
+      }
+    },
+    {
+      "id": "constraint.pf.agent-authority-is-revocable",
+      "kind": "constraint",
+      "title": "agent-authority-is-revocable",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "revocable",
+      "checkability": "automated",
+      "assertion": "revocable on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-18"
+        ],
+        "control_titles": {
+          "AIR-PREV-18": "Agent Authority Least Privilege Framework"
+        },
+        "regulatory_citations": {
+          "atr": [
+            {
+              "key": "ATR-2026-00012",
+              "title": "ATR-2026-00012 Unauthorized Tool Call",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/tool-poisoning/ATR-2026-00012-unauthorized-tool-call.yaml"
+            },
+            {
+              "key": "ATR-2026-00040",
+              "title": "ATR-2026-00040 Agent Privilege Escalation",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/privilege-escalation/ATR-2026-00040-privilege-escalation.yaml"
+            },
+            {
+              "key": "ATR-2026-00098",
+              "title": "ATR-2026-00098 Unauthorized Financial Action by Agent",
+              "url": "https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/rules/excessive-autonomy/ATR-2026-00098-unauthorized-financial-action.yaml"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-5",
+              "title": "Table 3.5: Risk Management of Advanced AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=36"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-2",
+              "title": "AC-2 Account Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A130%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ac-3",
+              "title": "AC-3 Access Enforcement",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A142%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C500.0%2C0%5D"
+            },
+            {
+              "key": "ac-5",
+              "title": "AC-5 Separation Of Duties",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C611.0%2C0%5D"
+            },
+            {
+              "key": "ac-6",
+              "title": "AC-6 Least Privilege",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A181%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C336.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.agent-authority-is-revocable.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for agent-authority-is-revocable",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:31Z",
+        "observed_at": "2026-08-19T21:39:31Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.agent-authority-is-revocable",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-uk",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.high-impact-actions-need-a-human",
+      "kind": "intent",
+      "title": "Human oversight is a chain that shows the approval, not a document that asserts it. Approvals are append-only and bound to the action they approve, and an ac...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Human oversight is a chain that shows the approval, not a document that asserts it. Approvals are append-only and bound to the action they approve, and an actor approving their own action is a finding rather than an approval."
+      }
+    },
+    {
+      "id": "constraint.pf.high-impact-actions-need-a-human",
+      "kind": "constraint",
+      "title": "high-impact-actions-need-a-human",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "approval_recorded",
+      "checkability": "automated",
+      "assertion": "approval_recorded on artifact_glob=**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-DET-11"
+        ],
+        "control_titles": {
+          "AIR-DET-11": "Human Feedback Loop for AI Systems"
+        },
+        "regulatory_citations": {
+          "eu-ai-act": [
+            {
+              "key": "c3-s2-a14",
+              "title": "III.S2.A14: Human Oversight",
+              "url": "https://artificialintelligenceact.eu/article/14/"
+            },
+            {
+              "key": "c9-s1-a72",
+              "title": "IX.S1.A72: Post-Market Monitoring by Providers and Post-Market Monitoring Plan for High-Risk AI Systems",
+              "url": "https://artificialintelligenceact.eu/article/72/"
+            }
+          ],
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t3-7",
+              "title": "Table 3.7: Controls and Human Oversight of AI Systems",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            },
+            {
+              "key": "t6-3",
+              "title": "Table 6.3: Documentation of AI-Generated Outcomes",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=54"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-3-3",
+              "title": "ISO 42001: Reporting of concerns",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-2",
+              "title": "ISO 42001: System documentation and information for users",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-3",
+              "title": "ISO 42001: External reporting",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "at-2",
+              "title": "AT-2 Literacy Training And Awareness",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A253%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "ca-2",
+              "title": "CA-2 Control Assessments",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A324%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C684%2C0%5D"
+            },
+            {
+              "key": "ca-7",
+              "title": "CA-7 Authorization",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A342%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C310%2C0%5D"
+            },
+            {
+              "key": "ir-6",
+              "title": "IR-6 Incident Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A542%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "pm-26",
+              "title": "PM-26 Complaint Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A722%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C365.0%2C0%5D"
+            },
+            {
+              "key": "ra-5",
+              "title": "RA-5 Vulnerability Monitoring And Scanning",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A797%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C594.0%2C0%5D"
+            },
+            {
+              "key": "si-2",
+              "title": "SI-2 Flaw Remediation",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1070%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "si-4",
+              "title": "SI-4 System Monitoring",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1079%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C111.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.high-impact-actions-need-a-human.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for high-impact-actions-need-a-human",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:31Z",
+        "observed_at": "2026-08-19T21:39:31Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.high-impact-actions-need-a-human",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-uk",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.model-routing-is-declared",
+      "kind": "intent",
+      "title": "Which model answers which step is a declared table, not whatever the caller passed. An unregistered step is recorded as such, and the recorded verdict matche...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Which model answers which step is a declared table, not whatever the caller passed. An unregistered step is recorded as such, and the recorded verdict matches what actually happened rather than what policy would have preferred."
+      }
+    },
+    {
+      "id": "constraint.pf.model-routing-is-declared",
+      "kind": "constraint",
+      "title": "model-routing-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "routing_declared",
+      "checkability": "automated",
+      "assertion": "routing_declared on artifact_glob=**/agents/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/agents/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-10"
+        ],
+        "control_titles": {
+          "AIR-PREV-10": "AI Model Version Pinning"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t3-6",
+              "title": "Table 3.6: AI Model Validation, Testing and Monitoring",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=37"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-4-4",
+              "title": "ISO 42001: Tooling resources",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-3",
+              "title": "ISO 42001: Documentation of AI system design and development",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-5",
+              "title": "ISO 42001: AI system deployment",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-6-2-6",
+              "title": "ISO 42001: AI system operation and monitoring",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "au-2",
+              "title": "AU-2 Event Logging",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A271%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "cm-2",
+              "title": "CM-2 Baseline Configuration",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A363%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "cm-3",
+              "title": "CM-3 Configuration Change Control",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A366%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C205.0%2C0%5D"
+            },
+            {
+              "key": "cm-4",
+              "title": "CM-4 Impact Analyses",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A375%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C509.0%2C0%5D"
+            },
+            {
+              "key": "cm-8",
+              "title": "CM-8 System Component Inventory",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A393%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C197.0%2C0%5D"
+            },
+            {
+              "key": "sa-10",
+              "title": "SA-10 Developer Configuration Management",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A890%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C211.0%2C0%5D"
+            },
+            {
+              "key": "sa-22",
+              "title": "SA-22 Unsupported System Components",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A941%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C497.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sr-4",
+              "title": "SR-4 Provenance",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1169%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C257.0%2C0%5D"
+            },
+            {
+              "key": "sr-8",
+              "title": "SR-8 Notification Agreements",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1184%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C620.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.model-routing-is-declared.pf-provenance-verify",
+      "kind": "evidence",
+      "title": "pf provenance verify for model-routing-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:32Z",
+        "observed_at": "2026-08-19T21:39:32Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "ledger_audit",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.model-routing-is-declared",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-uk",
+        "detail": "pf provenance verify not produced yet"
+      }
+    },
+    {
+      "id": "intent.pf.upstream-licences-are-reviewed",
+      "kind": "intent",
+      "title": "Every upstream this platform borrowed from carries a licence, and some of them constrain what we may ship. The review is written down per upstream and surfac...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "Every upstream this platform borrowed from carries a licence, and some of them constrain what we may ship. The review is written down per upstream and surfaced in the listing, so a constraint is a fact in the registry rather than something someone once checked."
+      }
+    },
+    {
+      "id": "constraint.pf.upstream-licences-are-reviewed",
+      "kind": "constraint",
+      "title": "upstream-licences-are-reviewed",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "SHOULD",
+      "constraint_type": "licence_reviewed",
+      "checkability": "automated",
+      "assertion": "licence_reviewed on artifact_glob=vendor/**",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "warning",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "vendor/**"
+        },
+        "params": {},
+        "controls": [
+          "AIR-PREV-7"
+        ],
+        "control_titles": {
+          "AIR-PREV-7": "Legal and Contractual Frameworks for AI Systems"
+        },
+        "regulatory_citations": {
+          "iosco-supervisory-toolkit": [
+            {
+              "key": "t4-1",
+              "title": "Table 4.1: Assessment of Risk-Proportionate Controls",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=41"
+            },
+            {
+              "key": "t4-7",
+              "title": "Table 4.7: Legal Framework and Accountability",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=44"
+            },
+            {
+              "key": "t7-third-party",
+              "title": "Table 7: Third-Party Dependencies and Concentrations",
+              "url": "https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf#page=58"
+            }
+          ],
+          "iso-42001": [
+            {
+              "key": "A-10-2",
+              "title": "ISO 42001: Allocating responsibilities",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-10-3",
+              "title": "ISO 42001: Suppliers",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-2-3",
+              "title": "ISO 42001: Alignment with other organizational policies",
+              "url": "https://www.iso.org/standard/81230.html"
+            },
+            {
+              "key": "A-8-5",
+              "title": "ISO 42001: Information for interested parties",
+              "url": "https://www.iso.org/standard/81230.html"
+            }
+          ],
+          "nist-sp-800-53r5": [
+            {
+              "key": "ac-20",
+              "title": "AC-20 Use Of External Systems",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A232%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C598.0%2C0%5D"
+            },
+            {
+              "key": "ca-3",
+              "title": "CA-3 Information Exchange",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A330%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C166.0%2C0%5D"
+            },
+            {
+              "key": "ir-6",
+              "title": "IR-6 Incident Reporting",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A542%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "pm-30",
+              "title": "PM-30 Supply Chain Risk Management Strategy",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A728%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C427.0%2C0%5D"
+            },
+            {
+              "key": "ps-7",
+              "title": "PS-7 External Personnel Security",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A752%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C623.0%2C0%5D"
+            },
+            {
+              "key": "sa-4",
+              "title": "SA-4 Acquisition Process",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A827%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C720.0%2C0%5D"
+            },
+            {
+              "key": "sa-9",
+              "title": "SA-9 External System Services",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A884%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C665.0%2C0%5D"
+            },
+            {
+              "key": "sr-2",
+              "title": "SR-2 Supply Chain Risk Management Plan",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1163%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C684.0%2C0%5D"
+            },
+            {
+              "key": "sr-3",
+              "title": "SR-3 Supply Chain Controls And Processes",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1166%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C440.0%2C0%5D"
+            },
+            {
+              "key": "sr-5",
+              "title": "SR-5 Acquisition Strategies, Tools, And Methods",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1175%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C243.0%2C0%5D"
+            },
+            {
+              "key": "sr-8",
+              "title": "SR-8 Notification Agreements",
+              "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf#%5B%7B%22num%22%3A1184%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88.0%2C620.0%2C0%5D"
+            }
+          ]
+        },
+        "catalogue": {
+          "source": "finos/ai-governance-framework",
+          "path": "vendor/ai-governance-framework",
+          "commit": "274760ccd058da1f1cb12cdbd72e50dfd1258122",
+          "licence": "CC-BY-4.0"
+        }
+      }
+    },
+    {
+      "id": "evidence.pf.upstream-licences-are-reviewed.pf-check",
+      "kind": "evidence",
+      "title": "pf check for upstream-licences-are-reviewed",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:32Z",
+        "observed_at": "2026-08-19T21:39:32Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "conformance_report",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.upstream-licences-are-reviewed",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-uk",
+        "detail": "0 error(s), 1 issue(s)"
+      }
+    },
+    {
+      "id": "intent.pf.control-baseline-is-declared",
+      "kind": "intent",
+      "title": "A risk register that names controls nobody enforces is a document. Each entity declares in `air.yaml` which controls it commits to; those are derived from th...",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "extensions": {
+        "statement": "A risk register that names controls nobody enforces is a document. Each entity declares in `air.yaml` which controls it commits to; those are derived from the repository on every run and block the merge when they fail, while everything outside the baseline is reported and does not."
+      }
+    },
+    {
+      "id": "constraint.pf.control-baseline-is-declared",
+      "kind": "constraint",
+      "title": "control-baseline-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "modality": "MUST",
+      "constraint_type": "baseline_declared",
+      "checkability": "automated",
+      "assertion": "baseline_declared on artifact_glob=**/air.yaml",
+      "expression_language": "pf.ontology.policy/1",
+      "severity": "error",
+      "extensions": {
+        "applies_to": {
+          "artifact_glob": "**/air.yaml"
+        },
+        "params": {}
+      }
+    },
+    {
+      "id": "evidence.pf.control-baseline-is-declared.pf-air-coverage",
+      "kind": "evidence",
+      "title": "pf air coverage for control-baseline-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:32Z",
+        "observed_at": "2026-08-19T21:39:32Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "control_coverage_verdicts",
+      "result": "unknown",
+      "subjects": [
+        {
+          "id": "constraint.pf.control-baseline-is-declared",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-uk",
+        "detail": "pf air coverage not produced yet"
+      }
+    },
+    {
+      "id": "evidence.pf.control-baseline-is-declared.governance-air-register-md",
+      "kind": "evidence",
+      "title": "governance/air-register.md for control-baseline-is-declared",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:20Z",
+        "observed_at": "2026-08-19T18:05:20Z",
+        "actor": "pf.projections.otop"
+      },
+      "evidence_type": "per-entity_risk_register",
+      "result": "pass",
+      "subjects": [
+        {
+          "id": "constraint.pf.control-baseline-is-declared",
+          "kind": "constraint",
+          "relationship_type": "verified_by"
+        }
+      ],
+      "provenance": {
+        "actor": "pf.projections.otop",
+        "scope": "zenith/zenith-uk",
+        "detail": "groups/zenith/projects/zenith-uk/governance/air-register.md"
+      }
+    },
+    {
       "id": "artifact.pf.pf.ontology.validate.money-without-currency",
       "kind": "artifact",
       "title": "pf.ontology.validate:money-without-currency",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "money-without-currency",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -726,18 +4045,18 @@
       "title": "pf.ontology.validate:class-without-identity",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "class-without-identity",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -749,18 +4068,18 @@
       "title": "pf.ontology.validate:illegal-edge",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "illegal-edge",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -772,18 +4091,18 @@
       "title": "pf.loops.registry:pii_audit",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T02:49:37Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "loop",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/loops/registry.py",
         "language": "python",
         "symbol": "pii_audit",
-        "digest": "git:293a23d6448c5fe70cee7c96a01f2690d8af47c2"
+        "digest": "git:e81ff725c18b4ff2a8187f5fb953a9dc003a56f4"
       },
       "extensions": {
         "exists": true
@@ -795,18 +4114,18 @@
       "title": "pf.kg.build:model-grain",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T02:04:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/kg/build.py",
         "language": "python",
         "symbol": "model-grain",
-        "digest": "git:2c8398b8a1246d27395ac2140ceba10eea0d3072"
+        "digest": "git:db169407ccb59827ce7f3c5932b2b4a0d40e1124"
       },
       "extensions": {
         "exists": true
@@ -818,18 +4137,18 @@
       "title": "pf.ontology.validate:metric-shaped-column",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T07:28:11Z",
+        "created_at": "2026-08-17T21:24:35Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/validate.py",
         "language": "python",
         "symbol": "metric-shaped-column",
-        "digest": "git:d607efad0ac5ece0a8edef879f81281fb0ea7d00"
+        "digest": "git:8ce91318943049a190ffe3cbeea52768c2b2a1f7"
       },
       "extensions": {
         "exists": true
@@ -841,17 +4160,17 @@
       "title": "platform/hooks/pre_tool_use.py",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-13T00:11:17Z",
+        "created_at": "2026-08-18T18:40:22Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "hook",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/hooks/pre_tool_use.py",
         "language": "python",
-        "digest": "git:2cb586ed58222bcb50e9cd0013d536cb2c9e6856"
+        "digest": "git:230bc9d9639eaa71c8c511affccb14881cdfc1f1"
       },
       "extensions": {
         "exists": true
@@ -863,14 +4182,14 @@
       "title": "platform/hooks/pre_commit.sh",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-12T16:06:37Z",
+        "created_at": "2026-08-12T14:06:37Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "hook",
       "language": "bash",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/hooks/pre_commit.sh",
         "language": "bash",
         "digest": "git:ce8e6f322ce15a546c16d2eb25bddf4fab5b6688"
@@ -885,18 +4204,18 @@
       "title": "pf.tools.recce:dagster_assets",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:50:23Z",
+        "created_at": "2026-08-17T23:50:05Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/tools/recce.py",
         "language": "python",
         "symbol": "dagster_assets",
-        "digest": "git:8a560994bb5a994b5a57b37a07f99114656b18a3"
+        "digest": "git:6d6c7a4515c5aa68b9642ca221805c28a15f4fc1"
       },
       "extensions": {
         "exists": true
@@ -908,18 +4227,18 @@
       "title": "pf.tools.recce:register_commands",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:50:23Z",
+        "created_at": "2026-08-17T23:50:05Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/tools/recce.py",
         "language": "python",
         "symbol": "register_commands",
-        "digest": "git:8a560994bb5a994b5a57b37a07f99114656b18a3"
+        "digest": "git:6d6c7a4515c5aa68b9642ca221805c28a15f4fc1"
       },
       "extensions": {
         "exists": true
@@ -931,18 +4250,18 @@
       "title": "pf.ontology.model:Role.review_intent",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-15T22:35:09Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/ontology/model.py",
         "language": "python",
         "symbol": "Role.review_intent",
-        "digest": "git:3e691a864da03459b04489a674bbba0a1839b1ea"
+        "digest": "git:513888ee8c2df8cfa1d09562ad3dc2793c4f741e"
       },
       "extensions": {
         "exists": true
@@ -954,18 +4273,106 @@
       "title": "pf.tools.recce:generate_config",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-16T22:50:23Z",
+        "created_at": "2026-08-17T23:50:05Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "check",
       "language": "python",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "platform/src/pf/tools/recce.py",
         "language": "python",
         "symbol": "generate_config",
-        "digest": "git:8a560994bb5a994b5a57b37a07f99114656b18a3"
+        "digest": "git:6d6c7a4515c5aa68b9642ca221805c28a15f4fc1"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.elementary.bootstrap-project",
+      "kind": "artifact",
+      "title": "pf.tools.elementary:bootstrap_project",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:27Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/elementary.py",
+        "language": "python",
+        "symbol": "bootstrap_project"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.elementary.ensure-package",
+      "kind": "artifact",
+      "title": "pf.tools.elementary:ensure_package",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:28Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/elementary.py",
+        "language": "python",
+        "symbol": "ensure_package"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.expectations.write-tests",
+      "kind": "artifact",
+      "title": "pf.tools.expectations:write_tests",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:28Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/expectations.py",
+        "language": "python",
+        "symbol": "write_tests"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.expectations.bootstrap-project",
+      "kind": "artifact",
+      "title": "pf.tools.expectations:bootstrap_project",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:28Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/expectations.py",
+        "language": "python",
+        "symbol": "bootstrap_project"
       },
       "extensions": {
         "exists": true
@@ -977,18 +4384,408 @@
       "title": "gate.yaml:denylist",
       "lifecycle": "active",
       "metadata": {
-        "created_at": "2026-08-17T00:38:30Z",
+        "created_at": "2026-08-18T18:40:22Z",
         "actor": "pf.projections.otop"
       },
       "artifact_type": "configuration",
       "language": "yaml",
       "locator": {
         "repository": "https://github.com/Atomz-org/data-platform.git",
-        "commit": "818351c205d6945d153b6f4023ea6d0974d3d976",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
         "path": "gate.yaml",
         "language": "yaml",
         "symbol": "denylist",
-        "digest": "git:f0f6dc9c2d8e60c371d7df8c8a9af65e9571c965"
+        "digest": "git:7d51894f5fdae49fa67534d8359ac34a48175bc8"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.gate.yaml.platform-denylist",
+      "kind": "artifact",
+      "title": "gate.yaml:platform_denylist",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "configuration",
+      "language": "yaml",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "gate.yaml",
+        "language": "yaml",
+        "symbol": "platform_denylist",
+        "digest": "git:7d51894f5fdae49fa67534d8359ac34a48175bc8"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.loops.gate.check-path",
+      "kind": "artifact",
+      "title": "pf.loops.gate:check_path",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-15T05:28:10Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "loop",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/loops/gate.py",
+        "language": "python",
+        "symbol": "check_path",
+        "digest": "git:0e0d5d990b04901c47b39e09bf783eb4a8821183"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.tools.spec.Tool.gate-sections",
+      "kind": "artifact",
+      "title": "pf.tools.spec:Tool.gate_sections",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-17T23:50:05Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/tools/spec.py",
+        "language": "python",
+        "symbol": "Tool.gate_sections",
+        "digest": "git:3b36976709eb70b17628d2c2228e4e398ed2df05"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.decision",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:decision",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "decision",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.platform.hooks.post-tool-use.py",
+      "kind": "artifact",
+      "title": "platform/hooks/post_tool_use.py",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "hook",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/hooks/post_tool_use.py",
+        "language": "python",
+        "digest": "git:99dc8363fbb485907c66034f6c6fefdc51336650"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.chain.verify",
+      "kind": "artifact",
+      "title": "pf.provenance.chain:verify",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/chain.py",
+        "language": "python",
+        "symbol": "verify",
+        "digest": "git:07d2c60e49bda58cd6b9d51534b3417cec91777c"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.anchor.stamp-rfc3161",
+      "kind": "artifact",
+      "title": "pf.provenance.anchor:stamp_rfc3161",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/anchor.py",
+        "language": "python",
+        "symbol": "stamp_rfc3161",
+        "digest": "git:a38a0c14b0286745dbe157807967085d044af606"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.loops.gate.project-for",
+      "kind": "artifact",
+      "title": "pf.loops.gate:project_for",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-15T05:28:10Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "loop",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/loops/gate.py",
+        "language": "python",
+        "symbol": "project_for",
+        "digest": "git:0e0d5d990b04901c47b39e09bf783eb4a8821183"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.revoke",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:revoke",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "revoke",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.is-revoked",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:is_revoked",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "is_revoked",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.ledger.approve",
+      "kind": "artifact",
+      "title": "pf.provenance.ledger:approve",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/ledger.py",
+        "language": "python",
+        "symbol": "approve",
+        "digest": "git:bad84747e5a346de5766f022bff1dad850b446c7"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.provenance.audit.report",
+      "kind": "artifact",
+      "title": "pf.provenance.audit:report",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/provenance/audit.py",
+        "language": "python",
+        "symbol": "report",
+        "digest": "git:048a4041043b8b6d2628b0f97929752c079fb95e"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.agents.base.AGENTS",
+      "kind": "artifact",
+      "title": "pf.agents.base:AGENTS",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-18T18:40:22Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/agents/base.py",
+        "language": "python",
+        "symbol": "AGENTS",
+        "digest": "git:21365423e93b1c6427aa7dbf6dbb2823993e42c2"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.vendor.model.load-registry",
+      "kind": "artifact",
+      "title": "pf.vendor.model:load_registry",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-13T01:11:58Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/vendor/model.py",
+        "language": "python",
+        "symbol": "load_registry",
+        "digest": "git:3364fcfb711181efa434a9fe7024e4dcc01984df"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.vendor.verify.verify",
+      "kind": "artifact",
+      "title": "pf.vendor.verify:verify",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/vendor/verify.py",
+        "language": "python",
+        "symbol": "verify",
+        "digest": "git:4b39f17a26d3f030c4f2ef101c60a502c2f9ccfb"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.air.coverage.assess",
+      "kind": "artifact",
+      "title": "pf.air.coverage:assess",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/air/coverage.py",
+        "language": "python",
+        "symbol": "assess",
+        "digest": "git:fd67a5e7eeec7fdfe079c96e066992764601c00f"
+      },
+      "extensions": {
+        "exists": true
+      }
+    },
+    {
+      "id": "artifact.pf.pf.air.register.render-register",
+      "kind": "artifact",
+      "title": "pf.air.register:render_register",
+      "lifecycle": "active",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "actor": "pf.projections.otop"
+      },
+      "artifact_type": "check",
+      "language": "python",
+      "locator": {
+        "repository": "https://github.com/Atomz-org/data-platform.git",
+        "commit": "727018a9bbfd967b24fc2ff788b63fdf70ba1442",
+        "path": "platform/src/pf/air/register.py",
+        "language": "python",
+        "symbol": "render_register",
+        "digest": "git:c45d0bbbe459fadea3ab3edfbf96beb6db505f25"
       },
       "extensions": {
         "exists": true
@@ -1002,7 +4799,7 @@
       "to": "intent.pf.money-requires-currency",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1013,7 +4810,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1022,8 +4819,8 @@
       "to": "artifact.pf.pf.ontology.validate.money-without-currency",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1032,8 +4829,8 @@
       "to": "evidence.pf.money-requires-currency.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:47:37Z",
-        "verified_at": "2026-08-16T23:47:37Z"
+        "created_at": "2026-08-19T21:39:24Z",
+        "verified_at": "2026-08-19T21:39:24Z"
       }
     },
     {
@@ -1042,7 +4839,7 @@
       "to": "intent.pf.entity-requires-identity",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1053,7 +4850,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1062,8 +4859,8 @@
       "to": "artifact.pf.pf.ontology.validate.class-without-identity",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1072,8 +4869,8 @@
       "to": "evidence.pf.entity-requires-identity.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:47:37Z",
-        "verified_at": "2026-08-16T23:47:37Z"
+        "created_at": "2026-08-19T21:39:24Z",
+        "verified_at": "2026-08-19T21:39:24Z"
       }
     },
     {
@@ -1082,7 +4879,7 @@
       "to": "intent.pf.link-must-be-in-topology",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1093,7 +4890,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1102,8 +4899,8 @@
       "to": "artifact.pf.pf.ontology.validate.illegal-edge",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1112,8 +4909,8 @@
       "to": "evidence.pf.link-must-be-in-topology.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:47:37Z",
-        "verified_at": "2026-08-16T23:47:37Z"
+        "created_at": "2026-08-19T21:39:24Z",
+        "verified_at": "2026-08-19T21:39:24Z"
       }
     },
     {
@@ -1122,7 +4919,7 @@
       "to": "intent.pf.pii-not-in-consumption",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1133,7 +4930,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1142,8 +4939,8 @@
       "to": "artifact.pf.pf.loops.registry.pii-audit",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1152,8 +4949,8 @@
       "to": "evidence.pf.pii-not-in-consumption.pf-loop-run-pii-audit",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:47:38Z",
-        "verified_at": "2026-08-16T23:47:38Z"
+        "created_at": "2026-08-19T21:39:25Z",
+        "verified_at": "2026-08-19T21:39:25Z"
       }
     },
     {
@@ -1162,8 +4959,8 @@
       "to": "evidence.pf.pii-not-in-consumption.state-md",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "verified_at": "2026-08-15T20:35:53Z"
+        "created_at": "2026-08-18T15:42:57Z",
+        "verified_at": "2026-08-18T15:42:57Z"
       }
     },
     {
@@ -1172,7 +4969,7 @@
       "to": "intent.pf.mart-declares-grain",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1183,7 +4980,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1192,8 +4989,8 @@
       "to": "artifact.pf.pf.kg.build.model-grain",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1202,8 +4999,8 @@
       "to": "evidence.pf.mart-declares-grain.kg-context-card-md",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:47:37Z",
-        "verified_at": "2026-08-16T23:47:37Z"
+        "created_at": "2026-08-19T21:39:23Z",
+        "verified_at": "2026-08-19T21:39:23Z"
       }
     },
     {
@@ -1212,7 +5009,7 @@
       "to": "intent.pf.metric-owns-aggregation",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1223,7 +5020,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1232,8 +5029,8 @@
       "to": "artifact.pf.pf.ontology.validate.metric-shaped-column",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1242,8 +5039,8 @@
       "to": "evidence.pf.metric-owns-aggregation.pf-check",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:47:38Z",
-        "verified_at": "2026-08-16T23:47:38Z"
+        "created_at": "2026-08-19T21:39:26Z",
+        "verified_at": "2026-08-19T21:39:26Z"
       }
     },
     {
@@ -1252,7 +5049,7 @@
       "to": "intent.pf.change-declares-blast-radius",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1263,7 +5060,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1272,8 +5069,8 @@
       "to": "artifact.pf.platform.hooks.pre-tool-use.py",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1282,8 +5079,8 @@
       "to": "artifact.pf.platform.hooks.pre-commit.sh",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1292,8 +5089,8 @@
       "to": "evidence.pf.change-declares-blast-radius.impact-reports",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:47:38Z",
-        "verified_at": "2026-08-16T23:47:38Z"
+        "created_at": "2026-08-19T21:39:26Z",
+        "verified_at": "2026-08-19T21:39:26Z"
       }
     },
     {
@@ -1302,8 +5099,8 @@
       "to": "evidence.pf.change-declares-blast-radius.loop-ledger-json",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-15T20:35:53Z",
-        "verified_at": "2026-08-15T20:35:53Z"
+        "created_at": "2026-08-19T20:47:22Z",
+        "verified_at": "2026-08-19T20:47:22Z"
       }
     },
     {
@@ -1312,7 +5109,7 @@
       "to": "intent.pf.change-verified-against-baseline",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1323,7 +5120,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1332,8 +5129,8 @@
       "to": "artifact.pf.pf.tools.recce.dagster-assets",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1342,8 +5139,8 @@
       "to": "artifact.pf.pf.tools.recce.register-commands",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1352,8 +5149,8 @@
       "to": "evidence.pf.change-verified-against-baseline.pf-tool-recce-run",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T22:57:40Z",
-        "verified_at": "2026-08-16T22:57:40Z"
+        "created_at": "2026-08-19T21:39:27Z",
+        "verified_at": "2026-08-19T21:39:27Z"
       }
     },
     {
@@ -1362,7 +5159,7 @@
       "to": "intent.pf.review-artifacts-exclude-pii",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1373,7 +5170,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1382,8 +5179,8 @@
       "to": "artifact.pf.pf.ontology.model.Role.review-intent",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1392,8 +5189,8 @@
       "to": "artifact.pf.pf.tools.recce.generate-config",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1402,8 +5199,118 @@
       "to": "evidence.pf.review-artifacts-exclude-pii.pf-tool-recce-config",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-15T20:38:47Z",
-        "verified_at": "2026-08-15T20:38:47Z"
+        "created_at": "2026-08-18T15:42:57Z",
+        "verified_at": "2026-08-18T15:42:57Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.derived-from.intent.pf.builds-record-observability",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "intent.pf.builds-record-observability",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.implemented-by.artifact.pf.pf.tools.elementary.bootstrap-project",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "artifact.pf.pf.tools.elementary.bootstrap-project",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.implemented-by.artifact.pf.pf.tools.elementary.ensure-package",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "artifact.pf.pf.tools.elementary.ensure-package",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.verified-by.evidence.pf.builds-record-observability.pf-tool-elementary-report",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "evidence.pf.builds-record-observability.pf-tool-elementary-report",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:28Z",
+        "verified_at": "2026-08-19T21:39:28Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.builds-record-observability.verified-by.evidence.pf.builds-record-observability.loop-ledger-json",
+      "from": "constraint.pf.builds-record-observability",
+      "to": "evidence.pf.builds-record-observability.loop-ledger-json",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T20:47:22Z",
+        "verified_at": "2026-08-19T20:47:22Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.derived-from.intent.pf.quality-floor-derived-from-ontology",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "intent.pf.quality-floor-derived-from-ontology",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.implemented-by.artifact.pf.pf.tools.expectations.write-tests",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "artifact.pf.pf.tools.expectations.write-tests",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.implemented-by.artifact.pf.pf.tools.expectations.bootstrap-project",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "artifact.pf.pf.tools.expectations.bootstrap-project",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.quality-floor-derived-from-ontology.verified-by.evidence.pf.quality-floor-derived-from-ontology.pf-tool-expectations-run",
+      "from": "constraint.pf.quality-floor-derived-from-ontology",
+      "to": "evidence.pf.quality-floor-derived-from-ontology.pf-tool-expectations-run",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:28Z",
+        "verified_at": "2026-08-19T21:39:28Z"
       }
     },
     {
@@ -1412,7 +5319,7 @@
       "to": "intent.pf.secrets-never-in-context",
       "type": "derived_from",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
+        "created_at": "2026-08-19T18:05:19Z",
         "confidence": "high",
         "method": "human_review"
       }
@@ -1423,7 +5330,7 @@
       "to": "policy.pf.data-platform",
       "type": "governed_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1432,8 +5339,8 @@
       "to": "artifact.pf.gate.yaml.denylist",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1442,8 +5349,8 @@
       "to": "artifact.pf.platform.hooks.pre-tool-use.py",
       "type": "implemented_by",
       "metadata": {
-        "created_at": "2026-08-13T22:01:06Z",
-        "implemented_at": "2026-08-13T22:01:06Z"
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
       }
     },
     {
@@ -1452,8 +5359,528 @@
       "to": "evidence.pf.secrets-never-in-context.pf-gate",
       "type": "verified_by",
       "metadata": {
-        "created_at": "2026-08-16T23:47:39Z",
-        "verified_at": "2026-08-16T23:47:39Z"
+        "created_at": "2026-08-19T21:39:28Z",
+        "verified_at": "2026-08-19T21:39:28Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.derived-from.intent.pf.agent-authority-is-least-privilege",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "intent.pf.agent-authority-is-least-privilege",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.implemented-by.artifact.pf.gate.yaml.denylist",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "artifact.pf.gate.yaml.denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.implemented-by.artifact.pf.gate.yaml.platform-denylist",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "artifact.pf.gate.yaml.platform-denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.implemented-by.artifact.pf.pf.loops.gate.check-path",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "artifact.pf.pf.loops.gate.check-path",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-least-privilege.verified-by.evidence.pf.agent-authority-is-least-privilege.pf-gate",
+      "from": "constraint.pf.agent-authority-is-least-privilege",
+      "to": "evidence.pf.agent-authority-is-least-privilege.pf-gate",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:29Z",
+        "verified_at": "2026-08-19T21:39:29Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.derived-from.intent.pf.tool-contribution-may-only-tighten",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "intent.pf.tool-contribution-may-only-tighten",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.implemented-by.artifact.pf.pf.tools.spec.Tool.gate-sections",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "artifact.pf.pf.tools.spec.Tool.gate-sections",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.tool-contribution-may-only-tighten.verified-by.evidence.pf.tool-contribution-may-only-tighten.pf-check",
+      "from": "constraint.pf.tool-contribution-may-only-tighten",
+      "to": "evidence.pf.tool-contribution-may-only-tighten.pf-check",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:29Z",
+        "verified_at": "2026-08-19T21:39:29Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.derived-from.intent.pf.agent-decisions-are-recorded",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "intent.pf.agent-decisions-are-recorded",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.implemented-by.artifact.pf.pf.provenance.ledger.decision",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "artifact.pf.pf.provenance.ledger.decision",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.implemented-by.artifact.pf.platform.hooks.pre-tool-use.py",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "artifact.pf.platform.hooks.pre-tool-use.py",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.implemented-by.artifact.pf.platform.hooks.post-tool-use.py",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "artifact.pf.platform.hooks.post-tool-use.py",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-decisions-are-recorded.verified-by.evidence.pf.agent-decisions-are-recorded.pf-provenance-verify",
+      "from": "constraint.pf.agent-decisions-are-recorded",
+      "to": "evidence.pf.agent-decisions-are-recorded.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:30Z",
+        "verified_at": "2026-08-19T21:39:30Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.derived-from.intent.pf.evidence-chain-is-tamper-evident",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "intent.pf.evidence-chain-is-tamper-evident",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.implemented-by.artifact.pf.pf.provenance.chain.verify",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "artifact.pf.pf.provenance.chain.verify",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.implemented-by.artifact.pf.pf.provenance.anchor.stamp-rfc3161",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "artifact.pf.pf.provenance.anchor.stamp-rfc3161",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.implemented-by.artifact.pf.gate.yaml.denylist",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "artifact.pf.gate.yaml.denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.evidence-chain-is-tamper-evident.verified-by.evidence.pf.evidence-chain-is-tamper-evident.pf-provenance-verify",
+      "from": "constraint.pf.evidence-chain-is-tamper-evident",
+      "to": "evidence.pf.evidence-chain-is-tamper-evident.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:30Z",
+        "verified_at": "2026-08-19T21:39:30Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.derived-from.intent.pf.sister-projects-are-isolated",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "intent.pf.sister-projects-are-isolated",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.implemented-by.artifact.pf.gate.yaml.platform-denylist",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "artifact.pf.gate.yaml.platform-denylist",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.implemented-by.artifact.pf.pf.loops.gate.project-for",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "artifact.pf.pf.loops.gate.project-for",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.sister-projects-are-isolated.verified-by.evidence.pf.sister-projects-are-isolated.pf-gate",
+      "from": "constraint.pf.sister-projects-are-isolated",
+      "to": "evidence.pf.sister-projects-are-isolated.pf-gate",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:30Z",
+        "verified_at": "2026-08-19T21:39:30Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.derived-from.intent.pf.agent-authority-is-revocable",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "intent.pf.agent-authority-is-revocable",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.implemented-by.artifact.pf.pf.provenance.ledger.revoke",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "artifact.pf.pf.provenance.ledger.revoke",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.implemented-by.artifact.pf.pf.provenance.ledger.is-revoked",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "artifact.pf.pf.provenance.ledger.is-revoked",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.agent-authority-is-revocable.verified-by.evidence.pf.agent-authority-is-revocable.pf-provenance-verify",
+      "from": "constraint.pf.agent-authority-is-revocable",
+      "to": "evidence.pf.agent-authority-is-revocable.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:31Z",
+        "verified_at": "2026-08-19T21:39:31Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.derived-from.intent.pf.high-impact-actions-need-a-human",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "intent.pf.high-impact-actions-need-a-human",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.implemented-by.artifact.pf.pf.provenance.ledger.approve",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "artifact.pf.pf.provenance.ledger.approve",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.implemented-by.artifact.pf.pf.provenance.audit.report",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "artifact.pf.pf.provenance.audit.report",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.high-impact-actions-need-a-human.verified-by.evidence.pf.high-impact-actions-need-a-human.pf-provenance-verify",
+      "from": "constraint.pf.high-impact-actions-need-a-human",
+      "to": "evidence.pf.high-impact-actions-need-a-human.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:31Z",
+        "verified_at": "2026-08-19T21:39:31Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.derived-from.intent.pf.model-routing-is-declared",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "intent.pf.model-routing-is-declared",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.implemented-by.artifact.pf.pf.agents.base.AGENTS",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "artifact.pf.pf.agents.base.AGENTS",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.model-routing-is-declared.verified-by.evidence.pf.model-routing-is-declared.pf-provenance-verify",
+      "from": "constraint.pf.model-routing-is-declared",
+      "to": "evidence.pf.model-routing-is-declared.pf-provenance-verify",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:32Z",
+        "verified_at": "2026-08-19T21:39:32Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.derived-from.intent.pf.upstream-licences-are-reviewed",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "intent.pf.upstream-licences-are-reviewed",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.implemented-by.artifact.pf.pf.vendor.model.load-registry",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "artifact.pf.pf.vendor.model.load-registry",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.implemented-by.artifact.pf.pf.vendor.verify.verify",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "artifact.pf.pf.vendor.verify.verify",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.upstream-licences-are-reviewed.verified-by.evidence.pf.upstream-licences-are-reviewed.pf-check",
+      "from": "constraint.pf.upstream-licences-are-reviewed",
+      "to": "evidence.pf.upstream-licences-are-reviewed.pf-check",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:32Z",
+        "verified_at": "2026-08-19T21:39:32Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.derived-from.intent.pf.control-baseline-is-declared",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "intent.pf.control-baseline-is-declared",
+      "type": "derived_from",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "confidence": "high",
+        "method": "human_review"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.governed-by.policy.pf.data-platform",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "policy.pf.data-platform",
+      "type": "governed_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.implemented-by.artifact.pf.pf.air.coverage.assess",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "artifact.pf.pf.air.coverage.assess",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.implemented-by.artifact.pf.pf.air.register.render-register",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "artifact.pf.pf.air.register.render-register",
+      "type": "implemented_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:19Z",
+        "implemented_at": "2026-08-19T18:05:19Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.verified-by.evidence.pf.control-baseline-is-declared.pf-air-coverage",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "evidence.pf.control-baseline-is-declared.pf-air-coverage",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T21:39:32Z",
+        "verified_at": "2026-08-19T21:39:32Z"
+      }
+    },
+    {
+      "id": "rel.constraint.pf.control-baseline-is-declared.verified-by.evidence.pf.control-baseline-is-declared.governance-air-register-md",
+      "from": "constraint.pf.control-baseline-is-declared",
+      "to": "evidence.pf.control-baseline-is-declared.governance-air-register-md",
+      "type": "verified_by",
+      "metadata": {
+        "created_at": "2026-08-19T18:05:20Z",
+        "verified_at": "2026-08-19T18:05:20Z"
       }
     }
   ],

--- a/platform/src/pf/ontology/policy.yaml
+++ b/platform/src/pf/ontology/policy.yaml
@@ -129,6 +129,34 @@ policies:
     evidence: [pf tool recce config]
     controls: [AIR-DET-1, AIR-PREV-12]
 
+  - id: builds-record-observability
+    intent: >
+      A dbt build that leaves no queryable record cannot be triaged; failures
+      get diagnosed from whichever log happened to survive. Every build must
+      record its run and test results into the warehouse with history — for
+      every test framework at once — so "is this new, recurring, or flaky?"
+      is a query, not an archaeology dig.
+    applies_to: {artifact_glob: "**/transform/packages.yml"}
+    constraint: observability_recorded
+    severity: warning
+    enforced_by: [pf.tools.elementary:bootstrap_project, pf.tools.elementary:ensure_package]
+    evidence: [pf tool elementary report, loop-ledger.json]
+    controls: [AIR-DET-4, AIR-PREV-6]
+
+  - id: quality-floor-derived-from-ontology
+    intent: >
+      Hand-written test coverage decays to whichever models someone remembered.
+      The floor — an annotated mart is never empty, a declared identity
+      identifies — must be derived from the ontology roles, so coverage is a
+      function of annotation rather than of memory, and a wrong test is a wrong
+      role rather than a stale file.
+    applies_to: {artifact_glob: "**/transform/tests/expectations/**"}
+    constraint: tests_derived_from_roles
+    severity: warning
+    enforced_by: [pf.tools.expectations:write_tests, pf.tools.expectations:bootstrap_project]
+    evidence: [pf tool expectations run]
+    controls: [AIR-PREV-6, AIR-PREV-5]
+
   - id: secrets-never-in-context
     intent: >
       A credential placed in a prompt, a model file or a committed artefact is
@@ -297,6 +325,12 @@ evidence_kinds:
   - {id: "pf loop run pii-audit", produces: PII findings, durable: false}
   - {id: "pf tool recce run",    produces: data diff against baseline, durable: true}
   - {id: "pf tool recce config", produces: derived review checks, durable: true}
+  # The quality-stack pair. The report is durable because the tables it renders
+  # are — Elementary's history is append-only in the warehouse. The expectations
+  # run is a dbt test invocation whose verdicts land in that same history, so
+  # the command itself stores nothing.
+  - {id: "pf tool elementary report",  produces: observability report over recorded history, durable: true}
+  - {id: "pf tool expectations run",   produces: quality floor verdicts, durable: false}
   # Added with the agent-governance policies above. `pf provenance verify` is
   # durable because the thing it audits is: the ledger is append-only and
   # anchored, so re-running the audit next year reads the same records. The


### PR DESCRIPTION
Two policies close the intent → constraint → artifact → evidence chain: builds-record-observability (AIR-DET-4, AIR-PREV-6) and quality-floor-derived-from-ontology (AIR-PREV-6, AIR-PREV-5), each naming real enforcement in pf.tools.*. Second commit is the mechanical otop refresh (20 → 22 constraints per project).

Stack 6/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)