### PR TITLE
feat(kg): graph commands reach every project, and notice a stale one

### DIFF
--- a/.github/workflows/acme-eu.yml
+++ b/.github/workflows/acme-eu.yml
@@ -105,6 +105,32 @@ jobs:
           uv run pf kg build acme acme-eu
           uv run pf impact-gate acme acme-eu "${{ steps.changed.outputs.models }}"
 
+  # The graph has no clock. One built before a model landed answers every query
+  # confidently and wrongly, and nothing else notices — it simply holds fewer
+  # nodes than the project has models. Every other job here trusts that graph:
+  # the impact gate computes a blast radius from it, and an agent reads its
+  # context card. A stale graph makes both of those quietly wrong rather than
+  # loudly broken, which is why this is a gate and not a reminder.
+  kg-current:
+    needs: changes
+    if: needs.changes.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync
+
+      # `pf kg check` parses the dbt project first — `target/` is gitignored, so
+      # a runner has no manifest to compare the committed graph against, and
+      # without one the check reports "not exercised" and passes.
+      #
+      # It compares only what a runner without a warehouse can see: models,
+      # metrics and exposures come from the dbt manifests, which this checkout
+      # has. Columns are backfilled from information_schema, which it does not —
+      # comparing those too would be red on every pull request forever.
+      - name: Is the committed graph current?
+        run: uv run pf kg check acme acme-eu --strict
+
   # dbt review: what the change did to the data, not just to the DAG.
   #
   # Two upstream pieces, both pinned as submodules under vendor/recce:

--- a/.github/workflows/acme-rollup.yml
+++ b/.github/workflows/acme-rollup.yml
@@ -105,6 +105,32 @@ jobs:
           uv run pf kg build acme acme-rollup
           uv run pf impact-gate acme acme-rollup "${{ steps.changed.outputs.models }}"
 
+  # The graph has no clock. One built before a model landed answers every query
+  # confidently and wrongly, and nothing else notices — it simply holds fewer
+  # nodes than the project has models. Every other job here trusts that graph:
+  # the impact gate computes a blast radius from it, and an agent reads its
+  # context card. A stale graph makes both of those quietly wrong rather than
+  # loudly broken, which is why this is a gate and not a reminder.
+  kg-current:
+    needs: changes
+    if: needs.changes.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync
+
+      # `pf kg check` parses the dbt project first — `target/` is gitignored, so
+      # a runner has no manifest to compare the committed graph against, and
+      # without one the check reports "not exercised" and passes.
+      #
+      # It compares only what a runner without a warehouse can see: models,
+      # metrics and exposures come from the dbt manifests, which this checkout
+      # has. Columns are backfilled from information_schema, which it does not —
+      # comparing those too would be red on every pull request forever.
+      - name: Is the committed graph current?
+        run: uv run pf kg check acme acme-rollup --strict
+
   # dbt review: what the change did to the data, not just to the DAG.
   #
   # Two upstream pieces, both pinned as submodules under vendor/recce:

--- a/.github/workflows/acme-us.yml
+++ b/.github/workflows/acme-us.yml
@@ -105,6 +105,32 @@ jobs:
           uv run pf kg build acme acme-us
           uv run pf impact-gate acme acme-us "${{ steps.changed.outputs.models }}"
 
+  # The graph has no clock. One built before a model landed answers every query
+  # confidently and wrongly, and nothing else notices — it simply holds fewer
+  # nodes than the project has models. Every other job here trusts that graph:
+  # the impact gate computes a blast radius from it, and an agent reads its
+  # context card. A stale graph makes both of those quietly wrong rather than
+  # loudly broken, which is why this is a gate and not a reminder.
+  kg-current:
+    needs: changes
+    if: needs.changes.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync
+
+      # `pf kg check` parses the dbt project first — `target/` is gitignored, so
+      # a runner has no manifest to compare the committed graph against, and
+      # without one the check reports "not exercised" and passes.
+      #
+      # It compares only what a runner without a warehouse can see: models,
+      # metrics and exposures come from the dbt manifests, which this checkout
+      # has. Columns are backfilled from information_schema, which it does not —
+      # comparing those too would be red on every pull request forever.
+      - name: Is the committed graph current?
+        run: uv run pf kg check acme acme-us --strict
+
   # dbt review: what the change did to the data, not just to the DAG.
   #
   # Two upstream pieces, both pinned as submodules under vendor/recce:

--- a/.github/workflows/globex-core.yml
+++ b/.github/workflows/globex-core.yml
@@ -105,6 +105,32 @@ jobs:
           uv run pf kg build globex globex-core
           uv run pf impact-gate globex globex-core "${{ steps.changed.outputs.models }}"
 
+  # The graph has no clock. One built before a model landed answers every query
+  # confidently and wrongly, and nothing else notices — it simply holds fewer
+  # nodes than the project has models. Every other job here trusts that graph:
+  # the impact gate computes a blast radius from it, and an agent reads its
+  # context card. A stale graph makes both of those quietly wrong rather than
+  # loudly broken, which is why this is a gate and not a reminder.
+  kg-current:
+    needs: changes
+    if: needs.changes.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync
+
+      # `pf kg check` parses the dbt project first — `target/` is gitignored, so
+      # a runner has no manifest to compare the committed graph against, and
+      # without one the check reports "not exercised" and passes.
+      #
+      # It compares only what a runner without a warehouse can see: models,
+      # metrics and exposures come from the dbt manifests, which this checkout
+      # has. Columns are backfilled from information_schema, which it does not —
+      # comparing those too would be red on every pull request forever.
+      - name: Is the committed graph current?
+        run: uv run pf kg check globex globex-core --strict
+
   # dbt review: what the change did to the data, not just to the DAG.
   #
   # Two upstream pieces, both pinned as submodules under vendor/recce:

--- a/.github/workflows/globex-eu.yml
+++ b/.github/workflows/globex-eu.yml
@@ -105,6 +105,32 @@ jobs:
           uv run pf kg build globex globex-eu
           uv run pf impact-gate globex globex-eu "${{ steps.changed.outputs.models }}"
 
+  # The graph has no clock. One built before a model landed answers every query
+  # confidently and wrongly, and nothing else notices — it simply holds fewer
+  # nodes than the project has models. Every other job here trusts that graph:
+  # the impact gate computes a blast radius from it, and an agent reads its
+  # context card. A stale graph makes both of those quietly wrong rather than
+  # loudly broken, which is why this is a gate and not a reminder.
+  kg-current:
+    needs: changes
+    if: needs.changes.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync
+
+      # `pf kg check` parses the dbt project first — `target/` is gitignored, so
+      # a runner has no manifest to compare the committed graph against, and
+      # without one the check reports "not exercised" and passes.
+      #
+      # It compares only what a runner without a warehouse can see: models,
+      # metrics and exposures come from the dbt manifests, which this checkout
+      # has. Columns are backfilled from information_schema, which it does not —
+      # comparing those too would be red on every pull request forever.
+      - name: Is the committed graph current?
+        run: uv run pf kg check globex globex-eu --strict
+
   # dbt review: what the change did to the data, not just to the DAG.
   #
   # Two upstream pieces, both pinned as submodules under vendor/recce:

--- a/.github/workflows/jaffle-shop.yml
+++ b/.github/workflows/jaffle-shop.yml
@@ -105,6 +105,32 @@ jobs:
           uv run pf kg build jaffle jaffle-shop
           uv run pf impact-gate jaffle jaffle-shop "${{ steps.changed.outputs.models }}"
 
+  # The graph has no clock. One built before a model landed answers every query
+  # confidently and wrongly, and nothing else notices — it simply holds fewer
+  # nodes than the project has models. Every other job here trusts that graph:
+  # the impact gate computes a blast radius from it, and an agent reads its
+  # context card. A stale graph makes both of those quietly wrong rather than
+  # loudly broken, which is why this is a gate and not a reminder.
+  kg-current:
+    needs: changes
+    if: needs.changes.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync
+
+      # `pf kg check` parses the dbt project first — `target/` is gitignored, so
+      # a runner has no manifest to compare the committed graph against, and
+      # without one the check reports "not exercised" and passes.
+      #
+      # It compares only what a runner without a warehouse can see: models,
+      # metrics and exposures come from the dbt manifests, which this checkout
+      # has. Columns are backfilled from information_schema, which it does not —
+      # comparing those too would be red on every pull request forever.
+      - name: Is the committed graph current?
+        run: uv run pf kg check jaffle jaffle-shop --strict
+
   # dbt review: what the change did to the data, not just to the DAG.
   #
   # Two upstream pieces, both pinned as submodules under vendor/recce:

--- a/.github/workflows/zenith-de.yml
+++ b/.github/workflows/zenith-de.yml
@@ -105,6 +105,32 @@ jobs:
           uv run pf kg build zenith zenith-de
           uv run pf impact-gate zenith zenith-de "${{ steps.changed.outputs.models }}"
 
+  # The graph has no clock. One built before a model landed answers every query
+  # confidently and wrongly, and nothing else notices — it simply holds fewer
+  # nodes than the project has models. Every other job here trusts that graph:
+  # the impact gate computes a blast radius from it, and an agent reads its
+  # context card. A stale graph makes both of those quietly wrong rather than
+  # loudly broken, which is why this is a gate and not a reminder.
+  kg-current:
+    needs: changes
+    if: needs.changes.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync
+
+      # `pf kg check` parses the dbt project first — `target/` is gitignored, so
+      # a runner has no manifest to compare the committed graph against, and
+      # without one the check reports "not exercised" and passes.
+      #
+      # It compares only what a runner without a warehouse can see: models,
+      # metrics and exposures come from the dbt manifests, which this checkout
+      # has. Columns are backfilled from information_schema, which it does not —
+      # comparing those too would be red on every pull request forever.
+      - name: Is the committed graph current?
+        run: uv run pf kg check zenith zenith-de --strict
+
   # dbt review: what the change did to the data, not just to the DAG.
   #
   # Two upstream pieces, both pinned as submodules under vendor/recce:

--- a/.github/workflows/zenith-uk.yml
+++ b/.github/workflows/zenith-uk.yml
@@ -105,6 +105,32 @@ jobs:
           uv run pf kg build zenith zenith-uk
           uv run pf impact-gate zenith zenith-uk "${{ steps.changed.outputs.models }}"
 
+  # The graph has no clock. One built before a model landed answers every query
+  # confidently and wrongly, and nothing else notices — it simply holds fewer
+  # nodes than the project has models. Every other job here trusts that graph:
+  # the impact gate computes a blast radius from it, and an agent reads its
+  # context card. A stale graph makes both of those quietly wrong rather than
+  # loudly broken, which is why this is a gate and not a reminder.
+  kg-current:
+    needs: changes
+    if: needs.changes.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync
+
+      # `pf kg check` parses the dbt project first — `target/` is gitignored, so
+      # a runner has no manifest to compare the committed graph against, and
+      # without one the check reports "not exercised" and passes.
+      #
+      # It compares only what a runner without a warehouse can see: models,
+      # metrics and exposures come from the dbt manifests, which this checkout
+      # has. Columns are backfilled from information_schema, which it does not —
+      # comparing those too would be red on every pull request forever.
+      - name: Is the committed graph current?
+        run: uv run pf kg check zenith zenith-uk --strict
+
   # dbt review: what the change did to the data, not just to the DAG.
   #
   # Two upstream pieces, both pinned as submodules under vendor/recce:

--- a/docs/KG-ATLAS.md
+++ b/docs/KG-ATLAS.md
@@ -441,13 +441,89 @@ the graph is the stale one.
 
 ---
 
-## Rebuilding
+## Keeping it current
+
+The graph is only worth querying while it matches the project beside it. Three
+mechanisms keep it there, and none of them requires remembering a project name.
+
+### The commands take any scope
 
 ```bash
-uv run pf kg build <group> <project>    # parses dbt first if no manifest
-uv run pf kg card  <group> <project>    # regenerate the card, never hand-trim it
-uv run pf tokens                        # the card budgets, enforced
+uv run pf kg build                      # every project in every group
+uv run pf kg build acme                 # every project in one group
+uv run pf kg build acme acme-us         # one project
 ```
 
+`build`, `card` and `check` all widen the same way: **no arguments means
+everything**. A command that can only be pointed at one project at a time gets
+run for the project you remembered, which is how seven graphs end up a month
+stale while the eighth is fine.
+
+`pf kg build` parses the dbt project first when there is no manifest — without
+one the graph holds no Model nodes and every blast-radius query comes back empty.
+
+### A new group or project gets one on creation
+
+`pf new-project` runs the shared bootstrap, and building the graph, rendering the
+card and refreshing the group roster are steps in it. Nothing here is a follow-up
+you can forget:
+
+```console
+$ uv run pf new-project demo demo-us
+  ✓ knowledge graph          99 nodes across 6 kinds
+  ✓ context card             ~106 tokens / 1500
+  ✓ group card               sister roster refreshed
+  ✓ ci workflow              3 job(s): impact-gate, kg-current, recce
+```
+
+`pf bootstrap --all` does the same for every project that already exists, which
+is how a project created before a capability landed catches up.
+
+### CI fails a pull request that leaves it stale
+
+```bash
+uv run pf kg check                      # is every committed graph current?
+uv run pf kg check acme --strict        # one group; unjudgeable also fails
+```
+
+`pf kg check` compares the tracked `kg/graph.json` against the dbt manifests and
+reports what the project has that the graph does not:
+
+```console
+⛔ acme/acme-us — 4 resource(s) missing from the graph
+     models: fct_revenue
+     metrics: revenue
+     exposures: crm_customer_sync, exec_weekly_dashboard
+     run `pf kg build` and commit kg/graph.json
+```
+
+It compares **only what a runner without a warehouse can see** — models, metrics
+and exposures, which come from the manifests. Columns are backfilled from
+`information_schema`, which CI does not have, so comparing those too would be red
+on every pull request forever, and a permanently red check is one nobody reads.
+
+A project with no manifest at all reports **not exercised** rather than clean.
+That is the same refusal `GateNotExercised` makes: a green tick meaning "found
+nothing" is worse than no check, because it is trusted.
+
+The job reaches every project because it is contributed by a **capability**, not
+written into a workflow file:
+
+```python
+"github": Capability(
+    ci_jobs={"impact-gate": IMPACT_JOB, "kg-current": KG_CURRENT_JOB},
+    default_enabled=True,
+),
+```
+
+`_ci_workflow` composes one workflow per project from every enabled capability's
+jobs. Adding this job edited one dictionary — no scaffolder, no CLI, no workflow
+file — and the next `pf bootstrap --all` put it in all eight. A project created
+tomorrow gets it for the same reason, and an opt-in check would instead reach
+only the projects whose author remembered the flag.
+
+### What is tracked
+
 `kg/graph.duckdb` and `kg/context_card.md` are gitignored and rebuilt locally.
-`kg/graph.json` is tracked, so a graph change is reviewable in a diff.
+`kg/graph.json` is tracked, so a graph change is reviewable in a diff — and so
+CI has something to check the manifest against.

--- a/platform/src/pf/capabilities.py
+++ b/platform/src/pf/capabilities.py
@@ -407,6 +407,35 @@ policies: []
 """
 
 
+KG_CURRENT_JOB = """\
+  # The graph has no clock. One built before a model landed answers every query
+  # confidently and wrongly, and nothing else notices — it simply holds fewer
+  # nodes than the project has models. Every other job here trusts that graph:
+  # the impact gate computes a blast radius from it, and an agent reads its
+  # context card. A stale graph makes both of those quietly wrong rather than
+  # loudly broken, which is why this is a gate and not a reminder.
+  kg-current:
+    needs: changes
+    if: needs.changes.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync
+
+      # `pf kg check` parses the dbt project first — `target/` is gitignored, so
+      # a runner has no manifest to compare the committed graph against, and
+      # without one the check reports "not exercised" and passes.
+      #
+      # It compares only what a runner without a warehouse can see: models,
+      # metrics and exposures come from the dbt manifests, which this checkout
+      # has. Columns are backfilled from information_schema, which it does not —
+      # comparing those too would be red on every pull request forever.
+      - name: Is the committed graph current?
+        run: uv run pf kg check {{group}} {{project}} --strict
+"""
+
+
 CAPABILITIES: dict[str, Capability] = {
     "governance": Capability(
         name="governance",
@@ -453,9 +482,10 @@ CAPABILITIES: dict[str, Capability] = {
     ),
     "github": Capability(
         name="github",
-        description="Run the impact gate on every pull request touching this project.",
+        description="Run the impact gate and the graph currency check on every "
+                    "pull request touching this project.",
         files={"docs/github.md": GITHUB_README},
-        ci_jobs={"impact-gate": IMPACT_JOB},
+        ci_jobs={"impact-gate": IMPACT_JOB, "kg-current": KG_CURRENT_JOB},
         settings={
             "permissions": {"allow": ["Bash(gh pr view:*)", "Bash(gh pr diff:*)"]},
         },

--- a/platform/src/pf/cli.py
+++ b/platform/src/pf/cli.py
@@ -666,35 +666,108 @@ def work(group: str, project: str) -> None:
 
 # ------------------------------------------------------------ graph & card --
 @kg_app.command("build")
-def cmd_kg_build(group: str, project: str,
+def cmd_kg_build(group: str = typer.Argument("", help="omit for every group"),
+                 project: str = typer.Argument("", help="omit for every project in the group"),
                  parse: bool = typer.Option(
                      True, help="parse the dbt project first if it has no manifest")) -> None:
-    """Rebuild a project's knowledge graph from annotations + dbt manifests."""
-    d = pdir(group, project)
-    # The builder treats the manifest as optional and degrades without it. That
-    # is the right default for a source of documentation and the wrong one for
-    # the graph CI gates against: no manifest means no Model, Metric or Exposure
-    # nodes, and a blast-radius query over that graph finds nothing and says so.
-    if parse:
-        from pf.runtime.dbt_runtime import ensure_manifest
-        from pf.runtime.warehouse import Warehouse
-        ensure_manifest(d, duckdb_path=Warehouse.for_project(d, group, project).path)
-    counts = build_graph(d, group=group, project=project)
-    t = Table("kind", "nodes", title=f"{group}/{project} graph")
-    for k, v in sorted(counts.items()):
-        t.add_row(k, str(v))
+    """Rebuild knowledge graphs. No arguments → every project."""
+    targets = _targets(group, project)
+    rows: list[tuple[str, dict[str, int]]] = []
+    for g, p, d in targets:
+        # The builder treats the manifest as optional and degrades without it.
+        # That is the right default for a source of documentation and the wrong
+        # one for the graph CI gates against: no manifest means no Model, Metric
+        # or Exposure nodes, and a blast-radius query over that graph finds
+        # nothing and says so.
+        if parse:
+            from pf.runtime.dbt_runtime import ensure_manifest
+            from pf.runtime.warehouse import Warehouse
+            ensure_manifest(d, duckdb_path=Warehouse.for_project(d, g, p).path)
+        rows.append((f"{g}/{p}", build_graph(d, group=g, project=p)))
+
+    if len(rows) == 1:
+        name, counts = rows[0]
+        t = Table("kind", "nodes", title=f"{name} graph")
+        for k, v in sorted(counts.items()):
+            t.add_row(k, str(v))
+        console.print(t)
+        return
+
+    # Across many projects the per-kind breakdown is noise; what is worth seeing
+    # at a glance is the kinds whose absence means something. A zero here is the
+    # finding — no Model means the gate cannot run at all.
+    t = Table("project", "nodes", "models", "metrics", "policies",
+              title=f"{len(rows)} graph(s) rebuilt")
+    for name, counts in rows:
+        def cell(kind: str, c: dict[str, int] = counts) -> str:
+            n = c.get(kind, 0)
+            return str(n) if n else "[red]0[/]"
+        t.add_row(name, str(sum(counts.values())),
+                  cell("Model"), cell("Metric"), cell("Policy"))
     console.print(t)
 
 
 @kg_app.command("card")
-def cmd_kg_card(group: str, project: str) -> None:
-    """Regenerate the context card (the always-in-context index)."""
-    d = pdir(group, project)
-    p = render_project_card(d, group, project)
-    render_group_card(root() / "groups" / group, group)
-    tokens = estimate_tokens(p.read_text())
-    status = "green" if tokens <= PROJECT_CARD_BUDGET else "red"
-    console.print(f"[{status}]✓[/] {p}  (~{tokens} tokens / {PROJECT_CARD_BUDGET} budget)")
+def cmd_kg_card(group: str = typer.Argument("", help="omit for every group"),
+                project: str = typer.Argument("", help="omit for every project in the group")) -> None:
+    """Regenerate context cards. No arguments → every project."""
+    targets = _targets(group, project)
+    for g, p, d in targets:
+        card = render_project_card(d, g, p)
+        tokens = estimate_tokens(card.read_text())
+        ok = tokens <= PROJECT_CARD_BUDGET
+        # Rendering reports the budget but does not enforce it — `pf tokens` is
+        # the enforcement point, and having two commands fail on the same
+        # condition means fixing it twice and trusting neither.
+        console.print(f"[{'green' if ok else 'red'}]✓[/] {g}/{p}"
+                      f"  [dim](~{tokens} tokens / {PROJECT_CARD_BUDGET})[/]")
+    # Once per group, not once per project: the group card is a roster of
+    # sisters, so rendering it inside the loop rewrites the same file N times.
+    for g in sorted({g for g, _, _ in targets}):
+        render_group_card(root() / "groups" / g, g)
+
+
+@kg_app.command("check")
+def cmd_kg_check(group: str = typer.Argument("", help="omit for every group"),
+                 project: str = typer.Argument("", help="omit for every project in the group"),
+                 strict: bool = typer.Option(
+                     False, "--strict",
+                     help="a project that cannot be judged fails too"),
+                 parse: bool = typer.Option(
+                     True, help="parse the dbt project first if it has no manifest")) -> None:
+    """Is each committed graph current with the dbt project beside it?
+
+    The graph has no clock. One built before a model landed answers every query
+    confidently and wrongly, and nothing else in the repo notices — it simply
+    holds fewer nodes than the project has models. This is what notices.
+    """
+    from pf.kg.build import graph_drift
+
+    drifted = unexercised = 0
+    for g, p, d in _targets(group, project):
+        # `target/` is gitignored, so a fresh checkout — every CI runner — has no
+        # manifest to compare the committed graph against. Without this the check
+        # reports "not exercised" everywhere it matters most and passes.
+        if parse:
+            from pf.runtime.dbt_runtime import ensure_manifest
+            from pf.runtime.warehouse import Warehouse
+            try:
+                ensure_manifest(d, duckdb_path=Warehouse.for_project(d, g, p).path)
+            except Exception as exc:  # noqa: BLE001 — reported per project, not fatal
+                console.print(f"[dim]{g}/{p}: dbt parse failed — {exc}[/]")
+        report = graph_drift(d, f"{g}/{p}")
+        console.print(report.render())
+        if not report.exercised:
+            unexercised += 1
+        elif report.total:
+            drifted += 1
+
+    if drifted:
+        console.print(f"[red]{drifted} stale graph(s)[/] — run `pf kg build` and commit "
+                      f"kg/graph.json")
+    if unexercised and strict:
+        console.print(f"[red]{unexercised} graph(s) could not be checked[/]")
+    raise typer.Exit(1 if drifted or (unexercised and strict) else 0)
 
 
 @kg_app.command("search")
@@ -2176,12 +2249,25 @@ def _recce_or_exit():  # the pf.tools.recce module, for its key semantics
 
 
 def _targets(group: str, project: str) -> list[tuple[str, str, Path]]:
-    """One project, or every project when neither argument is given."""
+    """One project, one group, or every project when nothing is given.
+
+    The widening from "both or neither" is what lets the graph commands be run
+    the way they are actually needed — `pf kg build` after adding a project
+    anywhere, `pf kg build acme` after changing something a family shares. A
+    command that can only be pointed at one project at a time gets run for the
+    project you remembered, which is how seven graphs end up a month stale.
+    """
     if group and project:
         return [(group, project, pdir(group, project))]
-    if group or project:
-        console.print("[red]give both group and project, or neither[/]")
+    if project:
+        console.print("[red]a project needs its group[/]")
         raise typer.Exit(1)
+    if group:
+        hits = [(g, p, d) for g, p, d in all_projects() if g == group]
+        if not hits:
+            console.print(f"[red]group {group} has no projects[/]")
+            raise typer.Exit(1)
+        return hits
     return all_projects()
 
 

--- a/platform/src/pf/kg/build.py
+++ b/platform/src/pf/kg/build.py
@@ -11,6 +11,7 @@ Inputs (each optional — the builder degrades gracefully):
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from pf.kg.store import Edge, Node, open_graph
@@ -431,6 +432,91 @@ def _add_semantic(root: Path, nodes: list[Node], edges: list[Edge]) -> None:
             if owner:
                 edges.append(Edge(src=mid(owner), dst=n_id, kind="measures",
                                   props={"measure": measure}))
+
+
+@dataclass
+class GraphDrift:
+    """dbt resources the manifest declares that the tracked graph does not hold.
+
+    Deliberately compares **only what a runner without a warehouse can see**.
+    Models, metrics and exposures come from the dbt manifests, which any checkout
+    has; columns are backfilled from `information_schema`, which CI does not. A
+    check that compared columns too would be red on every pull request forever,
+    and a permanently red check is one nobody reads.
+
+    `exercised` is the honest third answer. A project with no manifest cannot be
+    judged either way, and reporting that as "no drift" would be the same green
+    tick for "found nothing" that `GateNotExercised` exists to refuse.
+    """
+
+    project: str
+    exercised: bool
+    reason: str = ""
+    models: list[str] = field(default_factory=list)
+    metrics: list[str] = field(default_factory=list)
+    exposures: list[str] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return len(self.models) + len(self.metrics) + len(self.exposures)
+
+    def render(self) -> str:
+        if not self.exercised:
+            return f"?  {self.project} — not exercised: {self.reason}"
+        if not self.total:
+            return f"✓  {self.project} — graph is current"
+        parts = [f"⛔ {self.project} — {self.total} resource(s) missing from the graph"]
+        for label, names in (("models", self.models), ("metrics", self.metrics),
+                             ("exposures", self.exposures)):
+            if names:
+                head = ", ".join(sorted(names)[:8])
+                rest = f", +{len(names) - 8} more" if len(names) > 8 else ""
+                parts.append(f"     {label}: {head}{rest}")
+        parts.append("     run `pf kg build` and commit kg/graph.json")
+        return "\n".join(parts)
+
+
+def graph_drift(project_dir: str | Path, project: str = "") -> GraphDrift:
+    """Is the committed graph current with the dbt project beside it?
+
+    This is the question a merge gate needs and `pf kg build` cannot answer:
+    the graph is a build artefact with no clock, so one built before a model
+    landed answers confidently and wrongly. Nothing else in the repo notices —
+    the graph simply has fewer nodes than the project has models.
+    """
+    root = Path(project_dir)
+    name = project or root.name
+
+    manifest_path = root / "transform" / "target" / "manifest.json"
+    if not manifest_path.exists():
+        return GraphDrift(name, exercised=False,
+                          reason="no dbt manifest; run `pf kg build` (which parses first)")
+
+    graph_json = root / "kg" / "graph.json"
+    if not graph_json.exists():
+        return GraphDrift(name, exercised=False,
+                          reason="no kg/graph.json; the graph has never been built")
+
+    payload = json.loads(graph_json.read_text())
+    have = {(n.get("kind"), n.get("name")) for n in payload.get("nodes") or []}
+
+    manifest = json.loads(manifest_path.read_text())
+    drift = GraphDrift(name, exercised=True)
+
+    for node in (manifest.get("nodes") or {}).values():
+        if node.get("resource_type") == "model" and ("Model", node["name"]) not in have:
+            drift.models.append(node["name"])
+    for exp in (manifest.get("exposures") or {}).values():
+        if ("Exposure", exp["name"]) not in have:
+            drift.exposures.append(exp["name"])
+
+    sm_path = root / "transform" / "target" / "semantic_manifest.json"
+    if sm_path.exists():
+        sm = json.loads(sm_path.read_text())
+        for metric in sm.get("metrics") or []:
+            if ("Metric", metric["name"]) not in have:
+                drift.metrics.append(metric["name"])
+    return drift
 
 
 def _export_json(graph_path: Path, out_path: Path) -> None:

--- a/platform/tests/test_kg_currency.py
+++ b/platform/tests/test_kg_currency.py
@@ -1,0 +1,205 @@
+"""Tests for the graph currency check and the bulk graph commands.
+
+The graph is a build artefact with no clock. One built before a model landed
+answers every query confidently and wrongly, and nothing else in the repo
+notices — it simply holds fewer nodes than the project has models. Every other
+guarantee is downstream of that: the impact gate computes a blast radius from
+the graph, and an agent reads its context card.
+
+The check has to be warehouse-independent to be worth having. A CI runner has a
+checkout and no warehouse, so a check that compared *columns* — backfilled from
+`information_schema` — would be red on every pull request forever, and a
+permanently red check is one nobody reads.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pf.kg.build import graph_drift
+
+
+def _manifest(pdir: Path, models: list[str], exposures: list[str] | None = None) -> None:
+    nodes = {
+        f"model.demo.{m}": {"resource_type": "model", "name": m, "path": f"marts/{m}.sql"}
+        for m in models
+    }
+    exps = {f"exposure.demo.{e}": {"name": e, "type": "dashboard"} for e in exposures or []}
+    target = pdir / "transform" / "target"
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "manifest.json").write_text(
+        json.dumps({"nodes": nodes, "exposures": exps, "parent_map": {}, "child_map": {}}))
+
+
+def _semantic(pdir: Path, metrics: list[str]) -> None:
+    target = pdir / "transform" / "target"
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "semantic_manifest.json").write_text(
+        json.dumps({"metrics": [{"name": m, "type": "simple"} for m in metrics],
+                    "semantic_models": []}))
+
+
+def _graph_json(pdir: Path, nodes: list[tuple[str, str]]) -> None:
+    kg = pdir / "kg"
+    kg.mkdir(parents=True, exist_ok=True)
+    (kg / "graph.json").write_text(json.dumps({
+        "nodes": [{"id": f"{k.lower()}:{n}", "kind": k, "name": n,
+                   "layer": "", "label": "", "props": {}} for k, n in nodes],
+        "edges": [],
+    }))
+
+
+# ------------------------------------------------------------- the check ----
+def test_a_current_graph_reports_no_drift(tmp_path: Path) -> None:
+    _manifest(tmp_path, ["fct_payments", "dim_customers"])
+    _graph_json(tmp_path, [("Model", "fct_payments"), ("Model", "dim_customers")])
+
+    d = graph_drift(tmp_path, "demo/demo-us")
+
+    assert d.exercised
+    assert d.total == 0
+    assert "current" in d.render()
+
+
+def test_a_model_added_after_the_last_build_is_caught(tmp_path: Path) -> None:
+    """The failure this exists for: the graph predates a model in the project."""
+    _manifest(tmp_path, ["fct_payments", "fct_revenue"])
+    _graph_json(tmp_path, [("Model", "fct_payments")])
+
+    d = graph_drift(tmp_path, "demo/demo-us")
+
+    assert d.exercised
+    assert d.models == ["fct_revenue"]
+    assert d.total == 1
+    assert "fct_revenue" in d.render()
+    assert "pf kg build" in d.render(), "a failure must say how to fix it"
+
+
+def test_metrics_and_exposures_drift_too(tmp_path: Path) -> None:
+    _manifest(tmp_path, ["fct_payments"], exposures=["exec_dashboard"])
+    _semantic(tmp_path, ["revenue", "aov"])
+    _graph_json(tmp_path, [("Model", "fct_payments"), ("Metric", "revenue")])
+
+    d = graph_drift(tmp_path, "demo/demo-us")
+
+    assert d.metrics == ["aov"]
+    assert d.exposures == ["exec_dashboard"]
+    assert d.total == 2
+
+
+def test_columns_are_not_compared(tmp_path: Path) -> None:
+    """Columns are backfilled from the warehouse, which CI does not have.
+
+    Comparing them would make this check red on every pull request forever, and
+    a permanently red check is one nobody reads. A graph holding no columns at
+    all is still *current* by this measure.
+    """
+    _manifest(tmp_path, ["fct_payments"])
+    _graph_json(tmp_path, [("Model", "fct_payments")])  # no Column nodes at all
+
+    assert graph_drift(tmp_path, "demo/demo-us").total == 0
+
+
+# ------------------------------------------------------- cannot be judged ---
+def test_no_manifest_is_not_exercised_rather_than_clean(tmp_path: Path) -> None:
+    """A green tick meaning "found nothing" is worse than no check."""
+    _graph_json(tmp_path, [("Model", "fct_payments")])
+
+    d = graph_drift(tmp_path, "demo/demo-us")
+
+    assert not d.exercised
+    assert d.total == 0
+    assert "not exercised" in d.render()
+
+
+def test_a_graph_that_was_never_built_is_not_exercised(tmp_path: Path) -> None:
+    _manifest(tmp_path, ["fct_payments"])
+
+    d = graph_drift(tmp_path, "demo/demo-us")
+
+    assert not d.exercised
+    assert "never been built" in d.reason
+
+
+# ------------------------------------------------------------ the reach -----
+def test_the_ci_job_is_carried_by_a_default_capability() -> None:
+    """The job must arrive without anyone remembering to ask for it.
+
+    This is the whole reason it is a capability rather than a workflow file: an
+    opt-in check reaches the projects whose author remembered the flag, which is
+    how seven graphs go stale while the eighth is gated.
+    """
+    from pf.capabilities import CAPABILITIES, defaults
+
+    owners = [c for c in CAPABILITIES.values() if "kg-current" in c.ci_jobs]
+    assert owners, "no capability contributes the kg-current job"
+    assert all(c.name in defaults() for c in owners), \
+        "the graph currency check must be default-enabled"
+
+
+def test_the_ci_job_parameterises_group_and_project() -> None:
+    """A job that hardcoded a project would gate the wrong graph everywhere else."""
+    from pf.capabilities import KG_CURRENT_JOB
+
+    assert "{{group}}" in KG_CURRENT_JOB and "{{project}}" in KG_CURRENT_JOB
+    assert "--strict" in KG_CURRENT_JOB, \
+        "without --strict a runner with no manifest passes vacuously"
+
+
+def test_every_capability_job_renders_without_leftovers() -> None:
+    """No `{{placeholder}}` may survive into a generated workflow.
+
+    GitHub's own expressions are `${{ ... }}`, so the test has to distinguish
+    them from pf's `{{name}}` rather than searching for `{{`.
+    """
+    import re
+
+    from pf.capabilities import CAPABILITIES
+    from pf.scaffold.ci import render_project_workflow
+
+    jobs: dict[str, str] = {}
+    for cap in CAPABILITIES.values():
+        jobs.update(cap.ci_jobs)
+    rendered = render_project_workflow("demo", "demo-us", jobs)
+
+    leftover = re.findall(r"(?<!\$)\{\{\s*\w+\s*\}\}", rendered)
+    assert not leftover, f"unsubstituted placeholders: {set(leftover)}"
+    assert "pf kg check demo demo-us" in rendered
+
+
+# ------------------------------------------------------------ bulk scope ----
+@pytest.mark.parametrize("group,project,expected", [
+    ("", "", {"a/one", "a/two", "b/three"}),   # nothing  -> every project
+    ("a", "", {"a/one", "a/two"}),             # a group  -> its projects
+    ("a", "one", {"a/one"}),                   # both     -> one project
+])
+def test_targets_widens_from_nothing_to_one(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        group: str, project: str, expected: set[str]) -> None:
+    """`pf kg build` must be runnable at every scope a change happens at."""
+    from pf import cli
+
+    (tmp_path / "platform").mkdir()
+    for g, p in (("a", "one"), ("a", "two"), ("b", "three")):
+        (tmp_path / "groups" / g / "projects" / p).mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+
+    got = {f"{g}/{p}" for g, p, _ in cli._targets(group, project)}
+
+    assert got == expected
+
+
+def test_a_project_without_its_group_is_refused(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`pf kg build "" acme-us` is ambiguous: two groups may hold that name."""
+    import typer
+    from pf import cli
+
+    (tmp_path / "platform").mkdir()
+    (tmp_path / "groups" / "a" / "projects" / "one").mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(typer.Exit):
+        cli._targets("", "one")


### PR DESCRIPTION
Part **5 of 16** of a stack. Base is `stack/05-graph-rebuild`, so this diff is only its
own commits. Merge in order.

**Tests on this branch: 372 passing.** Every branch in the stack is green
on its own, not only the tip.

## Commits

- `9e71322` Make the graph commands reach every project, and notice when one goes stale
- `c412333` Regenerate the project workflows with the graph currency job

`13 files changed, 724 insertions(+), 33 deletions(-)`

---

<details><summary>The whole stack</summary>

| # | Branch | Tests |
|--:|---|--:|
| 1 | `stack/02-project-policy-layer` — a project carries its own policy | 356 |
| 2 | `stack/03-graph-project-scope` — graph from the project ontology | 359 |
| 3 | `stack/04-kg-atlas` — the atlas | 359 |
| 4 | `stack/05-graph-rebuild` — rebuild graphs and cards | 359 |
| 5 | `stack/06-kg-currency` — currency, and a stale-graph check | 372 |
| 6 | `stack/07-settings-format` — settings format migration | 372 |
| 7 | `stack/08-artifacts-by-scope` — artifacts beside what they describe | 372 |
| 8 | `stack/09-test-suite-layout` — group the suite, generate its index | 384 |
| 9 | `stack/10-script-folders` — name the script folders | 384 |
| 10 | `stack/11-gate-and-platform-ci` — gate renames, suite on PRs | 387 |
| 11 | `stack/12-architecture-map` — draw the repository | 397 |
| 12 | `stack/13-data-quality-toolkits` — expectations and anomalies | 401 |
| 13 | `stack/14-settings-schema` — align the scaffolder | 426 |
| 14 | `stack/15-ducklake-target` — DuckLake, warehouse MCP | 441 |
| 15 | `stack/16-capability-policies` — declare what must hold | 453 |
| 16 | `stack/17-platform-graph-mcp` — graph the platform layer | 453 |

</details>

<details><summary>This stack was reordered — what changed, and what did not</summary>

Branches 09–15 were red when first pushed, for three ordering defects. All three
are fixed and **the tip tree is byte-identical to before the reorder** — only
the order in which the work arrives changed.

**Two untracked test files were swept in five branches early.** `1ddd90b`'s own
message admits it: *"Also tracks two test files that existed only on disk"*.
`test_claude_settings.py` imports `pf.scaffold.claude_settings`, added at
stack/14; `test_warehouse_mcp.py` needs the warehouse MCP payloads, added at
stack/15. Both now arrive with their subjects. Until then the whole suite died
at collection.

**A consumer landed before its producer.** `54bc6c1` (stack/14) calls
`warehouse_capability`, which reads `ProductionWarehouse.mcp` — a field
declared by `dfaa46d` in stack/15. The field declaration moved back to the
commit that needs it; the per-warehouse payloads and DuckLake stayed put.

**Generated indexes described a future tree.** `platform/tests/README.md` at
stack/15 listed `test_capability_policies.py`, which does not exist until
stack/16. Both generated artefacts are now regenerated per branch, so each one
describes its own tree.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
