### PR TITLE
feat(ontology): a project carries its own policy, and only ever tightens

### DIFF
--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -1,0 +1,360 @@
+# The policy layer
+
+Vocabulary is shared. Obligations are not.
+
+Two sisters must mean the same thing by `Payment` or a roll-up adds two numbers
+that merely share a name — so classes, roles and relations live at the platform
+and group levels, and `acme-rollup` depends on exactly that. But what must
+*hold* is genuinely local: acme-eu answers to GDPR and acme-us does not, and a
+single platform-wide `policy.yaml` cannot say so.
+
+So policy layers where the rest of the ontology deliberately does not.
+
+```
+platform/src/pf/ontology/policy.yaml   the floor, applying everywhere
+groups/<group>/ontology/policy.yaml    the family's own obligations
+<project>/governance/policy.yaml       this entity's own obligations
+```
+
+This mirrors the shape `extension.yaml` already layers over `concepts.yaml`.
+The difference is what may be layered: `extension.yaml` adds vocabulary, and a
+policy overlay adds *rules*, so it carries a safety property the vocabulary
+layer does not need.
+
+---
+
+## The one rule: overlays may only tighten
+
+A layer can do three things, and only three:
+
+| Move | Example |
+|---|---|
+| **add** | declare a policy the platform does not have |
+| **tighten** | raise an inherited policy's severity, `info` → `warning` → `error` |
+| **enforce** | name another artifact or evidence kind for an inherited policy |
+
+It **cannot** lower a severity, and there is no syntax for deleting an
+inherited policy. A relaxation raises `PolicyRelaxation` at **load** time:
+
+```
+PolicyRelaxation: project:acme/acme-us: policy 'pii-not-in-consumption' lowers
+severity 'error' -> 'warning'. A layer may tighten a policy, never relax one;
+drop the override or raise it.
+```
+
+Load time, not check time, is the point. A relaxed policy that only failed when
+something tripped over it would be discovered by the incident it was written to
+prevent.
+
+This is the same stance `pf.tools.spec` takes on gate sections, for the same
+reason: **a governance layer that each project can weaken is not a governance
+layer.**
+
+---
+
+## Writing an overlay
+
+### Tighten an inherited policy
+
+`mart-declares-grain` ships from the platform as a `warning`. To make it fatal
+in one project:
+
+```yaml
+# groups/acme/projects/acme-eu/governance/policy.yaml
+policies:
+  - id: mart-declares-grain
+    severity: error
+```
+
+Everything else about the policy is inherited — its `intent`, `constraint`,
+`applies_to`, `params`, `enforced_by` and `evidence` all come from the platform
+definition. You are overriding one field.
+
+### Add a policy of your own
+
+```yaml
+policies:
+  - id: gdpr-erasure-path
+    intent: >
+      A subject access or erasure request must have a declared path to every
+      copy of the subject's data — marts and review artefacts included, not only
+      the raw tables it landed in.
+    applies_to: {role_glob: "pii_*"}
+    constraint: erasure_declared
+    severity: error
+```
+
+Note what this example does **not** do: it names no `enforced_by`. There is no
+erasure checker yet, so claiming one would make `pf semantic policy` report the
+rule as enforced when nothing enforces it. Left blank, it surfaces honestly:
+
+```
+1 unenforced policy(ies): gdpr-erasure-path
+```
+
+That is the finding, and it is meant to be seen. From `pf.projections.otop`:
+
+> An unenforced policy that reports `pass` is worse than no policy at all,
+> because it ends the conversation.
+
+### Add enforcement without claiming the policy
+
+```yaml
+policies:
+  - id: pii-not-in-consumption
+    enforced_by: [pf.local.checks:pii_sweep]
+    evidence: [pf loop run pii-audit]
+```
+
+`enforced_by` and `evidence` are unioned with what the base declared, in order,
+without duplicates. Because this changes no severity, the policy's `scope` stays
+`platform` — otherwise every project would appear to own every policy it merely
+helps enforce.
+
+---
+
+## An omitted `severity:` means *inherit*
+
+This is the subtlest rule in the layer, and it exists because of a real bug.
+
+In a **base** document an omitted severity defaults to `error` — the strict end,
+because a rule whose severity was forgotten should shout rather than whisper.
+
+In an **overlay** it must mean *inherit*. Otherwise the example directly above —
+an entry that only adds an `enforced_by` line — would silently escalate
+`pii-not-in-consumption`'s severity to `error`. That is a tightening nobody
+wrote, and nobody would spot it in the diff.
+
+```yaml
+# Inherits warning from the platform. Does NOT become an error.
+- id: mart-declares-grain
+  enforced_by: [pf.local:extra-check]
+```
+
+---
+
+## `applies_to` and `params` are not overridable
+
+An overlay that redefines either on an inherited policy is rejected:
+
+```
+PolicyRelaxation: project:acme/acme-us: policy 'pii-not-in-consumption'
+redefines 'applies_to'. Retargeting an inherited policy can silently narrow it;
+declare a new policy with its own id instead.
+```
+
+Narrowing `applies_to` reads like a refinement and is really a partial delete.
+`pii-not-in-consumption` retargeted from `role_glob: "pii_*"` to
+`role_glob: "pii_email"` stops covering `pii_name`, `pii_phone` and everything
+else — with nothing in the diff shaped like a removal.
+
+A project that genuinely needs different targeting declares a **new policy with
+a new id**, where the addition is visible as an addition.
+
+---
+
+## Reading the resolved result
+
+`pf semantic policy` takes an optional scope. With no argument it prints the
+platform floor; naming a group, or a group and a project, resolves the layers
+over it.
+
+```console
+$ pf semantic policy acme acme-eu
+scope: acme/acme-eu
+┏━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
+┃ policy      ┃ severity ┃ set by     ┃ constraint  ┃ enforced   ┃ evidence    ┃
+┃             ┃          ┃            ┃             ┃ by         ┃             ┃
+┡━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
+│ mart-decla… │ error    │ project:a… │ meta_field… │ pf.kg.bui… │ kg/context… │
+│ gdpr-erasu… │ error    │ project:a… │ erasure_de… │ NOTHING    │ —           │
+└─────────────┴──────────┴────────────┴─────────────┴────────────┴─────────────┘
+1 unenforced policy(ies): gdpr-erasure-path
+
+$ pf semantic policy acme acme-us
+scope: acme/acme-us
+│ mart-decla… │ warning  │ platform   │ meta_field… │ pf.kg.bui… │ kg/context… │
+every policy names an enforcing artifact
+```
+
+The **`set by`** column is the whole reason `Policy.scope` exists. "Why is this
+an error here and a warning next door" is answerable without diffing three
+files. Severities set by a local layer print highlighted; anything still at the
+platform default prints plain.
+
+---
+
+## Where the resolved policy is used
+
+| Consumer | What it resolves |
+|---|---|
+| `pf check` / `pf bootstrap` | `validate._ontology_for()` derives group **and** project from the path and resolves both layers |
+| `pf semantic policy` | prints the chain at the requested scope |
+| `pf.projections.otop` | `build_manifest()` exports at the scope it was asked for |
+
+The otop projection previously assumed policies were *"platform-wide, so
+identical in every project"*. That is no longer true, and exporting a project's
+governance against the platform floor would understate exactly the obligations
+that project was given. It now resolves per scope:
+
+```console
+$ python -c "..."
+eu constraints: 11 | us constraints: 10
+eu-only     : ['gdpr-erasure-path']
+```
+
+---
+
+## How it reaches a project
+
+The overlay is a **capability**, not a hardcoded scaffold step. One entry in
+`pf.capabilities.CAPABILITIES`; adding or removing it touches no scaffolder, no
+CLI and no gate.
+
+```python
+"governance": Capability(
+    name="governance",
+    description="Project-scoped policy overlay, layered over the platform "
+                "and group floors. Tightening only.",
+    files={"governance/policy.yaml": GOVERNANCE_POLICY},
+    preserve=("governance/policy.yaml",),
+    gate={"impact_required": ["**/governance/policy.yaml"]},
+    default_enabled=True,
+),
+```
+
+### New project
+
+```console
+$ pf new-project acme acme-de
+  + capability governance (1 file(s))
+```
+
+`default_enabled=True`, so it arrives without being asked for. An opt-in
+capability reaches only the projects whose author remembered the flag, which is
+how one project ends up governed and seven do not. Opt out with
+`pf new-project --without governance`.
+
+### Existing project
+
+```console
+$ pf capability-add governance acme acme-us
+  + governance (1 file(s))
+```
+
+`pf bootstrap` also backfills it into every project that lacks it, using the
+existing all-or-nothing rule: a capability is applied only when **every** file
+it writes is absent, never when some already exist.
+
+### The seeded file is inert
+
+The stub ships with `policies: []` and every example commented out. Scaffolding
+a project, or backfilling this into eight existing ones, **changes no verdict
+anywhere**. A capability that silently tightened the gate on adoption would be
+discovered as a broken build in a project nobody had touched.
+
+### `preserve` — seeded, not generated
+
+`Capability.preserve` names files written *when absent* and left alone *when
+present*. `apply()` otherwise rewrites every target wholesale, which is correct
+for a generated artefact and destructive for one a human is expected to edit.
+
+This matters because `pf capability-add` deliberately bypasses the backfill's
+all-or-nothing guard. Without `preserve`, re-adding the capability to a project
+that had written real policy into its overlay would silently destroy it.
+
+### The overlay is impact-required, not denied
+
+```python
+gate={"impact_required": ["**/governance/policy.yaml"]},
+```
+
+A policy overlay decides whether a change is allowed to land, so it is not
+something a change may quietly alter on its way past. It is deliberately *not*
+denylisted — a project must be able to write its own obligations. Edits are made
+visible instead, and the loosening guard lives in the loader, where it can read
+what the edit actually did rather than merely that an edit happened.
+
+---
+
+## Implementation notes
+
+### `load_ontology` is cached — overlays must never write through it
+
+`load_ontology()` is `functools.lru_cache`d and shared by every caller. An
+overlay that mutated it would leak one project's policy into every other, and
+the test that caught it would be somewhere else entirely.
+
+Every path that overlays returns a copy owning its own policy list. The path
+most likely to leak was the early return in `load_group_ontology` for a missing
+`extension.yaml`, which handed back the cached object directly:
+
+```python
+if not ext_path.exists():
+    # `base` is lru_cached and shared by every caller, so an overlay must
+    # never touch it — hand back a copy that owns its own policy list.
+    return _overlay_policy(_copy(base), gdir / "policy.yaml", scope)
+```
+
+### `PolicyRelaxation` subclasses `ValueError`
+
+`validate._ontology_for` catches `(OSError, ValueError)` to fall back to the
+platform ontology when a group's files are unreadable. `PolicyRelaxation` must
+be re-raised **before** that handler, or a project that tried to weaken a policy
+would be validated against the very policy set it tried to weaken:
+
+```python
+except PolicyRelaxation:
+    # A relaxation is a finding, not a fallback.
+    raise
+except (OSError, ValueError):
+    pass
+```
+
+### Severity is ranked, not compared
+
+```python
+SEVERITY_RANK = {"info": 0, "warning": 1, "error": 2}
+```
+
+`SEVERITY_RANK` is what makes "tightening only" a computation rather than a
+convention.
+
+---
+
+## API
+
+| Function | Returns |
+|---|---|
+| `load_ontology()` | the platform floor — cached, never mutate |
+| `load_group_ontology(root, group)` | platform + group extension + group policy |
+| `load_project_ontology(root, group, project)` | the above + the project's policy |
+| `merge_policies(base, overlay, scope)` | tightening-only merge; raises `PolicyRelaxation` |
+
+`Policy` gained one field:
+
+```python
+scope: str = "platform"   # "platform" | "group:<g>" | "project:<g>/<p>"
+```
+
+It records which layer set the severity — reattributed only on a real
+tightening, so an overlay that merely adds evidence leaves the owner where it
+was.
+
+---
+
+## What is deliberately *not* layered
+
+Concepts, topology and relations stay at platform and group scope.
+
+Project-scoped vocabulary would mean each project defining its own `Payment`,
+and `acme-rollup` — which depends on `AssetKey(acme-us, fct_revenue)` and
+`AssetKey(acme-eu, fct_revenue)` — would then sum two things that merely share a
+name. That is the "an assumption carried across is a bug" failure moved out of
+the vocabulary, where `pf check` can catch it, and into the arithmetic, where
+nothing can.
+
+Sharing a **word** is not sharing **business logic**. That a `Payment` has an
+amount, a currency and an `event_time` is vocabulary. *How acme-us recognises
+revenue* is business logic, and it already lives in project-confined dbt models,
+where it belongs.

--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -11,6 +11,12 @@ concepts.yaml   what things ARE   classes, identity, datatype properties        
 annotations     where they LIVE   concept/role/links per dlt resource            (per project)
 ```
 
+Only the bottom layer is per project — with one exception. **Policy also layers,
+platform → group → project, and may only ever tighten.** Vocabulary cannot: two
+sisters that mean different things by `Payment` cannot be rolled up. Obligations
+can and must, because acme-eu answers to GDPR and acme-us does not. See
+[POLICY.md](POLICY.md).
+
 The knowledge graph is the join of all four. Everything else is a **projection**
 of the graph, never a parallel hand-maintained file:
 

--- a/groups/acme/projects/acme-eu/governance/policy.yaml
+++ b/groups/acme/projects/acme-eu/governance/policy.yaml
@@ -1,0 +1,31 @@
+# Policy layer for acme-eu.
+#
+# acme-eu operates under GDPR and acme-us does not. That difference is not a
+# vocabulary difference — both sisters mean the same thing by `Payment`, and the
+# roll-up depends on it — so it belongs here rather than in the group ontology.
+#
+# This layers over platform/src/pf/ontology/policy.yaml and may only tighten it:
+# raise a severity, add a policy, name another enforcing artifact. Lowering a
+# severity raises PolicyRelaxation at load time. See pf.ontology.model.
+
+policies:
+  # The platform ships this as a warning. Here a mart with no declared grain
+  # blocks the merge: an undeclared grain is how a join silently fans out, and a
+  # fan-out on personal data is a reportable breach rather than a bad number.
+  - id: mart-declares-grain
+    severity: error
+
+  # Deliberately names no `enforced_by`. There is no erasure checker yet, and
+  # claiming one would make `pf semantic policy` report this as enforced — the
+  # exact dishonesty pf.projections.otop refuses ("an unenforced policy that
+  # reports pass is worse than no policy at all, because it ends the
+  # conversation"). Listed unenforced, it shows up in the unenforced count until
+  # somebody builds the check. That is the finding, and it is meant to be seen.
+  - id: gdpr-erasure-path
+    intent: >
+      A subject access or erasure request must have a declared path to every
+      copy of the subject's data — marts and review artefacts included, not only
+      the raw tables it landed in.
+    applies_to: {role_glob: "pii_*"}
+    constraint: erasure_declared
+    severity: error

--- a/platform/src/pf/capabilities.py
+++ b/platform/src/pf/capabilities.py
@@ -39,6 +39,13 @@ class Capability:
     name: str
     description: str
     files: dict[str, str] = field(default_factory=dict)
+    # Files that are *seeded*, not generated: written when absent, left alone
+    # when present. `apply` otherwise rewrites every target wholesale, which is
+    # correct for a generated artefact and destructive for one a human is
+    # expected to edit — a policy overlay, a README, a profiles.yml. Without this
+    # the only protection is `_bootstrap_capabilities` refusing a partial
+    # backfill, and `pf capability-add` deliberately bypasses that.
+    preserve: tuple[str, ...] = ()
     settings: dict[str, Any] = field(default_factory=dict)
     gate: dict[str, list[str]] = field(default_factory=dict)
     env: tuple[str, ...] = ()
@@ -333,7 +340,89 @@ def warehouse_capability(wh: ProductionWarehouse) -> Capability:
     )
 
 
+# ----------------------------------------------------------- governance -----
+# Seeded inert. Every policy below is commented out, so scaffolding a project or
+# backfilling this capability into eight existing ones changes no verdict
+# anywhere — the file exists to be found and edited, not to take effect on
+# arrival. A capability that silently tightened the gate on adoption would be
+# discovered as a broken build in a project nobody had touched.
+GOVERNANCE_POLICY = """\
+# Policy overlay for {{group}}/{{project}}.
+#
+# The platform ships a policy floor in `platform/src/pf/ontology/policy.yaml`
+# that applies to every project. This file layers over it, and over any group
+# overlay at `groups/{{group}}/ontology/policy.yaml`, for the obligations that
+# are this entity's alone — a jurisdiction, a customer contract, a retention
+# rule a sister does not share.
+#
+# Vocabulary is deliberately NOT layered here. Two sisters must mean the same
+# thing by `Payment` or a roll-up adds two numbers that merely share a name;
+# concepts live in the group ontology for that reason. What must *hold* is the
+# part that is genuinely local, so it is the part that layers.
+#
+# THIS FILE MAY ONLY TIGHTEN.
+#
+#   add       declare a policy the platform does not have
+#   tighten   raise an inherited policy's severity (info -> warning -> error)
+#   enforce   name another artifact or evidence kind for an inherited policy
+#
+# Lowering a severity raises `PolicyRelaxation` at load time, and there is no
+# syntax for deleting an inherited policy. An omitted `severity:` means inherit,
+# so adding an `enforced_by` line cannot silently escalate the rule.
+#
+# Inspect the resolved result — including which layer set each severity — with:
+#
+#     pf semantic policy {{group}} {{project}}
+
+policies: []
+
+# --- examples, all inert until uncommented -----------------------------------
+#
+# Tighten an inherited policy. `mart-declares-grain` ships as a warning; here an
+# undeclared grain would block the merge.
+#
+# policies:
+#   - id: mart-declares-grain
+#     severity: error
+#
+# Declare an obligation the platform does not know about. Note it names no
+# `enforced_by`: `pf semantic policy` will report it as unenforced, which is the
+# honest state until the check exists. Claiming enforcement that does not exist
+# is worse than declaring none — it ends the conversation.
+#
+#   - id: retention-window-declared
+#     intent: >
+#       A table holding personal data must declare how long it keeps it, or the
+#       retention promise is prose nobody can verify.
+#     applies_to: {role_glob: "pii_*"}
+#     constraint: retention_declared
+#     severity: error
+#
+# Add enforcement to an inherited policy without claiming ownership of it. The
+# severity's owner stays where it was; only the artifact list grows.
+#
+#   - id: pii-not-in-consumption
+#     enforced_by: [pf.local.checks:pii_sweep]
+#     evidence: [pf loop run pii-audit]
+"""
+
+
 CAPABILITIES: dict[str, Capability] = {
+    "governance": Capability(
+        name="governance",
+        description="Project-scoped policy overlay, layered over the platform "
+                    "and group floors. Tightening only.",
+        files={"governance/policy.yaml": GOVERNANCE_POLICY},
+        # Seeded, never regenerated: this is the one file in the capability a
+        # project is expected to own. Re-applying must not overwrite it.
+        preserve=("governance/policy.yaml",),
+        # A policy overlay decides whether a change is allowed to land, so it is
+        # not something a change may quietly relax on its way past. Edits are
+        # visible rather than blocked — the loosening guard lives in the loader,
+        # where it can read what the edit actually did.
+        gate={"impact_required": ["**/governance/policy.yaml"]},
+        default_enabled=True,
+    ),
     "evidence": Capability(
         name="evidence",
         description="Evidence BI reporting layer, generated from the semantic layer.",
@@ -444,6 +533,11 @@ def apply(cap: Capability, root: Path, project_dir: Path,
         rendered_rel = render(rel, ctx)
         base = root if rendered_rel.startswith(".github/") else project_dir
         target = base / rendered_rel
+        # A seeded file is written once. Re-applying the capability — which
+        # `pf capability-add` does on demand, past the backfill's own guard —
+        # must not overwrite what the project has since written in it.
+        if rel in cap.preserve and target.exists():
+            continue
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(render(template, ctx))
         written.append(target)

--- a/platform/src/pf/cli.py
+++ b/platform/src/pf/cli.py
@@ -1762,12 +1762,30 @@ def cmd_topology() -> None:
 
 
 @sem_app.command("policy")
-def cmd_policy() -> None:
-    """Policy chain: intent → constraint → artifact → evidence."""
-    o = load_ontology()
-    t = Table("policy", "severity", "constraint", "enforced by", "evidence")
+def cmd_policy(group: str = typer.Argument("", help="resolve at this group's scope"),
+               project: str = typer.Argument("", help="resolve at this project's scope")) -> None:
+    """Policy chain: intent → constraint → artifact → evidence.
+
+    With no argument this prints the platform floor. Naming a group, or a group
+    and a project, resolves the layers over it — which is the only way to answer
+    "what actually binds acme-eu", since a layer may tighten a policy the
+    platform set and the platform file will not show it.
+    """
+    from pf.ontology.model import load_group_ontology, load_project_ontology
+
+    if group and project:
+        o, scope = load_project_ontology(root(), group, project), f"{group}/{project}"
+    elif group:
+        o, scope = load_group_ontology(root(), group), group
+    else:
+        o, scope = load_ontology(), "platform"
+    console.print(f"[dim]scope:[/] {scope}")
+
+    t = Table("policy", "severity", "set by", "constraint", "enforced by", "evidence")
     for p in o.policies:
-        t.add_row(p.id, p.severity, p.constraint,
+        # Anything the local layers moved is the interesting row on this table.
+        sev = p.severity if p.scope == "platform" else f"[yellow]{p.severity}[/]"
+        t.add_row(p.id, sev, p.scope, p.constraint,
                   "\n".join(p.enforced_by) or "[red]NOTHING[/]",
                   "\n".join(p.evidence) or "—")
     console.print(t)

--- a/platform/src/pf/ontology/model.py
+++ b/platform/src/pf/ontology/model.py
@@ -9,13 +9,31 @@ Three files, three jobs:
 Keeping them separate matters: the ontology is stable, the topology changes when
 a new relation is discovered, and policy changes when governance does. Merging
 them would make every policy edit a vocabulary edit.
+
+Policy layers where the other two do not. Vocabulary is shared on purpose — two
+sisters that mean different things by `Payment` cannot be rolled up — but what
+must *hold* is genuinely local: acme-eu is bound by GDPR and acme-us is not, and
+a single platform-wide policy file cannot say so. So policy resolves through
+three files, in the same shape `extension.yaml` layers over `concepts.yaml`:
+
+  platform/src/pf/ontology/policy.yaml   the floor, applying everywhere
+  groups/<group>/ontology/policy.yaml    the family's own obligations
+  <project>/governance/policy.yaml       this entity's own obligations
+
+**The overlay may only tighten.** A layer can add a policy, raise a severity, or
+name another artifact that enforces one. It cannot lower a severity and it cannot
+delete an inherited policy — there is no syntax for removal, and a relaxation
+raises `PolicyRelaxation` at load time rather than quietly widening the rules
+that judge the project. This is the same stance `pf.tools.spec` takes on gate
+sections, for the same reason: a governance layer that each project can weaken is
+not a governance layer.
 """
 
 from __future__ import annotations
 
 import fnmatch
 import functools
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Literal
 
@@ -159,6 +177,21 @@ class Relation:
         return f"{self.domain} {self.label or 'relates to'} {self.range}"
 
 
+#: Severity ordered by strictness. A layer may move a policy up this list, never
+#: down — `SEVERITY_RANK` is what makes "tightening only" a computation rather
+#: than a convention.
+SEVERITY_RANK: dict[str, int] = {"info": 0, "warning": 1, "error": 2}
+
+
+class PolicyRelaxation(ValueError):
+    """A layer tried to weaken an inherited policy.
+
+    Raised at load time, not at check time. A relaxed policy that only failed
+    when something tripped over it would be discovered by the incident it was
+    written to prevent.
+    """
+
+
 @dataclass(frozen=True)
 class Policy:
     id: str
@@ -169,6 +202,10 @@ class Policy:
     params: dict[str, Any] = field(default_factory=dict)
     enforced_by: list[str] = field(default_factory=list)
     evidence: list[str] = field(default_factory=list)
+    #: Which layer this policy's severity came from — "platform", "group:<g>" or
+    #: "project:<g>/<p>". `pf policy` prints it, so "why is this an error here
+    #: and a warning next door" is answerable without diffing three files.
+    scope: str = "platform"
 
     @property
     def enforced(self) -> bool:
@@ -279,6 +316,105 @@ class Ontology:
         return [p for p in self.policies if not p.enforced]
 
 
+def _parse_policies(doc: dict[str, Any], scope: str, overlay: bool = False) -> list[Policy]:
+    """Parse a policy document.
+
+    `overlay` changes what an omitted severity means. In a base document there is
+    nothing to inherit, so it defaults to `error` — the strict end, because a rule
+    whose severity was forgotten should shout rather than whisper. In an overlay
+    it must mean *inherit*: an entry that only adds an `enforced_by` line would
+    otherwise silently escalate the policy it was documenting, which is a
+    tightening nobody wrote and nobody would see in the diff.
+    """
+    default = "" if overlay else "error"
+    return [
+        Policy(
+            id=p["id"], intent=p.get("intent", "").strip(),
+            constraint=p.get("constraint", ""), severity=p.get("severity", default),
+            applies_to=p.get("applies_to") or {}, params=p.get("params") or {},
+            enforced_by=p.get("enforced_by") or [], evidence=p.get("evidence") or [],
+            scope=scope,
+        )
+        for p in (doc.get("policies") or [])
+    ]
+
+
+def merge_policies(base: list[Policy], overlay: list[Policy], scope: str) -> list[Policy]:
+    """Layer `overlay` over `base`, refusing anything that loosens the result.
+
+    Three moves are allowed, and they are the only three:
+
+      add       an id the base does not carry becomes a new policy
+      tighten   an inherited id may raise its severity, never lower it
+      evidence  `enforced_by` and `evidence` may gain entries
+
+    `applies_to` and `params` are deliberately *not* overridable on an inherited
+    policy. Narrowing `applies_to` reads like a refinement and is in fact a
+    partial delete — `pii-not-in-consumption` scoped to one layer stops covering
+    the others, with nothing in the diff that looks like a removal. A project that
+    needs different targeting declares its own policy with its own id, where the
+    addition is visible as an addition.
+    """
+    by_id = {p.id: p for p in base}
+    out = list(base)
+    for over in overlay:
+        prior = by_id.get(over.id)
+        if prior is None:
+            # A brand-new policy that named no severity gets the strict default.
+            out.append(over if over.severity else replace(over, severity="error"))
+            continue
+
+        old = SEVERITY_RANK.get(prior.severity, 2)
+        # An omitted severity inherits rather than defaulting, so an overlay that
+        # only adds evidence cannot escalate the policy behind the author's back.
+        new = old if not over.severity else SEVERITY_RANK.get(over.severity, 2)
+        if new < old:
+            raise PolicyRelaxation(
+                f"{scope}: policy '{over.id}' lowers severity "
+                f"'{prior.severity}' -> '{over.severity}'. A layer may tighten a "
+                f"policy, never relax one; drop the override or raise it."
+            )
+        for field_name in ("applies_to", "params"):
+            if getattr(over, field_name) and getattr(over, field_name) != getattr(prior, field_name):
+                raise PolicyRelaxation(
+                    f"{scope}: policy '{over.id}' redefines '{field_name}'. Retargeting "
+                    f"an inherited policy can silently narrow it; declare a new policy "
+                    f"with its own id instead."
+                )
+
+        merged = Policy(
+            id=prior.id,
+            intent=over.intent or prior.intent,
+            constraint=prior.constraint,
+            severity=over.severity or prior.severity,
+            applies_to=prior.applies_to,
+            params=prior.params,
+            enforced_by=list(dict.fromkeys([*prior.enforced_by, *over.enforced_by])),
+            evidence=list(dict.fromkeys([*prior.evidence, *over.evidence])),
+            # Only a real tightening reattributes the policy; an overlay that
+            # merely adds evidence leaves the severity's owner where it was.
+            scope=scope if new > old else prior.scope,
+        )
+        out[out.index(prior)] = merged
+        by_id[over.id] = merged
+    return out
+
+
+def _overlay_policy(onto: Ontology, path: Path, scope: str) -> Ontology:
+    """Merge one policy file over an ontology, if the file exists."""
+    if not path.exists():
+        return onto
+    doc = yaml.safe_load(path.read_text()) or {}
+    onto.policies = merge_policies(
+        onto.policies, _parse_policies(doc, scope, overlay=True), scope)
+    known = {k.get("id") for k in onto.evidence_kinds}
+    onto.evidence_kinds = [
+        *onto.evidence_kinds,
+        *(k for k in (doc.get("evidence_kinds") or []) if k.get("id") not in known),
+    ]
+    return onto
+
+
 def _parse_properties(spec: dict[str, Any]) -> dict[str, Property]:
     out: dict[str, Property] = {}
     for pname, pspec in (spec.get("properties") or {}).items():
@@ -334,15 +470,7 @@ def load_ontology(directory: str | Path | None = None) -> Ontology:
         for r in (topology.get("relations") or [])
     ]
 
-    policies = [
-        Policy(
-            id=p["id"], intent=p.get("intent", "").strip(),
-            constraint=p.get("constraint", ""), severity=p.get("severity", "error"),
-            applies_to=p.get("applies_to") or {}, params=p.get("params") or {},
-            enforced_by=p.get("enforced_by") or [], evidence=p.get("evidence") or [],
-        )
-        for p in (policy_doc.get("policies") or [])
-    ]
+    policies = _parse_policies(policy_doc, scope="platform")
 
     return Ontology(
         version=int(concepts.get("version", 1)),
@@ -367,11 +495,18 @@ def load_group_ontology(root: str | Path, group: str) -> Ontology:
     putting it there makes every other company inherit a term that means nothing
     to them. The extension is where induced, steward-approved additions land, and
     promoting one to the platform is a separate, deliberate act.
+
+    Policy layers here too, from `groups/<group>/ontology/policy.yaml`, and may
+    only tighten — see the module docstring.
     """
     base = load_ontology()
-    ext_path = Path(root) / "groups" / group / "ontology" / "extension.yaml"
+    gdir = Path(root) / "groups" / group / "ontology"
+    ext_path = gdir / "extension.yaml"
+    scope = f"group:{group}"
     if not ext_path.exists():
-        return base
+        # `base` is lru_cached and shared by every caller, so an overlay must
+        # never touch it — hand back a copy that owns its own policy list.
+        return _overlay_policy(_copy(base), gdir / "policy.yaml", scope)
 
     ext = yaml.safe_load(ext_path.read_text()) or {}
 
@@ -410,9 +545,35 @@ def load_group_ontology(root: str | Path, group: str) -> Ontology:
             cardinality=r["cardinality"], label=r.get("label", ""),
             inverse=r.get("inverse", ""), description=r.get("description", "")))
 
-    return Ontology(version=base.version, namespace=base.namespace, prefix=base.prefix,
-                    classes=classes, roles=roles, relations=relations,
-                    policies=base.policies, evidence_kinds=base.evidence_kinds)
+    merged = Ontology(version=base.version, namespace=base.namespace, prefix=base.prefix,
+                      classes=classes, roles=roles, relations=relations,
+                      policies=list(base.policies),
+                      evidence_kinds=list(base.evidence_kinds))
+    return _overlay_policy(merged, gdir / "policy.yaml", scope)
+
+
+def load_project_ontology(root: str | Path, group: str, project: str) -> Ontology:
+    """Group ontology with the project's own policy merged over it.
+
+    Vocabulary deliberately stops at the group: two sisters that mean different
+    things by `Payment` cannot be rolled up, and `acme-rollup` depends on exactly
+    that. What must *hold* does not stop there — acme-eu answers to GDPR and
+    acme-us does not — so the project layer carries policy and nothing else.
+
+    The overlay may only tighten, so a project can be stricter than its family
+    but never quieter than it.
+    """
+    onto = load_group_ontology(root, group)
+    ppath = Path(root) / "groups" / group / "projects" / project / "governance" / "policy.yaml"
+    return _overlay_policy(onto, ppath, f"project:{group}/{project}")
+
+
+def _copy(onto: Ontology) -> Ontology:
+    """Shallow copy with its own policy and evidence lists."""
+    return Ontology(version=onto.version, namespace=onto.namespace, prefix=onto.prefix,
+                    classes=onto.classes, roles=onto.roles, relations=onto.relations,
+                    policies=list(onto.policies),
+                    evidence_kinds=list(onto.evidence_kinds))
 
 
 # v1 compatibility: callers importing TopologyEdge get the Relation type.

--- a/platform/src/pf/ontology/validate.py
+++ b/platform/src/pf/ontology/validate.py
@@ -190,7 +190,7 @@ def validate_instance(instance_path: str | Path, ontology: Ontology | None = Non
 
 
 def _ontology_for(project_dir: Path) -> Ontology:
-    """The platform ontology plus this project's group extension.
+    """The platform ontology plus this project's group extension and own policy.
 
     Loading only the platform ontology here was a real failure, not a
     simplification: every concept a group had legitimately added through
@@ -199,16 +199,28 @@ def _ontology_for(project_dir: Path) -> Ontology:
     on the same annotations. The group is derivable from the path — a project
     lives at `<root>/groups/<group>/projects/<project>` — so there is no reason
     to validate against a vocabulary the project does not actually use.
+
+    The same argument extends to policy, one layer further in: checking acme-eu
+    against a policy set that cannot express GDPR is the same mistake as checking
+    it against a vocabulary it does not use.
     """
-    from pf.ontology.model import load_group_ontology
+    from pf.ontology.model import PolicyRelaxation, load_group_ontology, load_project_ontology
 
     parts = project_dir.resolve().parts
     if "groups" in parts and "projects" in parts:
         i = parts.index("groups")
         root = Path(*parts[:i]) if i else Path("/")
         group = parts[i + 1]
+        j = parts.index("projects")
+        project = parts[j + 1] if j + 1 < len(parts) else ""
         try:
+            if project:
+                return load_project_ontology(root, group, project)
             return load_group_ontology(root, group)
+        except PolicyRelaxation:
+            # A relaxation is a finding, not a fallback. Swallowing it here would
+            # validate against the very policy set the project tried to weaken.
+            raise
         except (OSError, ValueError):
             pass
     return load_ontology()

--- a/platform/src/pf/projections/otop.py
+++ b/platform/src/pf/projections/otop.py
@@ -32,7 +32,12 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from pf.ontology.model import Policy, load_ontology
+from pf.ontology.model import (
+    Policy,
+    load_group_ontology,
+    load_ontology,
+    load_project_ontology,
+)
 
 OTOP_VERSION = 0.2
 NS = "pf"
@@ -295,15 +300,25 @@ def build_manifest(root: str | Path, group: str = "", project: str = "",
                    project_dir: str | Path | None = None) -> dict[str, Any]:
     """Emit the policy layer as an otop-core 0.2 manifest.
 
-    Scope is a choice, not an accident. Policies and their enforcing artifacts
-    are platform-wide, so they are identical in every project; evidence is not,
-    because `pf check` passes in one project and fails in another. Passing a
-    project produces the same governance skeleton with that project's observed
-    results attached.
+    Scope is a choice, not an accident, and it now applies to the constraints as
+    well as the evidence. This used to assume policies were platform-wide and so
+    identical everywhere; they are not. A group or a project may layer its own
+    `policy.yaml` over the platform floor — acme-eu carries obligations acme-us
+    does not — so the manifest resolves the ontology at the scope it was asked
+    for. Exporting a project's governance against the platform policy set would
+    understate exactly the obligations that project was given.
+
+    Evidence remains per-project for the original reason: `pf check` passes in
+    one project and fails in another.
     """
     root = Path(root)
     pdir = Path(project_dir) if project_dir else None
-    onto = load_ontology()
+    if group and project:
+        onto = load_project_ontology(root, group, project)
+    elif group:
+        onto = load_group_ontology(root, group)
+    else:
+        onto = load_ontology()
     commit = _commit(root)
     policy_created = _authored(root, "platform/src/pf/ontology/policy.yaml")
 

--- a/platform/tests/test_policy_layering.py
+++ b/platform/tests/test_policy_layering.py
@@ -38,6 +38,20 @@ def _by_id(onto, pid: str):
     return next(p for p in onto.policies if p.id == pid)
 
 
+def _fake_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Make `tmp_path` look like a repo root, and stand inside it.
+
+    `pf.obs.repo_root` walks up from cwd for a directory holding both
+    `platform/` and `groups/`, so anything that resolves the root itself —
+    rather than using the one it was passed — lands here instead of in the real
+    checkout.
+    """
+    (tmp_path / "platform").mkdir(exist_ok=True)
+    (tmp_path / "groups").mkdir(exist_ok=True)
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
 def test_a_project_may_add_a_policy_of_its_own(tmp_path: Path) -> None:
     _policy_file(_project(tmp_path, "acme", "acme-eu"), [{
         "id": "gdpr-erasure-path",
@@ -217,3 +231,42 @@ def test_a_new_project_is_scaffolded_with_the_overlay(tmp_path: Path) -> None:
     assert (pdir / "governance" / "policy.yaml").exists()
     assert CAPABILITIES["governance"].gate["impact_required"] == \
            ["**/governance/policy.yaml"]
+
+
+def test_bootstrap_backfills_the_overlay_into_a_project_without_one(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The path that reaches projects that already existed when this shipped.
+
+    `pf new-project` covers new ones; every project older than the capability
+    depends on this step, which is exactly the hole `pf bootstrap` was built to
+    close for platform steps.
+
+    `_fake_root` is not ceremony: the backfill merges gate rules through
+    `pf.cli._merge_gate_rules`, which resolves the repo from *cwd* rather than
+    from the `root` it was handed. Without the chdir this test writes into the
+    real gate.capabilities.yaml.
+    """
+    from pf.scaffold.bootstrap import _bootstrap_capabilities
+
+    pdir = _fake_root(tmp_path, monkeypatch) / "groups" / "acme" / "projects" / "acme-us"
+    pdir.mkdir(parents=True)
+    results = {r.name: r for r in _bootstrap_capabilities(tmp_path, "acme", "acme-us")}
+
+    assert "capability:governance" in results
+    assert (pdir / "governance" / "policy.yaml").exists()
+
+
+def test_bootstrap_leaves_an_existing_overlay_alone(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Backfill must never rewrite a policy file someone has written into."""
+    from pf.scaffold.bootstrap import _bootstrap_capabilities
+
+    pdir = _fake_root(tmp_path, monkeypatch) / "groups" / "acme" / "projects" / "acme-eu"
+    (pdir / "governance").mkdir(parents=True)
+    mine = pdir / "governance" / "policy.yaml"
+    _policy_file(mine, [{"id": "mart-declares-grain", "severity": "error"}])
+
+    _bootstrap_capabilities(tmp_path, "acme", "acme-eu")
+
+    assert _by_id(load_project_ontology(tmp_path, "acme", "acme-eu"),
+                  "mart-declares-grain").severity == "error"

--- a/platform/tests/test_policy_layering.py
+++ b/platform/tests/test_policy_layering.py
@@ -1,0 +1,150 @@
+"""Tests for the policy override layer.
+
+Policy is the one part of the ontology that is genuinely local: vocabulary must
+be shared or a roll-up adds two things that merely share a name, but what must
+*hold* differs per entity — acme-eu answers to GDPR and acme-us does not.
+
+Every case here is a way that layering could go wrong quietly. A layer that can
+relax an inherited rule is not a layer, it is a bypass, and the failure would be
+invisible until the incident the rule existed to prevent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from pf.ontology.model import (
+    PolicyRelaxation,
+    load_group_ontology,
+    load_ontology,
+    load_project_ontology,
+)
+
+
+def _policy_file(path: Path, policies: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump({"policies": policies}, sort_keys=False))
+
+
+def _project(root: Path, group: str, project: str) -> Path:
+    d = root / "groups" / group / "projects" / project / "governance"
+    d.mkdir(parents=True, exist_ok=True)
+    return d / "policy.yaml"
+
+
+def _by_id(onto, pid: str):
+    return next(p for p in onto.policies if p.id == pid)
+
+
+def test_a_project_may_add_a_policy_of_its_own(tmp_path: Path) -> None:
+    _policy_file(_project(tmp_path, "acme", "acme-eu"), [{
+        "id": "gdpr-erasure-path",
+        "intent": "A subject access request must have somewhere to land.",
+        "constraint": "erasure_declared",
+        "severity": "error",
+        "enforced_by": ["pf.ontology.validate:erasure-path"],
+    }])
+    onto = load_project_ontology(tmp_path, "acme", "acme-eu")
+    p = _by_id(onto, "gdpr-erasure-path")
+    assert p.severity == "error"
+    assert p.scope == "project:acme/acme-eu"
+
+
+def test_a_project_may_tighten_an_inherited_policy(tmp_path: Path) -> None:
+    """`mart-declares-grain` ships as a warning; a project may make it fatal."""
+    base = _by_id(load_ontology(), "mart-declares-grain")
+    assert base.severity == "warning", "fixture assumption changed"
+
+    _policy_file(_project(tmp_path, "acme", "acme-eu"),
+                 [{"id": "mart-declares-grain", "severity": "error"}])
+    p = _by_id(load_project_ontology(tmp_path, "acme", "acme-eu"), "mart-declares-grain")
+    assert p.severity == "error"
+    assert p.scope == "project:acme/acme-eu"
+    # Tightening keeps everything the base declared.
+    assert p.constraint == base.constraint
+    assert base.enforced_by[0] in p.enforced_by
+
+
+def test_a_project_cannot_relax_an_inherited_policy(tmp_path: Path) -> None:
+    _policy_file(_project(tmp_path, "acme", "acme-us"),
+                 [{"id": "pii-not-in-consumption", "severity": "warning"}])
+    with pytest.raises(PolicyRelaxation, match="lowers severity"):
+        load_project_ontology(tmp_path, "acme", "acme-us")
+
+
+def test_a_project_cannot_retarget_an_inherited_policy(tmp_path: Path) -> None:
+    """Narrowing `applies_to` is a partial delete wearing a refinement's clothes."""
+    _policy_file(_project(tmp_path, "acme", "acme-us"), [{
+        "id": "pii-not-in-consumption",
+        "severity": "error",
+        "applies_to": {"role_glob": "pii_email"},
+    }])
+    with pytest.raises(PolicyRelaxation, match="redefines 'applies_to'"):
+        load_project_ontology(tmp_path, "acme", "acme-us")
+
+
+def test_a_project_may_add_evidence_without_claiming_the_policy(tmp_path: Path) -> None:
+    """Naming another enforcing artifact is not a tightening, so the severity's
+    owner stays where it was — otherwise every project would appear to own every
+    policy it merely helps enforce."""
+    _policy_file(_project(tmp_path, "acme", "acme-us"), [{
+        "id": "mart-declares-grain",
+        "enforced_by": ["pf.local:extra-check"],
+        "evidence": ["local-report.md"],
+    }])
+    p = _by_id(load_project_ontology(tmp_path, "acme", "acme-us"), "mart-declares-grain")
+    assert "pf.local:extra-check" in p.enforced_by
+    assert "local-report.md" in p.evidence
+    assert p.scope == "platform"
+
+
+def test_sisters_do_not_inherit_each_others_policy(tmp_path: Path) -> None:
+    """The whole point: acme-eu may be stricter without moving acme-us."""
+    _policy_file(_project(tmp_path, "acme", "acme-eu"),
+                 [{"id": "mart-declares-grain", "severity": "error"}])
+    eu = _by_id(load_project_ontology(tmp_path, "acme", "acme-eu"), "mart-declares-grain")
+    us = _by_id(load_project_ontology(tmp_path, "acme", "acme-us"), "mart-declares-grain")
+    assert (eu.severity, us.severity) == ("error", "warning")
+
+
+def test_a_group_policy_reaches_every_sister(tmp_path: Path) -> None:
+    _policy_file(tmp_path / "groups" / "acme" / "ontology" / "policy.yaml",
+                 [{"id": "mart-declares-grain", "severity": "error"}])
+    for project in ("acme-us", "acme-eu"):
+        p = _by_id(load_project_ontology(tmp_path, "acme", project), "mart-declares-grain")
+        assert p.severity == "error"
+        assert p.scope == "group:acme"
+
+
+def test_a_project_cannot_relax_what_its_group_tightened(tmp_path: Path) -> None:
+    _policy_file(tmp_path / "groups" / "acme" / "ontology" / "policy.yaml",
+                 [{"id": "mart-declares-grain", "severity": "error"}])
+    _policy_file(_project(tmp_path, "acme", "acme-us"),
+                 [{"id": "mart-declares-grain", "severity": "warning"}])
+    with pytest.raises(PolicyRelaxation):
+        load_project_ontology(tmp_path, "acme", "acme-us")
+
+
+def test_overlaying_never_mutates_the_cached_platform_ontology(tmp_path: Path) -> None:
+    """`load_ontology` is lru_cached and shared by every caller. An overlay that
+    wrote through to it would leak one project's policy into every other, and the
+    test that caught it would be somewhere else entirely."""
+    before = [(p.id, p.severity, p.scope) for p in load_ontology().policies]
+    _policy_file(_project(tmp_path, "acme", "acme-eu"), [
+        {"id": "mart-declares-grain", "severity": "error"},
+        {"id": "gdpr-erasure-path", "intent": "x", "constraint": "erasure_declared"},
+    ])
+    load_project_ontology(tmp_path, "acme", "acme-eu")
+    assert [(p.id, p.severity, p.scope) for p in load_ontology().policies] == before
+
+
+def test_a_group_with_no_extension_still_gets_its_policy(tmp_path: Path) -> None:
+    """The early return for a missing extension.yaml is the path most likely to
+    hand back the shared cached object by accident."""
+    _policy_file(tmp_path / "groups" / "solo" / "ontology" / "policy.yaml",
+                 [{"id": "mart-declares-grain", "severity": "error"}])
+    onto = load_group_ontology(tmp_path, "solo")
+    assert _by_id(onto, "mart-declares-grain").severity == "error"
+    assert _by_id(load_ontology(), "mart-declares-grain").severity == "warning"

--- a/platform/tests/test_policy_layering.py
+++ b/platform/tests/test_policy_layering.py
@@ -148,3 +148,72 @@ def test_a_group_with_no_extension_still_gets_its_policy(tmp_path: Path) -> None
     onto = load_group_ontology(tmp_path, "solo")
     assert _by_id(onto, "mart-declares-grain").severity == "error"
     assert _by_id(load_ontology(), "mart-declares-grain").severity == "warning"
+
+
+# ------------------------------------------------------- scaffold seam ----
+def test_the_governance_capability_is_on_by_default() -> None:
+    """A policy overlay that only reached projects whose author remembered a
+    flag is how one project ends up governed and seven do not."""
+    from pf.capabilities import CAPABILITIES, defaults
+
+    assert "governance" in defaults()
+    assert "governance/policy.yaml" in CAPABILITIES["governance"].files
+
+
+def test_the_seeded_overlay_changes_no_verdict(tmp_path: Path) -> None:
+    """Scaffolding a project, or backfilling this into eight existing ones, must
+    not move a single severity. The stub exists to be found, not to take effect
+    on arrival."""
+    from pf.capabilities import CAPABILITIES
+    from pf.capabilities import apply as apply_capability
+
+    pdir = tmp_path / "groups" / "acme" / "projects" / "acme-us"
+    pdir.mkdir(parents=True)
+    apply_capability(CAPABILITIES["governance"], tmp_path, pdir,
+                     {"group": "acme", "project": "acme-us", "module": "acme_us"})
+
+    seeded = pdir / "governance" / "policy.yaml"
+    assert seeded.exists()
+    assert (yaml.safe_load(seeded.read_text()) or {}).get("policies") == []
+
+    resolved = load_project_ontology(tmp_path, "acme", "acme-us")
+    assert [(p.id, p.severity) for p in resolved.policies] == \
+           [(p.id, p.severity) for p in load_ontology().policies]
+
+
+def test_reapplying_the_capability_preserves_an_edited_overlay(tmp_path: Path) -> None:
+    """`pf capability-add` bypasses the backfill's all-or-nothing guard, so the
+    only thing standing between a re-apply and someone's policy file is
+    `Capability.preserve`."""
+    from pf.capabilities import CAPABILITIES
+    from pf.capabilities import apply as apply_capability
+
+    pdir = tmp_path / "groups" / "acme" / "projects" / "acme-eu"
+    ctx = {"group": "acme", "project": "acme-eu", "module": "acme_eu"}
+    pdir.mkdir(parents=True)
+    apply_capability(CAPABILITIES["governance"], tmp_path, pdir, ctx)
+
+    mine = pdir / "governance" / "policy.yaml"
+    mine.write_text(yaml.safe_dump(
+        {"policies": [{"id": "mart-declares-grain", "severity": "error"}]}))
+
+    apply_capability(CAPABILITIES["governance"], tmp_path, pdir, ctx)
+
+    assert _by_id(load_project_ontology(tmp_path, "acme", "acme-eu"),
+                  "mart-declares-grain").severity == "error"
+
+
+def test_a_new_project_is_scaffolded_with_the_overlay(tmp_path: Path) -> None:
+    from pf.capabilities import CAPABILITIES, defaults, resolve
+    from pf.capabilities import apply as apply_capability
+
+    pdir = tmp_path / "groups" / "acme" / "projects" / "acme-new"
+    pdir.mkdir(parents=True)
+    for cap in resolve(defaults()):
+        if cap.name != "governance":
+            continue
+        apply_capability(cap, tmp_path, pdir,
+                         {"group": "acme", "project": "acme-new", "module": "acme_new"})
+    assert (pdir / "governance" / "policy.yaml").exists()
+    assert CAPABILITIES["governance"].gate["impact_required"] == \
+           ["**/governance/policy.yaml"]


### PR DESCRIPTION
Part **1 of 16** of a stack. Base is `main`, so this diff is only its
own commits. Merge in order.

**Tests on this branch: 356 passing.** Every branch in the stack is green
on its own, not only the tip.

## Commits

- `a4c6864` Let a project carry its own policy, and only ever tighten
- `78be720` Make the policy overlay a capability, and document the layer
- `d24d602` Cover the backfill path, and keep the test out of the real repo

`9 files changed, 998 insertions(+), 29 deletions(-)`

---

<details><summary>The whole stack</summary>

| # | Branch | Tests |
|--:|---|--:|
| 1 | `stack/02-project-policy-layer` — a project carries its own policy | 356 |
| 2 | `stack/03-graph-project-scope` — graph from the project ontology | 359 |
| 3 | `stack/04-kg-atlas` — the atlas | 359 |
| 4 | `stack/05-graph-rebuild` — rebuild graphs and cards | 359 |
| 5 | `stack/06-kg-currency` — currency, and a stale-graph check | 372 |
| 6 | `stack/07-settings-format` — settings format migration | 372 |
| 7 | `stack/08-artifacts-by-scope` — artifacts beside what they describe | 372 |
| 8 | `stack/09-test-suite-layout` — group the suite, generate its index | 384 |
| 9 | `stack/10-script-folders` — name the script folders | 384 |
| 10 | `stack/11-gate-and-platform-ci` — gate renames, suite on PRs | 387 |
| 11 | `stack/12-architecture-map` — draw the repository | 397 |
| 12 | `stack/13-data-quality-toolkits` — expectations and anomalies | 401 |
| 13 | `stack/14-settings-schema` — align the scaffolder | 426 |
| 14 | `stack/15-ducklake-target` — DuckLake, warehouse MCP | 441 |
| 15 | `stack/16-capability-policies` — declare what must hold | 453 |
| 16 | `stack/17-platform-graph-mcp` — graph the platform layer | 453 |

</details>

<details><summary>This stack was reordered — what changed, and what did not</summary>

Branches 09–15 were red when first pushed, for three ordering defects. All three
are fixed and **the tip tree is byte-identical to before the reorder** — only
the order in which the work arrives changed.

**Two untracked test files were swept in five branches early.** `1ddd90b`'s own
message admits it: *"Also tracks two test files that existed only on disk"*.
`test_claude_settings.py` imports `pf.scaffold.claude_settings`, added at
stack/14; `test_warehouse_mcp.py` needs the warehouse MCP payloads, added at
stack/15. Both now arrive with their subjects. Until then the whole suite died
at collection.

**A consumer landed before its producer.** `54bc6c1` (stack/14) calls
`warehouse_capability`, which reads `ProductionWarehouse.mcp` — a field
declared by `dfaa46d` in stack/15. The field declaration moved back to the
commit that needs it; the per-warehouse payloads and DuckLake stayed put.

**Generated indexes described a future tree.** `platform/tests/README.md` at
stack/15 listed `test_capability_policies.py`, which does not exist until
stack/16. Both generated artefacts are now regenerated per branch, so each one
describes its own tree.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
