### PR TITLE
feat(jaffle-shop): elementary anomaly monitors on the core marts

### DIFF
--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/customers.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/customers.yml
@@ -2,10 +2,21 @@ models:
 - name: customers
   description: Customer overview data mart, offering key details for each unique customer. One row per
     customer.
+  # Elementary monitors (jaffle-shop-goes-online pattern): the new/returning
+  # mix drifting is a question no fixed rule can ask.
+  config:
+    elementary:
+      timestamp_column: first_ordered_at
   data_tests:
   - dbt_utils.expression_is_true:
       arguments:
         expression: lifetime_spend_pretax + lifetime_tax_paid = lifetime_spend
+  - elementary.dimension_anomalies:
+      arguments:
+        dimensions:
+        - customer_type
+      config:
+        severity: warn
   columns:
   - name: customer_id
     description: The unique key of the orders mart.
@@ -26,6 +37,13 @@ models:
     description: The sum of all the tax portion of every order a customer has placed.
   - name: lifetime_spend
     description: The sum of all the order totals (including tax) that a customer has ever placed.
+    data_tests:
+    - elementary.column_anomalies:
+        arguments:
+          column_anomalies:
+          - zero_count
+        config:
+          severity: warn
   - name: customer_type
     description: Options are 'new' or 'returning', indicating if a customer has ordered more than once
       or has only placed their first order to date.

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/order_items.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/order_items.yml
@@ -1,5 +1,11 @@
 models:
 - name: order_items
+  # Junction table other models and unit tests depend on — a schema change
+  # here breaks silently downstream, which is exactly what this watches for.
+  data_tests:
+  - elementary.schema_changes:
+      config:
+        severity: warn
   columns:
   - name: order_item_id
     data_tests:

--- a/groups/jaffle/projects/jaffle-shop/transform/models/marts/orders.yml
+++ b/groups/jaffle/projects/jaffle-shop/transform/models/marts/orders.yml
@@ -2,6 +2,12 @@ models:
 - name: orders
   description: Order overview data mart, offering key details for each order inlcluding if it's a customer's
     first order and a food vs. drink item breakdown. One row per order.
+  # Elementary monitors, after the jaffle-shop-goes-online reference use case:
+  # rules assert what must hold; these learn a baseline and flag departures.
+  # See the `elementary-observe: add-anomaly-tests` skill.
+  config:
+    elementary:
+      timestamp_column: ordered_at
   data_tests:
   - dbt_utils.expression_is_true:
       arguments:
@@ -9,6 +15,16 @@ models:
   - dbt_utils.expression_is_true:
       arguments:
         expression: order_total = subtotal + tax_paid
+  - elementary.volume_anomalies:
+      config:
+        severity: warn
+  - elementary.dimension_anomalies:
+      arguments:
+        dimensions:
+        - is_food_order
+        - is_drink_order
+      config:
+        severity: warn
   columns:
   - name: order_id
     description: The unique key of the orders mart.
@@ -24,6 +40,14 @@ models:
           field: customer_id
   - name: order_total
     description: The total amount of the order in USD including tax.
+    data_tests:
+    - elementary.column_anomalies:
+        arguments:
+          column_anomalies:
+          - zero_count
+          - zero_percent
+        config:
+          severity: warn
   - name: ordered_at
     description: The timestamp the order was placed at.
   - name: order_cost


### PR DESCRIPTION
The worked example the elementary-observe skills reference, after Elementary's jaffle-shop-goes-online demo: volume + dimension + column anomalies on orders and customers, schema_changes on order_items, all severity warn. Verified live: 45/45 build with all six monitors running and recording.

Stack 11/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)