### PR TITLE
fix(kg): build the graph from the project ontology, not the group one

### DIFF
--- a/platform/src/pf/kg/build.py
+++ b/platform/src/pf/kg/build.py
@@ -4,7 +4,8 @@ Inputs (each optional — the builder degrades gracefully):
   contracts/annotations.yaml        ontology annotations exported by dlt sources
   transform/target/manifest.json    dbt models, columns, tests, exposures, lineage
   transform/target/semantic_manifest.json   MetricFlow metrics and dimensions
-  the platform ontology             concept nodes and the topology
+  governance/policy.yaml            this project's own policy overlay
+  the project ontology              concept nodes, the topology, the policy chain
 """
 
 from __future__ import annotations
@@ -14,7 +15,7 @@ from pathlib import Path
 
 from pf.kg.store import Edge, Node, open_graph
 from pf.ontology.annotate import load_annotations
-from pf.ontology.model import load_group_ontology, load_ontology
+from pf.ontology.model import load_group_ontology, load_ontology, load_project_ontology
 
 
 def cid(name: str) -> str: return f"concept:{name}"
@@ -102,11 +103,26 @@ def build_graph(project_dir: str | Path, group: str = "", project: str = "") -> 
     nodes: list[Node] = []
     edges: list[Edge] = []
 
-    # The group ontology, not the platform one: a term a steward approved into
-    # groups/<g>/ontology/extension.yaml is not usable by dbt, Wren, BI or an
-    # agent until it is in the graph, and building from the platform ontology
+    # The *project* ontology, not the platform one: a term a steward approved
+    # into groups/<g>/ontology/extension.yaml is not usable by dbt, Wren, BI or
+    # an agent until it is in the graph, and building from the platform ontology
     # silently drops every approved extension.
-    onto = load_group_ontology(_repo_root(root), group) if group else load_ontology()
+    #
+    # Resolving only as far as the group made the same mistake one layer in. The
+    # governance plane is what an agent walks to ask "what constrains this, and
+    # what proves it ran" — built at group scope it answers with the family's
+    # floor, so a project that raised a severity or declared an obligation of its
+    # own (acme-eu's GDPR erasure path) is governed by rules its own graph does
+    # not contain. The overlay may only tighten, so the project scope is always
+    # the stricter and truer answer.
+    repo = _repo_root(root)
+    name = project or root.name
+    if group and name:
+        onto = load_project_ontology(repo, group, name)
+    elif group:
+        onto = load_group_ontology(repo, group)
+    else:
+        onto = load_ontology()
 
     _add_ontology(nodes, edges, onto)
     _add_annotations(root, nodes, edges, onto)
@@ -200,7 +216,11 @@ def _add_policy(onto, nodes: list[Node], edges: list[Edge]) -> None:
             props={"constraint": p.constraint, "severity": p.severity,
                    "applies_to": p.applies_to, "params": p.params,
                    "enforced_by": p.enforced_by, "enforced": p.enforced,
-                   "intent": p.intent},
+                   "intent": p.intent,
+                   # Which layer set this severity. Without it the graph shows a
+                   # policy raised to error but not who raised it, which is the
+                   # one question `Policy.scope` exists to answer.
+                   "scope": p.scope},
         ))
         for e in p.evidence:
             edges.append(Edge(src=polid(p.id), dst=evid(e), kind="evidenced_by"))

--- a/platform/tests/test_policy_layering.py
+++ b/platform/tests/test_policy_layering.py
@@ -270,3 +270,92 @@ def test_bootstrap_leaves_an_existing_overlay_alone(
 
     assert _by_id(load_project_ontology(tmp_path, "acme", "acme-eu"),
                   "mart-declares-grain").severity == "error"
+
+
+# --------------------------------------------------------------- the graph --
+# The overlay is only real where it is read. `pf semantic policy` resolving at
+# project scope while `pf kg build` stopped at the group meant the governance
+# plane an agent walks was the family floor — so a project that raised a
+# severity, or declared an obligation of its own, was governed by rules its own
+# graph did not contain.
+
+def _graph_policies(pdir: Path, group: str, project: str) -> dict[str, dict]:
+    """Build a graph for `pdir` and return its Policy nodes by id."""
+    import duckdb
+    from pf.kg.build import build_graph
+
+    build_graph(pdir, group=group, project=project)
+    con = duckdb.connect(str(pdir / "kg" / "graph.duckdb"), read_only=True)
+    try:
+        rows = con.execute(
+            "SELECT name, json_extract_string(props, '$.severity'), "
+            "json_extract_string(props, '$.scope') "
+            "FROM kg_nodes WHERE kind = 'Policy'"
+        ).fetchall()
+    finally:
+        con.close()
+    return {r[0]: {"severity": r[1], "scope": r[2]} for r in rows}
+
+
+def test_graph_carries_the_projects_own_policy(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A policy only the project declares has to reach that project's graph."""
+    root = _fake_root(tmp_path, monkeypatch)
+    pdir = root / "groups" / "acme" / "projects" / "acme-eu"
+    _policy_file(pdir / "governance" / "policy.yaml", [{
+        "id": "gdpr-erasure-path",
+        "intent": "A subject access request must have somewhere to land.",
+        "constraint": "erasure_declared",
+        "applies_to": {"role_glob": "pii_*"},
+        "severity": "error",
+    }])
+
+    found = _graph_policies(pdir, "acme", "acme-eu")
+
+    assert "gdpr-erasure-path" in found
+    assert found["gdpr-erasure-path"]["scope"] == "project:acme/acme-eu"
+
+
+def test_graph_carries_a_tightened_severity_and_says_who_set_it(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The graph must show the tightened severity, and attribute it.
+
+    Severity alone is not enough: an agent reading `error` off the graph cannot
+    tell an obligation this project took on from one the whole platform carries,
+    and those warrant different conversations.
+    """
+    root = _fake_root(tmp_path, monkeypatch)
+    pdir = root / "groups" / "acme" / "projects" / "acme-eu"
+    _policy_file(pdir / "governance" / "policy.yaml",
+                 [{"id": "mart-declares-grain", "severity": "error"}])
+
+    platform_default = _by_id(load_ontology(), "mart-declares-grain").severity
+    assert platform_default != "error", "fixture assumes the floor is looser"
+
+    found = _graph_policies(pdir, "acme", "acme-eu")
+
+    assert found["mart-declares-grain"]["severity"] == "error"
+    assert found["mart-declares-grain"]["scope"] == "project:acme/acme-eu"
+
+
+def test_a_sister_without_an_overlay_keeps_the_floor(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """One sister's overlay must not leak into another's graph.
+
+    `load_ontology` is lru_cached and shared, so the leak this guards against
+    would surface in a project that declared nothing at all.
+    """
+    root = _fake_root(tmp_path, monkeypatch)
+    eu = root / "groups" / "acme" / "projects" / "acme-eu"
+    _policy_file(eu / "governance" / "policy.yaml",
+                 [{"id": "mart-declares-grain", "severity": "error"}])
+    _graph_policies(eu, "acme", "acme-eu")
+
+    us = root / "groups" / "acme" / "projects" / "acme-us"
+    us.mkdir(parents=True, exist_ok=True)
+    found = _graph_policies(us, "acme", "acme-us")
+
+    assert found["mart-declares-grain"]["severity"] == \
+        _by_id(load_ontology(), "mart-declares-grain").severity
+    assert found["mart-declares-grain"]["scope"] == "platform"
+    assert "gdpr-erasure-path" not in found


### PR DESCRIPTION
Part **2 of 16** of a stack. Base is `stack/02-project-policy-layer`, so this diff is only its
own commits. Merge in order.

**Tests on this branch: 359 passing.** Every branch in the stack is green
on its own, not only the tip.

## Commits

- `df452a1` Build the graph from the project ontology, not the group one

`2 files changed, 116 insertions(+), 7 deletions(-)`

---

<details><summary>The whole stack</summary>

| # | Branch | Tests |
|--:|---|--:|
| 1 | `stack/02-project-policy-layer` — a project carries its own policy | 356 |
| 2 | `stack/03-graph-project-scope` — graph from the project ontology | 359 |
| 3 | `stack/04-kg-atlas` — the atlas | 359 |
| 4 | `stack/05-graph-rebuild` — rebuild graphs and cards | 359 |
| 5 | `stack/06-kg-currency` — currency, and a stale-graph check | 372 |
| 6 | `stack/07-settings-format` — settings format migration | 372 |
| 7 | `stack/08-artifacts-by-scope` — artifacts beside what they describe | 372 |
| 8 | `stack/09-test-suite-layout` — group the suite, generate its index | 384 |
| 9 | `stack/10-script-folders` — name the script folders | 384 |
| 10 | `stack/11-gate-and-platform-ci` — gate renames, suite on PRs | 387 |
| 11 | `stack/12-architecture-map` — draw the repository | 397 |
| 12 | `stack/13-data-quality-toolkits` — expectations and anomalies | 401 |
| 13 | `stack/14-settings-schema` — align the scaffolder | 426 |
| 14 | `stack/15-ducklake-target` — DuckLake, warehouse MCP | 441 |
| 15 | `stack/16-capability-policies` — declare what must hold | 453 |
| 16 | `stack/17-platform-graph-mcp` — graph the platform layer | 453 |

</details>

<details><summary>This stack was reordered — what changed, and what did not</summary>

Branches 09–15 were red when first pushed, for three ordering defects. All three
are fixed and **the tip tree is byte-identical to before the reorder** — only
the order in which the work arrives changed.

**Two untracked test files were swept in five branches early.** `1ddd90b`'s own
message admits it: *"Also tracks two test files that existed only on disk"*.
`test_claude_settings.py` imports `pf.scaffold.claude_settings`, added at
stack/14; `test_warehouse_mcp.py` needs the warehouse MCP payloads, added at
stack/15. Both now arrive with their subjects. Until then the whole suite died
at collection.

**A consumer landed before its producer.** `54bc6c1` (stack/14) calls
`warehouse_capability`, which reads `ProductionWarehouse.mcp` — a field
declared by `dfaa46d` in stack/15. The field declaration moved back to the
commit that needs it; the per-warehouse payloads and DuckLake stayed put.

**Generated indexes described a future tree.** `platform/tests/README.md` at
stack/15 listed `test_capability_policies.py`, which does not exist until
stack/16. Both generated artefacts are now regenerated per branch, so each one
describes its own tree.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
