### PR TITLE
fix(settings): migrate plugin settings to the format Claude Code writes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,14 +3,15 @@
   "extraKnownMarketplaces": {
     "platform": {
       "source": {
-        "source": "./platform"
+        "source": "directory",
+        "path": "./platform"
       }
     }
   },
-  "enabledPlugins": [
-    "platform-init@platform",
-    "power-tools@platform"
-  ],
+  "enabledPlugins": {
+    "platform-init@platform": true,
+    "power-tools@platform": true
+  },
   "permissions": {
     "deny": [
       "Read(./.env)",

--- a/groups/jaffle/projects/jaffle-shop/.claude/settings.json
+++ b/groups/jaffle/projects/jaffle-shop/.claude/settings.json
@@ -2,32 +2,34 @@
   "extraKnownMarketplaces": {
     "platform": {
       "source": {
-        "source": "../../../../platform"
+        "source": "directory",
+        "path": "../../../../platform"
       }
     },
     "jaffle": {
       "source": {
-        "source": "../.."
+        "source": "directory",
+        "path": "../.."
       }
     }
   },
-  "enabledPlugins": [
-    "platform-init@platform",
-    "dlt-ingest@platform",
-    "dlt-quality@platform",
-    "dlt-explore@platform",
-    "duckdb-ops@platform",
-    "dbt-modeling@platform",
-    "dbt-semantic@platform",
-    "dbt-testing@platform",
-    "dbt-govern@platform",
-    "dagster-orchestrate@platform",
-    "python-standards@platform",
-    "jaffle-group@jaffle",
-    "evidence-bi@platform",
-    "dbt-snowflake@platform",
-    "power-tools@platform"
-  ],
+  "enabledPlugins": {
+    "platform-init@platform": true,
+    "dlt-ingest@platform": true,
+    "dlt-quality@platform": true,
+    "dlt-explore@platform": true,
+    "duckdb-ops@platform": true,
+    "dbt-modeling@platform": true,
+    "dbt-semantic@platform": true,
+    "dbt-testing@platform": true,
+    "dbt-govern@platform": true,
+    "dagster-orchestrate@platform": true,
+    "python-standards@platform": true,
+    "jaffle-group@jaffle": true,
+    "evidence-bi@platform": true,
+    "dbt-snowflake@platform": true,
+    "power-tools@platform": true
+  },
   "permissions": {
     "deny": [
       "Read(../*/src/**)",


### PR DESCRIPTION
Part **6 of 16** of a stack. Base is `stack/06-kg-currency`, so this diff is only its
own commits. Merge in order.

**Tests on this branch: 372 passing.** Every branch in the stack is green
on its own, not only the tip.

## Commits

- `2ef18db` Migrate plugin settings to the format Claude Code now writes

`2 files changed, 27 insertions(+), 24 deletions(-)`

---

<details><summary>The whole stack</summary>

| # | Branch | Tests |
|--:|---|--:|
| 1 | `stack/02-project-policy-layer` — a project carries its own policy | 356 |
| 2 | `stack/03-graph-project-scope` — graph from the project ontology | 359 |
| 3 | `stack/04-kg-atlas` — the atlas | 359 |
| 4 | `stack/05-graph-rebuild` — rebuild graphs and cards | 359 |
| 5 | `stack/06-kg-currency` — currency, and a stale-graph check | 372 |
| 6 | `stack/07-settings-format` — settings format migration | 372 |
| 7 | `stack/08-artifacts-by-scope` — artifacts beside what they describe | 372 |
| 8 | `stack/09-test-suite-layout` — group the suite, generate its index | 384 |
| 9 | `stack/10-script-folders` — name the script folders | 384 |
| 10 | `stack/11-gate-and-platform-ci` — gate renames, suite on PRs | 387 |
| 11 | `stack/12-architecture-map` — draw the repository | 397 |
| 12 | `stack/13-data-quality-toolkits` — expectations and anomalies | 401 |
| 13 | `stack/14-settings-schema` — align the scaffolder | 426 |
| 14 | `stack/15-ducklake-target` — DuckLake, warehouse MCP | 441 |
| 15 | `stack/16-capability-policies` — declare what must hold | 453 |
| 16 | `stack/17-platform-graph-mcp` — graph the platform layer | 453 |

</details>

<details><summary>This stack was reordered — what changed, and what did not</summary>

Branches 09–15 were red when first pushed, for three ordering defects. All three
are fixed and **the tip tree is byte-identical to before the reorder** — only
the order in which the work arrives changed.

**Two untracked test files were swept in five branches early.** `1ddd90b`'s own
message admits it: *"Also tracks two test files that existed only on disk"*.
`test_claude_settings.py` imports `pf.scaffold.claude_settings`, added at
stack/14; `test_warehouse_mcp.py` needs the warehouse MCP payloads, added at
stack/15. Both now arrive with their subjects. Until then the whole suite died
at collection.

**A consumer landed before its producer.** `54bc6c1` (stack/14) calls
`warehouse_capability`, which reads `ProductionWarehouse.mcp` — a field
declared by `dfaa46d` in stack/15. The field declaration moved back to the
commit that needs it; the per-warehouse payloads and DuckLake stayed put.

**Generated indexes described a future tree.** `platform/tests/README.md` at
stack/15 listed `test_capability_policies.py`, which does not exist until
stack/16. Both generated artefacts are now regenerated per branch, so each one
describes its own tree.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
