### PR TITLE
fix(artifacts): the endpoint moves to environment-only

### DIFF
--- a/docs/ARTIFACTS.md
+++ b/docs/ARTIFACTS.md
@@ -70,16 +70,17 @@ branch's.
 
 | | Secret? | Where it lives |
 |---|---|---|
-| Endpoint (`https://<account-id>.r2.cloudflarestorage.com`) | **No** | committed default in `pf/artifacts.py` |
-| Bucket (`data-platform`) | **No** | committed default |
+| Endpoint (`https://<account-id>.r2.cloudflarestorage.com`) | **No** | `PF_ARTIFACTS_ENDPOINT`, environment only |
+| Bucket (`data-platform`) | **No** | committed default, `PF_ARTIFACTS_BUCKET` overrides |
 | Access Key ID | **Yes** | environment only |
 | Secret Access Key | **Yes** | environment only |
 
 The account id inside the endpoint is not a credential. Every S3 client needs
 it, it appears in every request URL, and it grants nothing on its own — the same
-way an AWS account number is not a secret. It is committed so `pf` works with no
-configuration. Override it with `PF_ARTIFACTS_ENDPOINT` / `PF_ARTIFACTS_BUCKET`
-for a fork or a second environment.
+way an AWS account number is not a secret. It still lives in the environment
+rather than in code: it identifies whose infrastructure this is, and an
+open-source checkout should not ship anyone's. Each environment — laptop, CI,
+fork — sets `PF_ARTIFACTS_ENDPOINT` beside the two keys.
 
 The two keys are credentials and are read **from the environment only**. No
 `pf` command writes them to a file, and none is written into a generated file.

--- a/platform/src/pf/artifacts.py
+++ b/platform/src/pf/artifacts.py
@@ -58,9 +58,11 @@ must set the `PF_` pair, or the AWS fallback will point this at the wrong
 endpoint's credentials and every call will 403.
 
 The endpoint and bucket are **not** credentials — an R2 endpoint carries the
-account id, which every client needs and no client can act on alone — so they
-are committed as defaults below and overridable by env for a fork or a second
-environment.
+account id, which every client needs and no client can act on alone. The
+bucket name is a committed default anyway; the endpoint is not, because the
+account id inside it identifies whose infrastructure this is, and an
+open-source checkout should not ship anyone's. It comes from the environment
+like the keys do.
 """
 
 from __future__ import annotations
@@ -71,9 +73,10 @@ import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 
-# The bucket this platform publishes to. Overridable, so a fork or a staging
-# environment is two env vars rather than a patch.
-DEFAULT_ENDPOINT = "https://3138e619a0287a5f6e9f343aa3d0b9a1.r2.cloudflarestorage.com"
+# The bucket this platform publishes to. The name is a committed default —
+# it identifies nothing outside this repo. The endpoint has no default on
+# purpose: it carries the account id, so each environment sets its own via
+# PF_ARTIFACTS_ENDPOINT.
 DEFAULT_BUCKET = "data-platform"
 
 # R2 accepts exactly this region and rejects a real AWS one. It is not a
@@ -89,9 +92,10 @@ SECRET_VARS = ("PF_ARTIFACTS_SECRET_ACCESS_KEY", "R2_SECRET_ACCESS_KEY",
 #: What to tell a caller that has no credentials. One string, so the CLI, the
 #: recce integration and the UI all say the same thing.
 SETUP_HINT = (
-    "artefact store not configured — set PF_ARTIFACTS_ACCESS_KEY_ID and "
-    "PF_ARTIFACTS_SECRET_ACCESS_KEY (an R2 API token with Object Read & Write "
-    "on the bucket). See docs/ARTIFACTS.md."
+    "artefact store not configured — set PF_ARTIFACTS_ENDPOINT "
+    "(https://<account-id>.r2.cloudflarestorage.com), "
+    "PF_ARTIFACTS_ACCESS_KEY_ID and PF_ARTIFACTS_SECRET_ACCESS_KEY (an R2 API "
+    "token with Object Read & Write on the bucket). See docs/ARTIFACTS.md."
 )
 
 
@@ -205,10 +209,11 @@ class Store:
         talk to the bucket call `required()` instead.
         """
         key_id, secret = _first_env(KEY_ID_VARS), _first_env(SECRET_VARS)
-        if not (key_id and secret):
+        endpoint = os.environ.get("PF_ARTIFACTS_ENDPOINT", "")
+        if not (key_id and secret and endpoint):
             return None
         return cls(
-            endpoint=os.environ.get("PF_ARTIFACTS_ENDPOINT") or DEFAULT_ENDPOINT,
+            endpoint=endpoint,
             bucket=os.environ.get("PF_ARTIFACTS_BUCKET") or DEFAULT_BUCKET,
             key_id=key_id, secret=secret,
         )


### PR DESCRIPTION
The bucket stays a committed default; the endpoint's account id identifies whose infrastructure this is, so PF_ARTIFACTS_ENDPOINT is environment-only and the docs table says which knob lives where.

Stack 13/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)