### PR TITLE
fix(settings): enabledPlugins as a record, not a list

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,10 +8,10 @@
       }
     }
   },
-  "enabledPlugins": [
-    "platform-init@platform",
-    "power-tools@platform"
-  ],
+  "enabledPlugins": {
+    "platform-init@platform": true,
+    "power-tools@platform": true
+  },
   "permissions": {
     "deny": [
       "Read(./.env)",

--- a/platform/src/pf/capabilities.py
+++ b/platform/src/pf/capabilities.py
@@ -325,7 +325,7 @@ def warehouse_capability(wh: ProductionWarehouse) -> Capability:
         },
         settings={
             "permissions": {"allow": ["Bash(pf align:*)", "Bash(pf dialect:*)"]},
-            **({"enabledPlugins": list(wh.plugins)} if wh.plugins else {}),
+            **({"enabledPlugins": dict.fromkeys(wh.plugins, True)} if wh.plugins else {}),
         },
         env=wh.env,
         warehouse=wh.name,
@@ -496,7 +496,7 @@ CAPABILITIES: dict[str, Capability] = {
                 "Bash(npm run dev:*)", "Bash(npm run build:*)",
                 "Bash(npm run sources:*)",
             ]},
-            "enabledPlugins": ["evidence-bi@platform"],
+            "enabledPlugins": {"evidence-bi@platform": True},
         },
         gate={
             # Generated artefacts and build output. Editing a compiled metric
@@ -601,6 +601,9 @@ def apply(cap: Capability, root: Path, project_dir: Path,
         settings_path = project_dir / ".claude" / "settings.json"
         if settings_path.exists():
             settings = json.loads(settings_path.read_text())
+            if isinstance(settings.get("enabledPlugins"), list):
+                # Legacy scaffold form; Claude Code expects a record.
+                settings["enabledPlugins"] = dict.fromkeys(settings["enabledPlugins"], True)
             _merge(settings, cap.settings)
             settings_path.write_text(json.dumps(settings, indent=2) + "\n")
             written.append(settings_path)


### PR DESCRIPTION
Claude Code expects a mapping of plugin name to flag; the scaffold emitted a list. Capabilities now contribute records, apply coerces a legacy list in place, and the workspace settings move over.

Stack 9/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)