### PR TITLE
feat(targets): DuckLake, PostgreSQL and Iceberg-on-R2 as production warehouses

### DIFF
--- a/groups/acme/projects/acme-eu/transform/models/utils/metricflow_time_spine.sql
+++ b/groups/acme/projects/acme-eu/transform/models/utils/metricflow_time_spine.sql
@@ -1,5 +1,11 @@
--- Required by MetricFlow for time-based metrics (offset windows, cumulative).
--- Platform-standard: daily grain, 2020-2030.
+-- Required by MetricFlow for time-based metrics. Platform-standard daily grain.
+--
+-- dbt_utils.date_spine, not DuckDB's range() table function: this model builds
+-- on every target the project has, and range() exists only on DuckDB — on a
+-- Postgres prod it was the one scaffolded model that failed the build.
 {{ config(materialized='table') }}
-select cast(range as date) as date_day
-from range(date '2020-01-01', date '2030-01-01', interval 1 day)
+select cast(date_day as date) as date_day
+from ({{ dbt_utils.date_spine(
+    datepart="day",
+    start_date="cast('2020-01-01' as date)",
+    end_date="cast('2030-01-01' as date)") }}) as spine

--- a/groups/acme/projects/acme-us/transform/models/utils/metricflow_time_spine.sql
+++ b/groups/acme/projects/acme-us/transform/models/utils/metricflow_time_spine.sql
@@ -1,5 +1,11 @@
--- Required by MetricFlow for time-based metrics (offset windows, cumulative).
--- Platform-standard: daily grain, 2020-2030.
+-- Required by MetricFlow for time-based metrics. Platform-standard daily grain.
+--
+-- dbt_utils.date_spine, not DuckDB's range() table function: this model builds
+-- on every target the project has, and range() exists only on DuckDB — on a
+-- Postgres prod it was the one scaffolded model that failed the build.
 {{ config(materialized='table') }}
-select cast(range as date) as date_day
-from range(date '2020-01-01', date '2030-01-01', interval 1 day)
+select cast(date_day as date) as date_day
+from ({{ dbt_utils.date_spine(
+    datepart="day",
+    start_date="cast('2020-01-01' as date)",
+    end_date="cast('2030-01-01' as date)") }}) as spine

--- a/groups/globex/projects/globex-core/transform/models/utils/metricflow_time_spine.sql
+++ b/groups/globex/projects/globex-core/transform/models/utils/metricflow_time_spine.sql
@@ -1,4 +1,11 @@
 -- Required by MetricFlow for time-based metrics. Platform-standard daily grain.
+--
+-- dbt_utils.date_spine, not DuckDB's range() table function: this model builds
+-- on every target the project has, and range() exists only on DuckDB — on a
+-- Postgres prod it was the one scaffolded model that failed the build.
 {{ config(materialized='table') }}
-select cast(range as date) as date_day
-from range(date '2020-01-01', date '2030-01-01', interval 1 day)
+select cast(date_day as date) as date_day
+from ({{ dbt_utils.date_spine(
+    datepart="day",
+    start_date="cast('2020-01-01' as date)",
+    end_date="cast('2030-01-01' as date)") }}) as spine

--- a/groups/globex/projects/globex-eu/transform/models/utils/metricflow_time_spine.sql
+++ b/groups/globex/projects/globex-eu/transform/models/utils/metricflow_time_spine.sql
@@ -1,4 +1,11 @@
 -- Required by MetricFlow for time-based metrics. Platform-standard daily grain.
+--
+-- dbt_utils.date_spine, not DuckDB's range() table function: this model builds
+-- on every target the project has, and range() exists only on DuckDB — on a
+-- Postgres prod it was the one scaffolded model that failed the build.
 {{ config(materialized='table') }}
-select cast(range as date) as date_day
-from range(date '2020-01-01', date '2030-01-01', interval 1 day)
+select cast(date_day as date) as date_day
+from ({{ dbt_utils.date_spine(
+    datepart="day",
+    start_date="cast('2020-01-01' as date)",
+    end_date="cast('2030-01-01' as date)") }}) as spine

--- a/groups/zenith/projects/zenith-de/transform/models/utils/metricflow_time_spine.sql
+++ b/groups/zenith/projects/zenith-de/transform/models/utils/metricflow_time_spine.sql
@@ -1,4 +1,11 @@
 -- Required by MetricFlow for time-based metrics. Platform-standard daily grain.
+--
+-- dbt_utils.date_spine, not DuckDB's range() table function: this model builds
+-- on every target the project has, and range() exists only on DuckDB — on a
+-- Postgres prod it was the one scaffolded model that failed the build.
 {{ config(materialized='table') }}
-select cast(range as date) as date_day
-from range(date '2020-01-01', date '2030-01-01', interval 1 day)
+select cast(date_day as date) as date_day
+from ({{ dbt_utils.date_spine(
+    datepart="day",
+    start_date="cast('2020-01-01' as date)",
+    end_date="cast('2030-01-01' as date)") }}) as spine

--- a/groups/zenith/projects/zenith-uk/transform/models/utils/metricflow_time_spine.sql
+++ b/groups/zenith/projects/zenith-uk/transform/models/utils/metricflow_time_spine.sql
@@ -1,4 +1,11 @@
 -- Required by MetricFlow for time-based metrics. Platform-standard daily grain.
+--
+-- dbt_utils.date_spine, not DuckDB's range() table function: this model builds
+-- on every target the project has, and range() exists only on DuckDB — on a
+-- Postgres prod it was the one scaffolded model that failed the build.
 {{ config(materialized='table') }}
-select cast(range as date) as date_day
-from range(date '2020-01-01', date '2030-01-01', interval 1 day)
+select cast(date_day as date) as date_day
+from ({{ dbt_utils.date_spine(
+    datepart="day",
+    start_date="cast('2020-01-01' as date)",
+    end_date="cast('2030-01-01' as date)") }}) as spine

--- a/platform/src/pf/runtime/targets.py
+++ b/platform/src/pf/runtime/targets.py
@@ -295,6 +295,82 @@ WAREHOUSES: dict[str, ProductionWarehouse] = {
              "not catalogued; `om_type` is empty on purpose."),
         ),
     ),
+    "iceberg": ProductionWarehouse(
+        name="iceberg",
+        title="Apache Iceberg on Cloudflare R2",
+        adapter="dbt-duckdb",
+        output={
+            "type": "duckdb",
+            # Scratch only — every model lands in the attached Iceberg catalog;
+            # this is where seeds and run-scoped state live. Deliberately NOT
+            # `PF_DUCKDB_PATH`: bootstrap detects the scaffold placeholder by
+            # that path, and reusing it here would get an Iceberg project
+            # silently retrofitted back onto the default warehouse — the exact
+            # regression DuckLake hit via `type == "duckdb"`.
+            "path": "{{ env_var('PF_ICEBERG_SCRATCH', ':memory:') }}",
+            "extensions": "[iceberg, httpfs]",
+            # DuckDB's `iceberg` secret is the bearer token the REST catalog
+            # expects; the data files under the tables are reached through the
+            # catalog's credential vending, so no S3-style keys appear here.
+            "secrets": [
+                {
+                    "type": "iceberg",
+                    "token": "{{ env_var('R2_CATALOG_TOKEN') }}",
+                },
+            ],
+            # Renders as `ATTACH '<warehouse>' (TYPE iceberg, ENDPOINT ...)`.
+            # Both values are printed on the bucket's Data Catalog page:
+            # warehouse `<account_id>_<bucket>`, endpoint
+            # `https://catalog.cloudflarestorage.com/<account_id>/<bucket>`.
+            "attach": [
+                {
+                    "path": "{{ env_var('R2_CATALOG_WAREHOUSE') }}",
+                    "alias": "lake",
+                    "options": {
+                        "type": "iceberg",
+                        "endpoint": "{{ env_var('R2_CATALOG_ENDPOINT') }}",
+                    },
+                },
+            ],
+            # Build into the attached catalog, never the scratch database.
+            "database": "lake",
+            "schema": "{{ env_var('R2_CATALOG_NAMESPACE', 'analytics') }}",
+            # Every model is one optimistic-concurrency commit against the REST
+            # catalog; commits to *different* tables never conflict, so dbt's
+            # parallelism is safe — kept below the in-warehouse engines' 8
+            # because each commit is also an HTTP round-trip.
+            "threads": "{{ env_var('R2_ICEBERG_THREADS', '4') | int }}",
+        },
+        env=("R2_CATALOG_WAREHOUSE", "R2_CATALOG_ENDPOINT", "R2_CATALOG_TOKEN"),
+        auth_note=(
+            "`R2_CATALOG_TOKEN` is a Cloudflare R2 API token with Data Catalog "
+            "read/write and Object read/write on the bucket. DuckDB presents it "
+            "to the REST catalog as a bearer token via the `iceberg` secret; "
+            "reads and writes of the data files under the tables ride the "
+            "catalog's credential vending, so it is the only credential."
+        ),
+        caveats=(
+            ("Same engine and dialect as dev, so the `pf align` dialect gate "
+             "passes by construction, exactly as with DuckLake. What changes is "
+             "the table format: every model becomes an Iceberg table with "
+             "snapshot history, readable in place by any Iceberg engine — and "
+             "R2 charges no egress, so that external read is free."),
+            ("Writes need the `iceberg` extension of DuckDB ≥ 1.4 and cover "
+             "CREATE, CREATE OR REPLACE and INSERT — table materialisations "
+             "and `append` incrementals. UPDATE/DELETE/MERGE are not there "
+             "yet, so `merge` and `delete+insert` incremental models must "
+             "switch strategy before this target builds them."),
+            ("dbt schemas map to catalog namespaces (`analytics`, "
+             "`analytics_staging`, …), created on first build."),
+            ("Enable managed compaction on the catalog: a dbt rebuild is many "
+             "small commits, and compaction is what keeps scan performance "
+             "flat. Old snapshots are retained per the catalog's policy — a "
+             "rebuild is time-travelable, not free."),
+            ("OpenMetadata has an Iceberg REST connector, but the payload is "
+             "not wired here until it is verified against the vendored schema "
+             "— `om_type` is empty on purpose, like DuckLake's."),
+        ),
+    ),
     "clickhouse": ProductionWarehouse(
         name="clickhouse",
         title="ClickHouse Cloud",

--- a/platform/src/pf/runtime/targets.py
+++ b/platform/src/pf/runtime/targets.py
@@ -196,6 +196,105 @@ WAREHOUSES: dict[str, ProductionWarehouse] = {
             "database": "${REDSHIFT_DATABASE}",
         },
     ),
+    "postgres": ProductionWarehouse(
+        name="postgres",
+        title="PostgreSQL",
+        adapter="dbt-postgres",
+        output={
+            "type": "postgres",
+            "host": "{{ env_var('POSTGRES_HOST') }}",
+            "port": "{{ env_var('POSTGRES_PORT', '5432') | int }}",
+            "user": "{{ env_var('POSTGRES_USER') }}",
+            "password": "{{ env_var('POSTGRES_PASSWORD', '') }}",
+            "dbname": "{{ env_var('POSTGRES_DATABASE') }}",
+            "schema": "{{ env_var('POSTGRES_SCHEMA', 'analytics') }}",
+            # `prefer` connects plain locally and TLS where offered; managed
+            # providers (Neon, RDS) want an explicit `require`.
+            "sslmode": "{{ env_var('POSTGRES_SSLMODE', 'prefer') }}",
+            "threads": 8,
+        },
+        env=("POSTGRES_HOST", "POSTGRES_USER", "POSTGRES_DATABASE"),
+        auth_note=(
+            "Password auth via `POSTGRES_PASSWORD`; leaving it unset uses "
+            "whatever libpq can do without one (peer auth locally, `.pgpass`). "
+            "Against a managed provider also set `POSTGRES_SSLMODE=require`."
+        ),
+        caveats=(
+            ("Postgres is an OLTP engine serving OLAP here. It is the "
+             "right-sized production target up to tens of GB of marts; beyond "
+             "that, vacuum pressure and sequential scans become the pipeline's "
+             "problem and a columnar target earns its keep."),
+            ("Unquoted identifiers fold to lower case, like Redshift — a model "
+             "relying on a quoted mixed-case column resolves differently here "
+             "than on DuckDB."),
+            ("The whole quality stack runs natively on this target: "
+             "dbt-expectations and the Elementary package both list Postgres "
+             "support, and the `edr` CLI ships a `postgres` extra."),
+        ),
+        om_type="Postgres",
+        om_connection={
+            "type": "Postgres",
+            "hostPort": "${POSTGRES_HOST}:${POSTGRES_PORT}",
+            "username": "${POSTGRES_USER}",
+            "authType": {"password": "${POSTGRES_PASSWORD}"},
+            "database": "${POSTGRES_DATABASE}",
+        },
+    ),
+    "ducklake": ProductionWarehouse(
+        name="ducklake",
+        title="DuckLake",
+        adapter="dbt-duckdb",
+        output={
+            "type": "duckdb",
+            # DuckDB opens a DuckLake catalog directly from a `ducklake:` path:
+            # a metadata catalog (file or server) plus parquet data files. The
+            # value is the *metadata* location — a `.ducklake` file for a
+            # single-writer lake, or `postgres:dbname=... host=...` for a
+            # multi-writer one. Where the parquet lands (DATA_PATH) is stored
+            # in the metadata when the lake is first created, so it is not
+            # repeated here — see the generated docs.
+            "path": "ducklake:{{ env_var('DUCKLAKE_METADATA') }}",
+            "schema": "{{ env_var('DUCKLAKE_SCHEMA', 'analytics') }}",
+            # A literal string, not a list, so it renders as flow YAML the same
+            # way the dev target writes it. httpfs rides along for lakes whose
+            # DATA_PATH is object storage.
+            "extensions": "[ducklake, httpfs]",
+            # One thread is the correct default, not a timid one. Every dbt
+            # model is DDL, DuckLake runs each cursor as its own catalog
+            # transaction, and a file-backed catalog resolves concurrent DDL by
+            # failing one side — measured here as 3–9 models flaking per
+            # 35-model build at dbt's usual 8 threads, and 35/35 green at one.
+            # A Postgres-backed catalog serializes properly; raise the var
+            # there, not in this file.
+            "threads": "{{ env_var('DUCKLAKE_THREADS', '1') | int }}",
+        },
+        env=("DUCKLAKE_METADATA",),
+        auth_note=(
+            "`DUCKLAKE_METADATA` is the catalog: a path like "
+            "`/lake/analytics.ducklake` (single writer), or a connection string "
+            "like `postgres:dbname=lake host=...` (concurrent writers; DuckDB "
+            "autoloads the postgres extension). Object-storage DATA_PATHs "
+            "authenticate through DuckDB secrets or the standard AWS/GCS "
+            "environment variables via httpfs — never a literal here."
+        ),
+        caveats=(
+            ("Same engine and dialect as dev, so the `pf align` dialect gate "
+             "passes by construction — this is the one production target with "
+             "zero portability distance from the laptop build."),
+            ("The parquet DATA_PATH is fixed when the lake is first created "
+             "(`ATTACH 'ducklake:...' (DATA_PATH 's3://...')`, once, by an "
+             "operator). Connecting afterwards reads it from the metadata; "
+             "moving it is a data migration, not a config change. With no "
+             "DATA_PATH given, files land in `<metadata>.files/` beside the "
+             "catalog."),
+            ("A `.ducklake` file catalog resolves concurrent DDL by failing "
+             "one side, and every dbt model is DDL — so `threads` defaults to "
+             "1 and the build is serial. With the metadata in Postgres, set "
+             "`DUCKLAKE_THREADS` up; with a file catalog, leave it."),
+            ("OpenMetadata has no DuckLake connector yet, so this target is "
+             "not catalogued; `om_type` is empty on purpose."),
+        ),
+    ),
     "clickhouse": ProductionWarehouse(
         name="clickhouse",
         title="ClickHouse Cloud",
@@ -226,6 +325,12 @@ WAREHOUSES: dict[str, ProductionWarehouse] = {
             ("ClickHouse calls a schema a database. `schema:` above is the "
              "ClickHouse database, which is why there is no separate "
              "`database` key."),
+            ("Quality stack, honestly: the Elementary package and `edr` CLI "
+             "both ship ClickHouse support (extra `clickhouse`), but "
+             "dbt-expectations depends on dbt_date, which does not declare "
+             "this adapter — the generated floor (row counts, uniqueness, "
+             "not-null) is dialect-safe, while date-windowed expectations "
+             "added by hand may error at runtime here."),
         ),
         om_type="Clickhouse",
         om_connection={

--- a/platform/src/pf/scaffold/bootstrap.py
+++ b/platform/src/pf/scaffold/bootstrap.py
@@ -376,7 +376,6 @@ def _dbt_wiring(root: Path, group: str, project: str) -> StepResult:
         PROJECT_TARGETS,
         render_target,
         replace_target,
-        target_type,
     )
 
     d = _pdir(root, group, project)
@@ -435,22 +434,34 @@ def _dbt_wiring(root: Path, group: str, project: str) -> StepResult:
         # succeeds, writes nothing anyone can see, and reports success. Seven of
         # eight projects were in that state.
         #
-        # Guarded on the *current* type, not on whether we have written here
-        # before. Anything already pointing at a real engine — Snowflake set by
-        # hand, BigQuery from `pf capability-add` — is left exactly alone, so
-        # this can never take a project off its own warehouse. And only the
-        # `prod` block is touched: `replace_target` is text-level precisely so
+        # Guarded on the placeholder's *path*, not on the adapter type. The type
+        # alone cannot tell the scaffold's local file from a deliberate DuckLake
+        # target — both are `type: duckdb` — and guarding on type is how
+        # `pf capability-add ducklake` got silently reverted to Snowflake by the
+        # very next bootstrap. Only the `PF_DUCKDB_PATH` local file is the
+        # placeholder; anything else — Snowflake set by hand, BigQuery from
+        # `pf capability-add`, a `ducklake:` catalog — is a decision, and this
+        # step must never take a project off its own warehouse. Only the `prod`
+        # block is touched: `replace_target` is text-level precisely so
         # hand-added keys on the DuckDB targets beside it survive.
         wh = default_warehouse()
         if wh is not None and outputs:
-            current = target_type(text, "prod")
-            if current == "duckdb":
+            prod = outputs.get("prod") or {}
+            placeholder = (prod.get("type") == "duckdb"
+                           and "PF_DUCKDB_PATH" in str(prod.get("path", "")))
+            if placeholder:
                 new_text, swapped = replace_target(text, "prod", wh.output)
                 if swapped:
                     profiles.write_text(new_text)
                     changed.append(f"prod -> {wh.name}")
-            elif current and current != wh.name:
-                changed.append(f"prod already on {current}, left alone")
+            elif prod:
+                # Name the engine the way an operator would. DuckLake reports as
+                # itself, not as the `duckdb` adapter that happens to drive it.
+                engine = ("ducklake"
+                          if str(prod.get("path", "")).startswith("ducklake:")
+                          else str(prod.get("type") or "?"))
+                if engine != wh.name:
+                    changed.append(f"prod already on {engine}, left alone")
 
     if not changed:
         return StepResult("dbt wiring", "ok", "macro-paths and targets current")

--- a/platform/src/pf/scaffold/generator.py
+++ b/platform/src/pf/scaffold/generator.py
@@ -327,21 +327,21 @@ PROJECT_SETTINGS = """\
     "platform": { "source": { "source": "../../../../platform" } },
     "{{group}}": { "source": { "source": "../.." } }
   },
-  "enabledPlugins": [
-    "platform-init@platform",
-    "dlt-ingest@platform",
-    "dlt-quality@platform",
-    "dlt-explore@platform",
-    "duckdb-ops@platform",
-    "dbt-modeling@platform",
-    "dbt-semantic@platform",
-    "dbt-testing@platform",
-    "dbt-govern@platform",
-    "dagster-orchestrate@platform",
-    "python-standards@platform",
-    "power-tools@platform",
-    "{{group}}-group@{{group}}"
-  ],
+  "enabledPlugins": {
+    "platform-init@platform": true,
+    "dlt-ingest@platform": true,
+    "dlt-quality@platform": true,
+    "dlt-explore@platform": true,
+    "duckdb-ops@platform": true,
+    "dbt-modeling@platform": true,
+    "dbt-semantic@platform": true,
+    "dbt-testing@platform": true,
+    "dbt-govern@platform": true,
+    "dagster-orchestrate@platform": true,
+    "python-standards@platform": true,
+    "power-tools@platform": true,
+    "{{group}}-group@{{group}}": true
+  },
   "permissions": {
     "deny": [{{deny_siblings}}, "Read(../../../*/projects/**)",
       "Read(./.env)", "Read(./.env.*)",
@@ -487,21 +487,48 @@ PROJECT_TARGETS: dict[str, dict[str, object]] = {
 
 def render_target(name: str, spec: dict[str, object], indent: str = "    ") -> str:
     """One dbt output block. The unit `pf align` checks and bootstrap appends."""
-    lines = [f"{indent}{name}:"]
+    return "\n".join([f"{indent}{name}:", *_render_map(spec, indent + "  ")]) + "\n"
+
+
+def _render_scalar(value: object) -> object:
+    if isinstance(value, bool):
+        # Before booleans appeared here every value was a string or an int,
+        # and Python's `True` reached the file verbatim. YAML 1.1 does read
+        # it as a boolean, so nothing was broken — but a generated file that
+        # nobody can copy an idiom from is a generated file people edit by
+        # hand, and `secure: True` beside `threads: 8` reads as a mistake.
+        return "true" if value else "false"
+    if isinstance(value, str) and "{{" in value:
+        return f'"{value}"'
+    return value
+
+
+def _render_map(spec: dict[str, object], indent: str) -> list[str]:
+    """Block-YAML lines for one mapping, nesting two spaces per level.
+
+    Flat targets render exactly as they always have. The nesting exists for
+    catalog-attached targets — dbt-duckdb's `secrets:` and `attach:` are lists
+    of mappings, and a list item puts its first key on the `- ` line the way
+    every hand-written dbt profile does, so the generated block is one a person
+    can copy an idiom from.
+    """
+    lines: list[str] = []
     for key, value in spec.items():
-        if isinstance(value, bool):
-            # Before booleans appeared here every value was a string or an int,
-            # and Python's `True` reached the file verbatim. YAML 1.1 does read
-            # it as a boolean, so nothing was broken — but a generated file that
-            # nobody can copy an idiom from is a generated file people edit by
-            # hand, and `secure: True` beside `threads: 8` reads as a mistake.
-            rendered: object = "true" if value else "false"
-        elif isinstance(value, str) and "{{" in value:
-            rendered = f'"{value}"'
+        if isinstance(value, dict):
+            lines.append(f"{indent}{key}:")
+            lines.extend(_render_map(value, indent + "  "))
+        elif isinstance(value, (list, tuple)):
+            lines.append(f"{indent}{key}:")
+            for item in value:
+                if isinstance(item, dict):
+                    entry = _render_map(item, indent + "    ")
+                    lines.append(f"{indent}  - {entry[0].lstrip()}")
+                    lines.extend(entry[1:])
+                else:
+                    lines.append(f"{indent}  - {_render_scalar(item)}")
         else:
-            rendered = value
-        lines.append(f"{indent}  {key}: {rendered}")
-    return "\n".join(lines) + "\n"
+            lines.append(f"{indent}{key}: {_render_scalar(value)}")
+    return lines
 
 
 def replace_target(text: str, name: str, spec: dict[str, object]) -> tuple[str, bool]:
@@ -699,9 +726,16 @@ compound instead of accumulating notes nobody reads.
 
 TIME_SPINE = """\
 -- Required by MetricFlow for time-based metrics. Platform-standard daily grain.
+--
+-- dbt_utils.date_spine, not DuckDB's range() table function: this model builds
+-- on every target the project has, and range() exists only on DuckDB — on a
+-- Postgres prod it was the one scaffolded model that failed the build.
 {{ config(materialized='table') }}
-select cast(range as date) as date_day
-from range(date '2020-01-01', date '2030-01-01', interval 1 day)
+select cast(date_day as date) as date_day
+from ({{ dbt_utils.date_spine(
+    datepart="day",
+    start_date="cast('2020-01-01' as date)",
+    end_date="cast('2030-01-01' as date)") }}) as spine
 """
 
 TIME_SPINE_YML = """\

--- a/platform/tests/test_targets.py
+++ b/platform/tests/test_targets.py
@@ -1,0 +1,164 @@
+"""Production warehouse registry — the invariants its docstring promises.
+
+"Adding ClickHouse is one entry and no other edit" is a claim about seams, and
+claims about seams rot silently: the entry gets added, the pyproject extra gets
+forgotten, and `uv sync --extra <name>` — the exact command the generated docs
+tell the operator to run — fails a quarter later. These tests make the
+registration mechanical.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+import yaml
+from pf.capabilities import CAPABILITIES
+from pf.runtime.targets import WAREHOUSES, default_warehouse
+from pf.scaffold.generator import PROJECT_TARGETS, render_profiles
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------- registry ----
+def test_exactly_one_warehouse_is_the_default() -> None:
+    defaults = [w.name for w in WAREHOUSES.values() if w.default_enabled]
+    assert defaults == ["snowflake"]
+    assert default_warehouse().name == "snowflake"
+
+
+@pytest.mark.parametrize("name", sorted(WAREHOUSES), ids=str)
+def test_every_warehouse_registers_a_capability(name: str) -> None:
+    cap = CAPABILITIES[name]
+    assert set(cap.files) == {"transform/profiles.yml", f"docs/{name}.md"}
+    assert cap.warehouse == name
+
+
+@pytest.mark.parametrize("name", sorted(WAREHOUSES), ids=str)
+def test_every_warehouse_has_its_uv_extra(name: str) -> None:
+    """The generated README says `uv sync --extra <name>`; this is what keeps
+    that sentence true for every entry, including the next one."""
+    doc = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    extras = doc["project"]["optional-dependencies"]
+    assert name in extras, f"pyproject has no `{name}` extra"
+    adapter = WAREHOUSES[name].adapter
+    assert any(adapter in dep for dep in extras[name]), (
+        f"extra `{name}` does not install {adapter}")
+
+
+@pytest.mark.parametrize("name", sorted(WAREHOUSES), ids=str)
+def test_a_warehouse_swaps_prod_and_only_prod(name: str) -> None:
+    """The seam's whole safety argument: a capability that could also move
+    `dev` is a capability that breaks the laptop build."""
+    text = render_profiles("demo", {**PROJECT_TARGETS, "prod": WAREHOUSES[name].output})
+    doc = yaml.safe_load(text)["demo"]["outputs"]
+    for target in ("dev", "ci", "base"):
+        assert doc[target]["type"] == "duckdb"
+        assert doc[target]["path"] == "{{ env_var('PF_DUCKDB_PATH') }}"
+
+
+# ---------------------------------------------------------------- ducklake ----
+def test_ducklake_prod_is_a_lakehouse_catalog() -> None:
+    text = render_profiles("demo", {**PROJECT_TARGETS, "prod": WAREHOUSES["ducklake"].output})
+    prod = yaml.safe_load(text)["demo"]["outputs"]["prod"]
+    # Same engine as dev — that is the target's entire portability story —
+    # pointed at a `ducklake:` catalog instead of a local file.
+    assert prod["type"] == "duckdb"
+    assert prod["path"] == "ducklake:{{ env_var('DUCKLAKE_METADATA') }}"
+    # Flow-style list, parsed as a real list: the extension must autoload
+    # before dbt's first statement touches the catalog.
+    assert prod["extensions"] == ["ducklake", "httpfs"]
+    # The metadata location is the one credential-shaped requirement.
+    assert WAREHOUSES["ducklake"].env == ("DUCKLAKE_METADATA",)
+    # dbt-duckdb ships in the dev group already; the extra exists for
+    # production installs, not for laptops.
+    assert WAREHOUSES["ducklake"].adapter == "dbt-duckdb"
+
+
+# ---------------------------------------------------------------- iceberg ----
+def test_iceberg_prod_is_an_attached_r2_catalog() -> None:
+    text = render_profiles("demo", {**PROJECT_TARGETS, "prod": WAREHOUSES["iceberg"].output})
+    prod = yaml.safe_load(text)["demo"]["outputs"]["prod"]
+    # Same engine as dev — the DuckLake portability story again — but the
+    # warehouse is an ATTACHed Iceberg REST catalog, never the local file.
+    assert prod["type"] == "duckdb"
+    # Bootstrap detects the scaffold placeholder by PF_DUCKDB_PATH; an iceberg
+    # prod carrying that path would be silently reverted to the default.
+    assert "PF_DUCKDB_PATH" not in str(prod["path"])
+    assert prod["extensions"] == ["iceberg", "httpfs"]
+    # The nested blocks survive the renderer as real YAML: one catalog secret,
+    # one attach whose alias the `database:` key builds into.
+    [secret] = prod["secrets"]
+    assert secret["type"] == "iceberg"
+    [attach] = prod["attach"]
+    assert attach["alias"] == "lake"
+    assert attach["options"]["type"] == "iceberg"
+    assert prod["database"] == "lake"
+    assert WAREHOUSES["iceberg"].env == (
+        "R2_CATALOG_WAREHOUSE", "R2_CATALOG_ENDPOINT", "R2_CATALOG_TOKEN")
+    assert WAREHOUSES["iceberg"].adapter == "dbt-duckdb"
+
+
+def test_replace_target_round_trips_nested_blocks() -> None:
+    """`replace_target` is text-level and indentation-bounded; a nested attach
+    block is the first target whose body is deeper than two levels, so this is
+    the shape that would break it."""
+    from pf.scaffold.generator import replace_target
+
+    text = render_profiles("demo", PROJECT_TARGETS)
+    swapped, changed = replace_target(text, "prod", WAREHOUSES["iceberg"].output)
+    assert changed
+    prod = yaml.safe_load(swapped)["demo"]["outputs"]["prod"]
+    assert prod["attach"][0]["options"]["endpoint"] == (
+        "{{ env_var('R2_CATALOG_ENDPOINT') }}")
+    # The other targets were not touched, and a second replace is a no-op.
+    assert yaml.safe_load(swapped)["demo"]["outputs"]["dev"]["type"] == "duckdb"
+    _, changed_again = replace_target(swapped, "prod", WAREHOUSES["iceberg"].output)
+    assert not changed_again
+
+
+# ---------------------------------------------------------------- wiring ----
+def test_bootstrap_never_takes_a_project_off_ducklake(tmp_path: Path) -> None:
+    """The regression that surfaced the moment DuckLake existed: `_dbt_wiring`
+    retrofits the scaffold's placeholder prod onto the default warehouse, and
+    it used to detect the placeholder by `type == "duckdb"` — which DuckLake
+    also is. Switching a project to DuckLake was silently reverted to Snowflake
+    by the very next bootstrap. The placeholder is the `PF_DUCKDB_PATH` local
+    file, nothing else."""
+    from pf.scaffold.bootstrap import _dbt_wiring
+    from pf.scaffold.generator import PROJECT_TARGETS
+
+    d = tmp_path / "groups" / "g" / "projects" / "p" / "transform"
+    d.mkdir(parents=True)
+    (d / "dbt_project.yml").write_text("name: demo\n")
+
+    # A deliberate DuckLake prod survives.
+    (d / "profiles.yml").write_text(render_profiles(
+        "demo", {**PROJECT_TARGETS, "prod": WAREHOUSES["ducklake"].output}))
+    _dbt_wiring(tmp_path, "g", "p")
+    prod = yaml.safe_load((d / "profiles.yml").read_text())["demo"]["outputs"]["prod"]
+    assert prod["path"].startswith("ducklake:"), "bootstrap reverted DuckLake to the default"
+
+    # The scaffold placeholder is still retrofitted onto the default warehouse.
+    (d / "profiles.yml").write_text(render_profiles("demo", PROJECT_TARGETS))
+    _dbt_wiring(tmp_path, "g", "p")
+    prod = yaml.safe_load((d / "profiles.yml").read_text())["demo"]["outputs"]["prod"]
+    assert prod["type"] == "snowflake"
+
+
+def test_bootstrap_never_takes_a_project_off_iceberg(tmp_path: Path) -> None:
+    """Iceberg is `type: duckdb` like the placeholder and DuckLake, but its
+    scratch path is not `PF_DUCKDB_PATH` — which is the whole reason the
+    placeholder guard keys on that path. This pins it."""
+    from pf.scaffold.bootstrap import _dbt_wiring
+
+    d = tmp_path / "groups" / "g" / "projects" / "p" / "transform"
+    d.mkdir(parents=True)
+    (d / "dbt_project.yml").write_text("name: demo\n")
+    (d / "profiles.yml").write_text(render_profiles(
+        "demo", {**PROJECT_TARGETS, "prod": WAREHOUSES["iceberg"].output}))
+    _dbt_wiring(tmp_path, "g", "p")
+    prod = yaml.safe_load((d / "profiles.yml").read_text())["demo"]["outputs"]["prod"]
+    assert prod["database"] == "lake", "bootstrap reverted Iceberg to the default"
+    assert prod["attach"][0]["options"]["type"] == "iceberg"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,12 @@ snowflake = ["dbt-snowflake>=1.9,<2"]
 bigquery = ["dbt-bigquery>=1.9,<2"]
 redshift = ["dbt-redshift>=1.9,<2"]
 clickhouse = ["dbt-clickhouse>=1.8,<2"]
+postgres = ["dbt-postgres>=1.9,<2"]
+# DuckLake is DuckDB pointed at a lakehouse catalog (`ducklake:` path), so its
+# adapter is dbt-duckdb — already in the dev group. The extra exists so a
+# production install that syncs nothing but its warehouse extra still works,
+# and so "one extra per `pf.runtime.targets` entry" stays true.
+ducklake = ["dbt-duckdb>=1.9,<2"]
 wren = [
     "wrenai>=0.13,<1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,11 @@ postgres = ["dbt-postgres>=1.9,<2"]
 # production install that syncs nothing but its warehouse extra still works,
 # and so "one extra per `pf.runtime.targets` entry" stays true.
 ducklake = ["dbt-duckdb>=1.9,<2"]
+# Iceberg on Cloudflare R2 is DuckDB attached to R2 Data Catalog's REST
+# endpoint (`ATTACH ... TYPE iceberg`), so its adapter is dbt-duckdb too —
+# same reasoning as ducklake above. Writing Iceberg needs the extension that
+# ships with DuckDB >= 1.4; the profile's `extensions:` loads it.
+iceberg = ["dbt-duckdb>=1.9,<2"]
 wren = [
     "wrenai>=0.13,<1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -681,6 +681,12 @@ bigquery = [
 clickhouse = [
     { name = "dbt-clickhouse" },
 ]
+ducklake = [
+    { name = "dbt-duckdb" },
+]
+postgres = [
+    { name = "dbt-postgres" },
+]
 recce = [
     { name = "recce" },
 ]
@@ -717,6 +723,8 @@ dev = [
 requires-dist = [
     { name = "dbt-bigquery", marker = "extra == 'bigquery'", specifier = ">=1.9,<2" },
     { name = "dbt-clickhouse", marker = "extra == 'clickhouse'", specifier = ">=1.8,<2" },
+    { name = "dbt-duckdb", marker = "extra == 'ducklake'", specifier = ">=1.9,<2" },
+    { name = "dbt-postgres", marker = "extra == 'postgres'", specifier = ">=1.9,<2" },
     { name = "dbt-redshift", marker = "extra == 'redshift'", specifier = ">=1.9,<2" },
     { name = "dbt-snowflake", marker = "extra == 'snowflake'", specifier = ">=1.9,<2" },
     { name = "pf", editable = "platform" },
@@ -725,7 +733,7 @@ requires-dist = [
     { name = "recce", marker = "extra == 'recce'", specifier = ">=1.60,<2" },
     { name = "wrenai", marker = "extra == 'wren'", specifier = ">=0.13,<1" },
 ]
-provides-extras = ["recce", "artifacts", "stack", "snowflake", "bigquery", "redshift", "clickhouse", "wren"]
+provides-extras = ["recce", "artifacts", "stack", "snowflake", "bigquery", "redshift", "clickhouse", "postgres", "ducklake", "wren"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Four commits: DuckLake + Postgres entries (with the registry test suite that makes warehouse registration mechanical — capability, uv extra, prod-only swap); the placeholder-detection fix (`type == duckdb` reverted a DuckLake prod to Snowflake on the next bootstrap — now detected by the PF_DUCKDB_PATH path); the portable time spine (DuckDB's `range()` was the one scaffolded model failing a real Postgres build — now dbt_utils.date_spine); and the Iceberg-on-R2 entry with the lock refresh.

Proven live: DuckLake 35/35 ×2 with recording inside the catalog; Postgres 35/35 with 30 elementary tables and 99 recorded results. DuckLake ships `threads: 1` by default — measured 3–9/35 models flaking at 8 threads on a file catalog, 35/35 at one.

Stack 7/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)