### PR TITLE
refactor(docs): keep each published artifact beside what it describes

### DIFF
--- a/docs/kg-atlas.html
+++ b/docs/kg-atlas.html
@@ -1,0 +1,915 @@
+<title>Knowledge Graph Atlas</title>
+<style>
+  :root {
+    --ground:   #f5f8f7;
+    --surface:  #ffffff;
+    --sunk:     #eaf1ef;
+    --ink:      #0f1a18;
+    --muted:    #566a66;
+    --faint:    #7d8f8b;
+    --hair:     #d5e2de;
+    --hair-2:   #b9ccc7;
+    --accent:   #0d7d72;
+    --accent-q: #e2f3f0;
+    --plate:    #fbfdfc;
+    --plate-ed: #dfe9e6;
+
+    /* Plane hues. Theme-invariant on purpose: these same values go into the
+       mermaid classDefs, which no media query can reach. */
+    --phy: #0f766e;  --phy-bg: #d9f4ee;
+    --sem: #5b21b6;  --sem-bg: #e9e1fb;
+    --gov: #334155;  --gov-bg: #e0e6ed;
+
+    --warn:   #9a3412;
+    --warn-bg:#fdece4;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --ground:   #0b1211;
+      --surface:  #131d1b;
+      --sunk:     #101917;
+      --ink:      #e8f0ee;
+      --muted:    #94a8a3;
+      --faint:    #7a8d89;
+      --hair:     #22322f;
+      --hair-2:   #2f4340;
+      --accent:   #48c2b1;
+      --accent-q: #102b28;
+      --plate:    #e9efed;
+      --plate-ed: #c3d0cd;
+      --warn:   #f0a882;
+      --warn-bg:#2a1a12;
+    }
+  }
+
+  :root[data-theme="dark"] {
+    --ground:   #0b1211;
+    --surface:  #131d1b;
+    --sunk:     #101917;
+    --ink:      #e8f0ee;
+    --muted:    #94a8a3;
+    --faint:    #7a8d89;
+    --hair:     #22322f;
+    --hair-2:   #2f4340;
+    --accent:   #48c2b1;
+    --accent-q: #102b28;
+    --plate:    #e9efed;
+    --plate-ed: #c3d0cd;
+    --warn:   #f0a882;
+    --warn-bg:#2a1a12;
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    background: var(--ground);
+    color: var(--ink);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    font-size: 16.5px;
+    line-height: 1.62;
+    margin: 0;
+    padding: 0 1.25rem 6rem;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wrap { max-width: 62rem; margin: 0 auto; }
+  .prose { max-width: 40rem; }
+
+  /* ---- type roles ---- */
+  h1, h2, h3 {
+    font-family: ui-serif, Georgia, "Iowan Old Style", "Palatino Linotype", Palatino, serif;
+    font-weight: 600;
+    text-wrap: balance;
+    letter-spacing: -0.011em;
+  }
+  h1 { font-size: clamp(2.1rem, 5.2vw, 3.05rem); line-height: 1.08; margin: 0 0 0.8rem; }
+  h2 { font-size: clamp(1.42rem, 3vw, 1.78rem); line-height: 1.2; margin: 0 0 0.55rem; }
+  h3 { font-size: 1.09rem; line-height: 1.32; margin: 2.1rem 0 0.5rem; }
+
+  .eyebrow {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.705rem;
+    letter-spacing: 0.13em;
+    text-transform: uppercase;
+    color: var(--faint);
+  }
+
+  code, .mono {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.855em;
+  }
+  p code, li code, td code {
+    background: var(--sunk);
+    border: 1px solid var(--hair);
+    border-radius: 3px;
+    padding: 0.05em 0.34em;
+    white-space: nowrap;
+  }
+
+  p { margin: 0 0 1.05rem; }
+  a { color: var(--accent); text-decoration-thickness: 1px; text-underline-offset: 2px; }
+  a:focus-visible, summary:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 2px; }
+  strong { font-weight: 650; }
+
+  /* ---- masthead ---- */
+  header.mast {
+    padding: 4.4rem 0 2.2rem;
+    border-bottom: 2px solid var(--ink);
+  }
+  .standfirst {
+    font-size: 1.12rem;
+    color: var(--muted);
+    max-width: 38rem;
+    margin: 0 0 1.6rem;
+  }
+  .mast-meta {
+    display: flex; flex-wrap: wrap; gap: 0.45rem 1.5rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.755rem; color: var(--faint);
+  }
+
+  /* ---- sections ---- */
+  section { padding: 3.1rem 0 0.4rem; border-top: 1px solid var(--hair); }
+  section:first-of-type { border-top: none; }
+  .sec-head { display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 1.5rem; }
+
+  /* ---- plane chips ---- */
+  .chip {
+    display: inline-flex; align-items: center; gap: 0.4rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.7rem; letter-spacing: 0.05em; text-transform: uppercase;
+    padding: 0.16rem 0.5rem; border-radius: 2px;
+    color: #0b0b0b; white-space: nowrap;
+  }
+  .chip.phy { background: var(--phy-bg); border: 1px solid var(--phy); }
+  .chip.sem { background: var(--sem-bg); border: 1px solid var(--sem); }
+  .chip.gov { background: var(--gov-bg); border: 1px solid var(--gov); }
+  .legend { display: flex; flex-wrap: wrap; gap: 0.55rem; margin: 0 0 1.4rem; }
+
+  /* ---- the plate (diagram surface) ---- */
+  figure { margin: 1.7rem 0 2rem; }
+  .plate {
+    background: var(--plate);
+    border: 1px solid var(--plate-ed);
+    border-radius: 3px;
+    padding: 1.5rem 1rem;
+    overflow-x: auto;
+  }
+  .plate pre.mermaid { margin: 0; display: block; min-width: min-content; }
+  figcaption {
+    font-size: 0.86rem; color: var(--muted);
+    margin-top: 0.7rem; max-width: 40rem;
+  }
+  figcaption .lead {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.7rem; letter-spacing: 0.11em; text-transform: uppercase;
+    color: var(--faint); display: block; margin-bottom: 0.25rem;
+  }
+
+  /* ---- tables ---- */
+  .tw { overflow-x: auto; margin: 1.4rem 0 1.9rem; border: 1px solid var(--hair); border-radius: 3px; background: var(--surface); }
+  table { border-collapse: collapse; width: 100%; font-size: 0.885rem; }
+  th, td { text-align: left; padding: 0.56rem 0.85rem; border-bottom: 1px solid var(--hair); vertical-align: top; }
+  thead th {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.685rem; letter-spacing: 0.08em; text-transform: uppercase;
+    color: var(--faint); font-weight: 500;
+    background: var(--sunk); border-bottom: 1px solid var(--hair-2);
+    position: sticky; top: 0;
+  }
+  tbody tr:last-child td { border-bottom: none; }
+  td.num { text-align: right; font-variant-numeric: tabular-nums; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+  td .mono, th .mono { white-space: nowrap; }
+  .dim { color: var(--muted); }
+
+  /* ---- code ---- */
+  pre.term {
+    background: var(--sunk);
+    border: 1px solid var(--hair);
+    border-left: 2px solid var(--hair-2);
+    border-radius: 3px;
+    padding: 0.95rem 1.1rem;
+    overflow-x: auto;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.795rem;
+    line-height: 1.62;
+    margin: 1.1rem 0 1.5rem;
+  }
+  pre.term b { color: var(--accent); font-weight: 600; }
+  pre.term i { color: var(--faint); font-style: normal; }
+
+  /* ---- recipes: ordered because the order is the content ---- */
+  ol.recipes { list-style: none; counter-reset: r; padding: 0; margin: 1.4rem 0 0; }
+  ol.recipes > li { counter-increment: r; display: grid; grid-template-columns: 2.4rem 1fr; gap: 0 1rem; padding: 1.15rem 0; border-top: 1px solid var(--hair); }
+  ol.recipes > li::before {
+    content: counter(r, decimal-leading-zero);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.76rem; color: var(--faint); padding-top: 0.28rem;
+  }
+  ol.recipes h3 { margin: 0 0 0.3rem; font-size: 1.02rem; }
+  ol.recipes p { margin: 0 0 0.55rem; font-size: 0.93rem; }
+  .chain {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.775rem; line-height: 1.85;
+    background: var(--sunk); border: 1px solid var(--hair);
+    border-radius: 3px; padding: 0.6rem 0.8rem;
+    overflow-x: auto; white-space: pre;
+  }
+
+  /* ---- callout ---- */
+  .note {
+    border: 1px solid var(--hair-2);
+    border-radius: 3px;
+    background: var(--surface);
+    padding: 1.05rem 1.2rem;
+    margin: 1.6rem 0;
+  }
+  .note.flag { border-color: var(--warn); background: var(--warn-bg); }
+  .note .eyebrow { display: block; margin-bottom: 0.4rem; }
+  .note .eyebrow.w { color: var(--warn); }
+  .note p:last-child { margin-bottom: 0; }
+
+  ul.tight { margin: 0.4rem 0 1.1rem; padding-left: 1.15rem; }
+  ul.tight li { margin-bottom: 0.34rem; }
+
+  footer { margin-top: 3.4rem; padding-top: 1.4rem; border-top: 2px solid var(--ink); }
+
+  @media (prefers-reduced-motion: reduce) {
+    * { animation: none !important; transition: none !important; }
+  }
+</style>
+
+<div class="wrap">
+
+<header class="mast">
+  <div class="eyebrow">platform reference · pf.kg</div>
+  <h1>Knowledge Graph Atlas</h1>
+  <p class="standfirst">
+    The graph answers questions about <em>this project</em>. It cannot tell you what
+    it is made of. This is that half: the fourteen node kinds, the fourteen legal
+    edges between them, and the traversals that turn them into answers.
+  </p>
+  <div class="mast-meta">
+    <span>store: kg/graph.duckdb</span>
+    <span>scope: one project</span>
+    <span>census: acme-us · 230 nodes · 250 edges</span>
+    <span>rebuilt 2026-08-21</span>
+  </div>
+</header>
+
+<section>
+  <div class="sec-head">
+    <span class="eyebrow">why it sits beside the graph</span>
+    <h2>A card says what is here. An atlas says what a graph is.</h2>
+  </div>
+  <div class="prose">
+    <p>
+      Three context tiers already exist, and each pays a different price.
+      <code>CLAUDE.md</code> and <code>kg/context_card.md</code> are
+      <strong>always on and budgeted</strong> — <code>pf tokens</code> fails the
+      build at 1,500 tokens for a project card, 400 for a group card. Toolkit
+      skills are <strong>on demand</strong>. The graph is
+      <strong>queried, never loaded</strong>.
+    </p>
+    <p>
+      That leaves a gap. The card is regenerated per project and lists
+      <em>instances</em> — acme-us has three raw tables and six metrics. It never
+      says that <code>realises</code> runs Column&nbsp;→&nbsp;Relation, that
+      <code>impact_analysis</code> ignores the semantic plane entirely, or that
+      <code>kg_path</code> walks edges in both directions. Those facts are
+      identical in all eight projects, so paying for them in every card would be
+      eight times the right price — and leaving them out is how a traversal gets
+      written backwards.
+    </p>
+    <p>
+      This page is the stable half. Read it once; query the graph forever after.
+    </p>
+  </div>
+</section>
+
+<section>
+  <div class="sec-head">
+    <span class="eyebrow">the meta-model</span>
+    <h2>Three planes, one store</h2>
+  </div>
+  <div class="prose">
+    <p>
+      Two DuckDB tables hold everything: <code>kg_nodes</code> and
+      <code>kg_edges</code>. The structure lives in the <code>kind</code> column,
+      and it divides cleanly into three planes — what physically exists, what it
+      means, and what must hold of it.
+    </p>
+  </div>
+
+  <div class="legend">
+    <span class="chip phy">physical · what exists</span>
+    <span class="chip sem">semantic · what it means</span>
+    <span class="chip gov">governance · what must hold</span>
+  </div>
+
+  <figure>
+    <div class="plate">
+<pre class="mermaid">
+%%{init: {"theme":"base","themeVariables":{"lineColor":"#78908b","edgeLabelBackground":"#ffffff","primaryTextColor":"#0b0b0b","fontFamily":"ui-monospace, SFMono-Regular, Menlo, monospace","fontSize":"12px"}}}%%
+flowchart LR
+  subgraph PHY["PHYSICAL / ANALYTICAL — what exists, and what it feeds"]
+    direction TB
+    SO[Source]
+    TA[Table]
+    MO[Model]
+    CL[Column]
+    ME[Metric]
+    DI[Dimension]
+    TE[Test]
+    EX[Exposure]
+    PJ[Project]
+    SO -->|contains| TA
+    TA -->|feeds| MO
+    TA -->|has_column| CL
+    MO -->|has_column| CL
+    MO -->|feeds| MO
+    MO -->|measures| ME
+    MO -->|grouped_by| DI
+    MO -->|tested_by| TE
+    MO -->|feeds| EX
+    ME -->|feeds| ME
+  end
+
+  subgraph SEM["SEMANTIC — what those things mean"]
+    direction TB
+    CO[Concept]
+    PP[Property]
+    RE[Relation]
+    CO -->|has_property| PP
+    CO -->|domain_of| RE
+    RE -->|range_of| CO
+  end
+
+  subgraph GOV["GOVERNANCE — what must hold"]
+    direction TB
+    PO[Policy]
+    EV[Evidence]
+    PO -->|evidenced_by| EV
+  end
+
+  TA -->|instantiates| CO
+  CL -->|links_to| CO
+  CL -->|realises| RE
+  PO -->|governs| CO
+
+  classDef phy fill:#d9f4ee,stroke:#0f766e,stroke-width:1.4px,color:#0b0b0b
+  classDef sem fill:#e9e1fb,stroke:#5b21b6,stroke-width:1.4px,color:#0b0b0b
+  classDef gov fill:#e0e6ed,stroke:#334155,stroke-width:1.4px,color:#0b0b0b
+  classDef orphan fill:#f2f6f5,stroke:#93a5a1,stroke-width:1.2px,stroke-dasharray:4 3,color:#0b0b0b
+
+  class SO,TA,MO,CL,ME,DI,TE,EX phy
+  class CO,PP,RE sem
+  class PO,EV gov
+  class PJ orphan
+
+  style PHY fill:#f4fbf9,stroke:#0f766e,stroke-dasharray:5 4,color:#0b0b0b
+  style SEM fill:#f8f5fe,stroke:#5b21b6,stroke-dasharray:5 4,color:#0b0b0b
+  style GOV fill:#f4f6f9,stroke:#334155,stroke-dasharray:5 4,color:#0b0b0b
+</pre>
+    </div>
+    <figcaption>
+      <span class="lead">plate i — every node kind and every legal edge</span>
+      All fourteen edge kinds appear here; nothing is declared that the builder does
+      not emit. <strong>Project</strong> is drawn dashed because it is an anchor with
+      no edges at all — one node per graph, carrying group and path in its props,
+      reachable only by id. The four edges crossing plane boundaries are the whole
+      point of the design: they are what let a governance question be answered by
+      walking, rather than by reading three YAML files.
+    </figcaption>
+  </figure>
+
+  <div class="note">
+    <span class="eyebrow">why the diagram is the same colour in both themes</span>
+    <p>
+      Mermaid will not recolour an explicit <code>classDef</code> fill, and there is
+      no media query inside a diagram. So every plate here uses the house rule from
+      the <code>viz-standards</code> toolkit — <strong>pale fill, saturated stroke of
+      the same hue, near-black ink</strong> — and sits on a light card in both themes.
+      A fill picked to look right on white is unreadable on black, and nothing
+      downstream can save it.
+    </p>
+  </div>
+</section>
+
+<section>
+  <div class="sec-head">
+    <span class="eyebrow">the load-bearing rule</span>
+    <h2>Every edge runs upstream → downstream</h2>
+  </div>
+  <div class="prose">
+    <p>
+      This is a contract, not a convention. It means <code>out_edges(n)</code> is
+      always <em>“what depends on n”</em> and <code>in_edges(n)</code> is always
+      <em>“what n was built from”</em> — with no per-kind exceptions to memorise.
+    </p>
+    <p>
+      <code>feeds</code> is named for that direction: a staging model
+      <em>feeds</em> a mart. It was once called <code>derives_from</code>, which
+      pointed the other way and made every rendered lineage path read backwards.
+      The rename is why the rule is stated in the module docstring rather than left
+      implicit.
+    </p>
+    <p>
+      One edge kind is deliberately walked <em>against</em> the arrow:
+      <code>has_column</code>. Changing a column implicates the model that owns it,
+      so impact analysis follows it upward. It is the single exception, and it is
+      encoded as one, in <code>UPWARD_KINDS</code>.
+    </p>
+  </div>
+
+  <div class="tw">
+    <table>
+      <thead>
+        <tr>
+          <th>Edge</th><th>Runs</th><th>Means</th><th>Impact walks it</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td><span class="chip phy">phy</span> <code>contains</code></td><td class="mono dim">Source → Table</td><td>a dlt source landed this table</td><td class="dim">no</td></tr>
+        <tr><td><span class="chip phy">phy</span> <code>has_column</code></td><td class="mono dim">Table/Model → Column</td><td>column belongs to it</td><td><strong>upward</strong></td></tr>
+        <tr><td><span class="chip phy">phy</span> <code>feeds</code></td><td class="mono dim">Table/Model/Metric → Model/Metric/Exposure</td><td>lineage; the general dependency edge</td><td><strong>yes</strong></td></tr>
+        <tr><td><span class="chip phy">phy</span> <code>measures</code></td><td class="mono dim">Model → Metric</td><td>a measure on this model backs the metric</td><td><strong>yes</strong></td></tr>
+        <tr><td><span class="chip phy">phy</span> <code>grouped_by</code></td><td class="mono dim">Model → Dimension</td><td>the semantic model exposes this dimension</td><td><strong>yes</strong></td></tr>
+        <tr><td><span class="chip phy">phy</span> <code>tested_by</code></td><td class="mono dim">Model → Test</td><td>a dbt test covers it</td><td><strong>yes</strong></td></tr>
+        <tr><td><span class="chip sem">sem</span> <code>instantiates</code></td><td class="mono dim">Table → Concept</td><td>this table is a physical <em>Payment</em></td><td class="dim">no</td></tr>
+        <tr><td><span class="chip sem">sem</span> <code>has_property</code></td><td class="mono dim">Concept → Property</td><td>datatype property of the class</td><td class="dim">no</td></tr>
+        <tr><td><span class="chip sem">sem</span> <code>domain_of</code></td><td class="mono dim">Concept → Relation</td><td>the relation starts here</td><td class="dim">no</td></tr>
+        <tr><td><span class="chip sem">sem</span> <code>range_of</code></td><td class="mono dim">Relation → Concept</td><td>the relation ends here</td><td class="dim">no</td></tr>
+        <tr><td><span class="chip sem">sem</span> <code>realises</code></td><td class="mono dim">Column → Relation</td><td>the physical FK behind the relation</td><td class="dim">no</td></tr>
+        <tr><td><span class="chip sem">sem</span> <code>links_to</code></td><td class="mono dim">Column → Concept</td><td>declared FK target</td><td class="dim">no</td></tr>
+        <tr><td><span class="chip gov">gov</span> <code>governs</code></td><td class="mono dim">Policy → Concept</td><td>this rule constrains that class</td><td class="dim">no</td></tr>
+        <tr><td><span class="chip gov">gov</span> <code>evidenced_by</code></td><td class="mono dim">Policy → Evidence</td><td>what proves the rule ran</td><td class="dim">no</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="note">
+    <span class="eyebrow">read this column before trusting a blast radius</span>
+    <p>
+      <code>impact_analysis</code> traverses <strong>five of the fourteen</strong>
+      edge kinds. It is a lineage instrument, not a governance one: a change that
+      breaks a <code>governs</code> or <code>realises</code> relationship comes back
+      <em>safe to change</em>, because those edges were never walked. For semantic
+      or policy consequences, use <code>kg_neighbors</code> and read the plane
+      directly.
+    </p>
+  </div>
+</section>
+
+<section>
+  <div class="sec-head">
+    <span class="eyebrow">traversals</span>
+    <h2>Four questions, as edge chains</h2>
+  </div>
+  <div class="prose">
+    <p>
+      These are numbered because the order <em>is</em> the content — each is a
+      sequence of hops that has to happen in that sequence. Every chain below was
+      run against <code>groups/acme/projects/acme-us</code> and is reproduced from
+      its actual output.
+    </p>
+  </div>
+
+  <ol class="recipes">
+    <li>
+      <div>
+        <h3>How does a raw column reach a business metric?</h3>
+        <p>The lineage question. Four hops from a Stripe column to a governed metric:</p>
+        <div class="chain">col:table:stripe.charges.amount
+  --has_column--&gt;  Table  table:stripe.charges
+  --feeds------&gt;    Model  model:stg_stripe__charges
+  --feeds------&gt;    Model  model:fct_payments
+  --measures---&gt;    Metric metric:revenue</div>
+      </div>
+    </li>
+    <li>
+      <div>
+        <h3>Why is this column a join key, and to what?</h3>
+        <p>
+          Nothing is inferred from a naming convention. The FK is bound to the named
+          relation it realises, and the relation carries the cardinality — inverted
+          when the key sits on the range side, because the FK is always on the many
+          side.
+        </p>
+        <div class="chain">col:table:stripe.charges.customer_id
+  --realises---&gt;   Relation customer_pays_payment
+                   props: from_concept=Payment, to_concept=Customer,
+                          fk_column=customer_id, fk_table=charges,
+                          cardinality, reverse
+  Relation --range_of--&gt; Concept Customer  (identity: customer_id)
+                   =&gt; fct_payments.customer_id = dim_customers.customer_id</div>
+      </div>
+    </li>
+    <li>
+      <div>
+        <h3>Is this rule actually enforced, and what proves it?</h3>
+        <p>
+          The OpenTopology chain — intent, constraint, artifact, evidence — is in the
+          graph so that “does anything check this” is a traversal rather than an
+          archaeology exercise across three YAML files.
+        </p>
+        <div class="chain">policy:entity-requires-identity
+  --governs-------&gt;  Concept concept:Customer
+  --evidenced_by--&gt;  Evidence evidence:impact_reports
+
+  props.enforced_by = []   =&gt;  NOTHING enforces it. That is the finding.</div>
+      </div>
+    </li>
+    <li>
+      <div>
+        <h3>Is it safe to change this?</h3>
+        <p>
+          One <code>has_column</code> hop upward, then everything downstream.
+          Severity is structural, not a judgement call: any exposure or metric in
+          the radius is <em>breaking</em>, models alone are <em>review</em>,
+          nothing is <em>safe</em>.
+        </p>
+        <div class="chain">impact_analysis("col:table:stripe.charges.amount")
+
+⛔ affects 14 downstream object(s) — severity: BREAKING
+   Models (3)      fct_payments, fct_revenue, stg_stripe__charges
+   Metrics (5)     aov, gross_payment_volume, payment_count,
+                   revenue, revenue_mom_growth
+   Dimensions (5)  country_code, customer_segment, paid_at,
+                   payment_status, plan_tier
+   Exposures (1)   exec_weekly_dashboard  ← owner: Finance
+   Tests that will re-run: 7</div>
+      </div>
+    </li>
+  </ol>
+</section>
+
+<section>
+  <div class="sec-head">
+    <span class="eyebrow">tool selection</span>
+    <h2>Which of the four to reach for</h2>
+  </div>
+
+  <figure>
+    <div class="plate">
+<pre class="mermaid">
+%%{init: {"theme":"base","themeVariables":{"lineColor":"#78908b","edgeLabelBackground":"#ffffff","primaryTextColor":"#0b0b0b","fontFamily":"ui-monospace, SFMono-Regular, Menlo, monospace","fontSize":"12px"}}}%%
+flowchart TD
+  Q{"what do you have<br/>to start from?"}
+
+  Q -->|a word, not an id| S["kg_search(term, kinds)"]
+  Q -->|one node id| N["kg_neighbors(node, depth)"]
+  Q -->|two node ids| P["kg_path(src, dst)"]
+  Q -->|a node about to change| I["impact_analysis(node)"]
+  Q -->|a business question| M["query_metrics(metrics, group_by)"]
+
+  S --> S1["substring over name, label and id<br/>case-insensitive · caps at 40"]
+  N --> N1["UNDIRECTED · both in and out edges<br/>narrow with kinds= before raising depth"]
+  P --> P1["UNDIRECTED shortest path, max 8 hops<br/>arrows show chain order, NOT edge direction"]
+  I --> I1["walks 5 edge kinds only<br/>records to obs · returns owners to notify"]
+  M --> M1["a governed definition, never raw SQL<br/>say which metric is missing instead"]
+
+  classDef q fill:#e0e6ed,stroke:#334155,stroke-width:1.4px,color:#0b0b0b
+  classDef tool fill:#d9f4ee,stroke:#0f766e,stroke-width:1.4px,color:#0b0b0b
+  classDef gotcha fill:#f6f4fb,stroke:#7c5cc4,stroke-width:1.2px,stroke-dasharray:4 3,color:#0b0b0b
+
+  class Q q
+  class S,N,P,I,M tool
+  class S1,N1,P1,I1,M1 gotcha
+</pre>
+    </div>
+    <figcaption>
+      <span class="lead">plate ii — entry points, and what each one quietly does</span>
+      The dashed boxes are the behaviours that most often produce a wrong reading.
+      Two are worth committing to memory: <strong>both traversal tools are
+      undirected</strong>. <code>kg_path</code> renders every hop as
+      <code>--kind--&gt;</code> regardless of which way the edge actually ran, so
+      the first hop of recipe 1 prints
+      <code>Column --has_column--&gt; Table</code> — the opposite of the stored
+      direction. The chain is correct; the arrow is chain order, not lineage.
+    </figcaption>
+  </figure>
+
+  <div class="prose">
+    <p>
+      Every one of these returns a compact string on purpose. The MCP truncation
+      policy — schema plus at most twenty rows plus summary stats, never a raw dump
+      — is the cheapest defence there is against a context blowup, and it applies to
+      every data-returning tool on the server, not only these.
+    </p>
+  </div>
+</section>
+
+<section>
+  <div class="sec-head">
+    <span class="eyebrow">provenance</span>
+    <h2>Where the graph comes from, and when it lies</h2>
+  </div>
+
+  <figure>
+    <div class="plate">
+<pre class="mermaid">
+%%{init: {"theme":"base","themeVariables":{"lineColor":"#78908b","edgeLabelBackground":"#ffffff","primaryTextColor":"#0b0b0b","fontFamily":"ui-monospace, SFMono-Regular, Menlo, monospace","fontSize":"12px"}}}%%
+flowchart LR
+  A1["contracts/annotations.yaml<br/>exported by dlt sources"]
+  A2["transform/target/manifest.json<br/>dbt models, columns, tests, exposures"]
+  A3["transform/target/semantic_manifest.json<br/>MetricFlow metrics and dimensions"]
+  A4["project ontology<br/>concepts + topology + resolved policy"]
+  A5["data/&lt;project&gt;.duckdb<br/>information_schema"]
+
+  B["pf kg build"]
+  G[("kg/graph.duckdb<br/>kg_nodes · kg_edges")]
+
+  C1["kg/context_card.md"]
+  C2["MDL · OWL · otop"]
+  C3["impact gate"]
+  C4["kg_search / kg_neighbors / kg_path"]
+
+  A1 --> B
+  A2 --> B
+  A3 --> B
+  A4 --> B
+  A5 --> B
+  B --> G
+  G --> C1
+  G --> C2
+  G --> C3
+  G --> C4
+
+  classDef src fill:#d9f4ee,stroke:#0f766e,stroke-width:1.4px,color:#0b0b0b
+  classDef onto fill:#e9e1fb,stroke:#5b21b6,stroke-width:1.4px,color:#0b0b0b
+  classDef build fill:#e0e6ed,stroke:#334155,stroke-width:1.6px,color:#0b0b0b
+  classDef store fill:#fdf6e3,stroke:#8a6d1f,stroke-width:1.6px,color:#0b0b0b
+  classDef out fill:#f4fbf9,stroke:#0f766e,stroke-width:1.2px,stroke-dasharray:4 3,color:#0b0b0b
+
+  class A1,A2,A3,A5 src
+  class A4 onto
+  class B build
+  class G store
+  class C1,C2,C3,C4 out
+</pre>
+    </div>
+    <figcaption>
+      <span class="lead">plate iii — inputs, store, consumers</span>
+      Every input is optional and the builder degrades quietly, which is exactly why
+      a thin graph is not obviously a broken one. The build is destructive by design:
+      <code>reset()</code> empties both tables first, so the graph is never a merge
+      of two eras.
+    </figcaption>
+  </figure>
+
+  <h3>Three ways the graph is thinner than reality</h3>
+  <ul class="tight">
+    <li>
+      <strong>A missing dbt manifest is silent.</strong> No manifest means no Model
+      nodes, and every blast radius over that graph returns empty — <em>“safe to
+      change”</em> for a change it could not see. The CI gate refuses rather than
+      passing: <code>gate()</code> raises <code>GateNotExercised</code> when the
+      graph holds zero models, because a green tick that means “found nothing” is
+      worse than no gate, since it is trusted.
+    </li>
+    <li>
+      <strong>Undocumented columns are backfilled, not documented.</strong> The dbt
+      manifest lists only columns someone wrote a description for — and join keys are
+      usually the columns nobody documents. The builder reads
+      <code>information_schema</code> to fill the gap, skipping <code>_dlt_*</code>
+      and inferring only structural roles from the name. It never infers PII: that
+      must be declared. So an undocumented column carries
+      <code>documented: false</code> and <code>pii: false</code>, and the second flag
+      means <em>not declared</em>, not <em>not sensitive</em>.
+    </li>
+    <li>
+      <strong>Edges to nodes that were never built are dropped.</strong> The last step
+      before writing filters every edge to those whose endpoints both exist. This
+      keeps the store consistent, and it means a missing input removes edges silently
+      rather than leaving dangling ones to trip over.
+    </li>
+  </ul>
+
+  <h3>The ontology is resolved at <em>project</em> scope</h3>
+  <div class="prose">
+    <p>
+      <code>build_graph</code> calls <code>load_project_ontology</code> — not
+      <code>load_group_ontology</code>, and not <code>load_ontology</code>. Both
+      narrower choices were bugs, one layer apart.
+    </p>
+    <p>
+      Building from the <strong>platform</strong> ontology silently drops every class
+      a steward approved into a group's <code>extension.yaml</code>, so an approved
+      term is unusable by dbt, Wren, BI or an agent. Building from the
+      <strong>group</strong> ontology drops the project's policy overlay — and the
+      governance plane is precisely what an agent walks to ask <em>“what constrains
+      this”</em>. At group scope it answers with the family's floor, so a project
+      that raised a severity or declared an obligation of its own was governed by
+      rules its own graph did not contain.
+    </p>
+  </div>
+
+  <pre class="term"><i># acme-eu declares a GDPR erasure path and raises mart-declares-grain</i>
+$ uv run pf kg build acme acme-eu
+  Policy   <b>11</b>
+$ uv run pf kg build acme acme-us
+  Policy   <b>10</b>
+
+<i># and every Policy node now records which layer set its severity</i>
+   gdpr-erasure-path        error     <b>project:acme/acme-eu</b>
+   mart-declares-grain      error     <b>project:acme/acme-eu</b>
+   pii-not-in-consumption   error     platform</pre>
+
+  <div class="prose">
+    <p>
+      That <code>scope</code> prop is the graph's copy of the <code>set by</code>
+      column in <code>pf semantic policy</code>. Severity alone cannot distinguish
+      an obligation this project took on from one the whole platform carries, and
+      those warrant different conversations.
+    </p>
+    <p>
+      Vocabulary deliberately does <strong>not</strong> layer this far — two sisters
+      that mean different things by <em>Payment</em> cannot be rolled up. Only
+      obligations layer, and only ever tighter.
+    </p>
+  </div>
+</section>
+
+<section>
+  <div class="sec-head">
+    <span class="eyebrow">calibration</span>
+    <h2>What a healthy graph looks like</h2>
+  </div>
+  <div class="prose">
+    <p>
+      Two projects three orders of magnitude apart, so an empty or lopsided graph is
+      recognisable as one. Both exercise all fourteen node kinds and all fourteen
+      edge kinds, which makes them reference shapes rather than just examples.
+      Counts are from the rebuild of 2026-08-21.
+    </p>
+  </div>
+
+  <div class="tw">
+    <table>
+      <thead>
+        <tr>
+          <th>Node kind</th><th>Plane</th>
+          <th class="num">acme-us</th><th class="num">jaffle-shop</th>
+          <th>Reads as</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td><code>Column</code></td><td><span class="chip phy">phy</span></td><td class="num">73</td><td class="num">10294</td><td class="dim">documented + backfilled from information_schema</td></tr>
+        <tr><td><code>Property</code></td><td><span class="chip sem">sem</span></td><td class="num">59</td><td class="num">298</td><td class="dim">datatype properties of the concepts</td></tr>
+        <tr><td><code>Model</code></td><td><span class="chip phy">phy</span></td><td class="num">7</td><td class="num">1058</td><td class="dim">staging + marts</td></tr>
+        <tr><td><code>Test</code></td><td><span class="chip phy">phy</span></td><td class="num">18</td><td class="num">532</td><td class="dim">dbt tests</td></tr>
+        <tr><td><code>Concept</code></td><td><span class="chip sem">sem</span></td><td class="num">16</td><td class="num">68</td><td class="dim">whole group vocabulary, not only what is used</td></tr>
+        <tr><td><code>Table</code></td><td><span class="chip phy">phy</span></td><td class="num">3</td><td class="num">57</td><td class="dim">raw, one per annotated dlt resource</td></tr>
+        <tr><td><code>Dimension</code></td><td><span class="chip phy">phy</span></td><td class="num">8</td><td class="num">25</td><td class="dim">MetricFlow dimensions</td></tr>
+        <tr><td><code>Metric</code></td><td><span class="chip phy">phy</span></td><td class="num">6</td><td class="num">19</td><td class="dim">simple, ratio and derived</td></tr>
+        <tr><td><code>Relation</code></td><td><span class="chip sem">sem</span></td><td class="num">17</td><td class="num">14</td><td class="dim">named, with inverse and cardinality</td></tr>
+        <tr><td><code>Policy</code></td><td><span class="chip gov">gov</span></td><td class="num">10</td><td class="num">10</td><td class="dim">resolved at project scope</td></tr>
+        <tr><td><code>Evidence</code></td><td><span class="chip gov">gov</span></td><td class="num">9</td><td class="num">9</td><td class="dim">declared evidence kinds</td></tr>
+        <tr><td><code>Exposure</code></td><td><span class="chip phy">phy</span></td><td class="num">2</td><td class="num">6</td><td class="dim">where impact analysis finds a human</td></tr>
+        <tr><td><code>Source</code></td><td><span class="chip phy">phy</span></td><td class="num">1</td><td class="num">1</td><td class="dim">the dlt source</td></tr>
+        <tr><td><code>Project</code></td><td><span class="chip phy">phy</span></td><td class="num">1</td><td class="num">1</td><td class="dim">anchor node, no edges</td></tr>
+        <tr><td><strong>total</strong></td><td></td><td class="num"><strong>230</strong></td><td class="num"><strong>12392</strong></td><td class="dim">edges: 250 and 13361</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="prose">
+    <p>
+      <strong>Concept far exceeding Table is normal</strong> — the vocabulary belongs
+      to the group, and a project instantiates only the part of it it needs, so 16
+      concepts against 3 tables is health rather than drift.
+    </p>
+    <p>
+      <strong>The semantic plane does not scale with the physical one.</strong>
+      jaffle-shop has 151&times; the models of acme-us and <em>fewer</em> relations —
+      14 against 17. Relations come from the group topology, not from the warehouse,
+      so a large project is not automatically a richly-modelled one. A thousand
+      models joined by fourteen named relations is where to go looking for
+      undeclared joins.
+    </p>
+    <p>
+      <strong>Zero of any kind is the signal.</strong> No Model means the dbt
+      manifest was never parsed and the gate cannot run; no Metric means every
+      business question falls back to raw SQL; no Exposure means impact analysis
+      stops at the mart and never reaches a human to notify. The card surfaces the
+      last two as known gaps for exactly that reason.
+    </p>
+  </div>
+</section>
+
+<section>
+  <div class="sec-head">
+    <span class="eyebrow">boundaries</span>
+    <h2>What the graph will never tell you</h2>
+  </div>
+  <div class="prose">
+    <p>
+      <strong>Anything about a sister.</strong> Graphs are per project and hold no
+      cross-project edges, so a sister's dependency on a change here is invisible —
+      not merely unqueried. Sisters share the group ontology, never a graph.
+      Cross-entity blast radius is assessed in the <code>&lt;group&gt;-rollup</code>
+      project, against its own graph, and nowhere else.
+    </p>
+    <p>
+      <strong>Business logic.</strong> That a <em>Payment</em> has an amount, a
+      currency and an event time is vocabulary, and it is in the graph. <em>How
+      acme-us recognises revenue</em> is business logic, and it lives in
+      project-confined dbt models. The distinction is the reason two sisters can
+      share a word without sharing a definition — and why an assumption carried
+      across is a bug rather than a shortcut.
+    </p>
+    <p>
+      <strong>Freshness — from the inside.</strong> The graph is a build artefact of
+      the last <code>pf kg build</code>. It has no clock, so a graph built before a
+      model landed answers confidently and wrongly. When an answer contradicts a file
+      you can see, the graph is the stale one. What notices from the outside is
+      <code>pf kg check</code>, below.
+    </p>
+  </div>
+</section>
+
+<section>
+  <div class="sec-head">
+    <span class="eyebrow">staying current</span>
+    <h2>Nobody has to remember a project name</h2>
+  </div>
+  <div class="prose">
+    <p>
+      Three mechanisms, none of which requires naming the project that changed.
+    </p>
+  </div>
+
+  <h3>The commands take any scope</h3>
+  <pre class="term">$ uv run pf kg build                  <i># every project in every group</i>
+$ uv run pf kg build acme             <i># every project in one group</i>
+$ uv run pf kg build acme acme-us     <i># one project</i></pre>
+  <div class="prose">
+    <p>
+      <code>build</code>, <code>card</code> and <code>check</code> widen the same
+      way: <strong>no arguments means everything</strong>. A command that can only be
+      pointed at one project at a time gets run for the project you remembered, which
+      is how seven graphs go a month stale while the eighth is fine.
+    </p>
+  </div>
+
+  <h3>A new group or project gets one on creation</h3>
+  <pre class="term">$ uv run pf new-project demo demo-us
+  ✓ knowledge graph          <b>99 nodes across 6 kinds</b>
+  ✓ context card             ~106 tokens / 1500
+  ✓ group card               sister roster refreshed
+  ✓ ci workflow              3 job(s): impact-gate, <b>kg-current</b>, recce</pre>
+  <div class="prose">
+    <p>
+      Building the graph, rendering the card and refreshing the group roster are
+      steps in the shared bootstrap that <code>pf new-project</code> runs — not
+      follow-ups anyone can forget. <code>pf bootstrap --all</code> does the same for
+      every project that already exists.
+    </p>
+  </div>
+
+  <h3>CI fails a pull request that leaves it stale</h3>
+  <pre class="term">$ uv run pf kg check
+⛔ acme/acme-us — 4 resource(s) missing from the graph
+     models: <b>fct_revenue</b>
+     metrics: <b>revenue</b>
+     exposures: <b>crm_customer_sync, exec_weekly_dashboard</b>
+     run `pf kg build` and commit kg/graph.json</pre>
+  <div class="prose">
+    <p>
+      It compares the tracked <code>kg/graph.json</code> against the dbt manifests —
+      and <strong>only what a runner without a warehouse can see</strong>. Columns are
+      backfilled from <code>information_schema</code>, which CI does not have, so
+      comparing those too would be red on every pull request forever, and a
+      permanently red check is one nobody reads.
+    </p>
+    <p>
+      A project with no manifest reports <strong>not exercised</strong> rather than
+      clean — the same refusal <code>GateNotExercised</code> makes, for the same
+      reason.
+    </p>
+  </div>
+
+  <div class="note">
+    <span class="eyebrow">why the job reaches projects that do not exist yet</span>
+    <p>
+      It is contributed by a <strong>capability</strong>, not written into a workflow
+      file. <code>_ci_workflow</code> composes one workflow per project from every
+      enabled capability's jobs, so adding this one edited a single dictionary — no
+      scaffolder, no CLI, no workflow file — and the next
+      <code>pf bootstrap --all</code> put it in all eight. A project created tomorrow
+      gets it for the same reason. An opt-in check would instead reach only the
+      projects whose author remembered the flag.
+    </p>
+  </div>
+</section>
+
+<footer>
+  <div class="mast-meta">
+    <span>pf.kg.store · pf.kg.build · pf.kg.query · pf.kg.impact</span>
+    <span>docs/SEMANTICS.md · docs/POLICY.md · docs/CLAUDE-CODE.md</span>
+  </div>
+</footer>
+
+</div>

--- a/groups/acme/acme-pipeline-atlas.html
+++ b/groups/acme/acme-pipeline-atlas.html
@@ -1,0 +1,410 @@
+<title>Acme Pipeline Atlas</title>
+<style>
+  /* Palette is lifted from the repo's own MM_CLASSDEF in platform/src/pf/pr.py,
+     so this page and the per-PR architecture chart read as one system. */
+  :root {
+    --ground:      #f4f4f2;
+    --surface:     #ffffff;
+    --surface-2:   #fafaf9;
+    --ink:         #0b0b0b;
+    --ink-muted:   #5c5a55;
+    --ink-faint:   #898781;
+    --rule:        #e2e1dc;
+    --accent:      #4a3aa7;
+    --accent-soft: #ded9f7;
+    --diagram-bg:  #fdfdfc;
+
+    --src:    #eda100;
+    --duck:   #2a78d6;
+    --model:  #1baf7a;
+    --metric: #e87ba4;
+    --expo:   #eb6834;
+    --plat:   #4a3aa7;
+
+    --font-sans: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+    --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --ground:      #15141a;
+      --surface:     #1c1b22;
+      --surface-2:   #232229;
+      --ink:         #f2f1ee;
+      --ink-muted:   #a8a59d;
+      --ink-faint:   #7d7a73;
+      --rule:        #302e3a;
+      --accent:      #a99bf0;
+      --accent-soft: #2b2545;
+      --src:    #f0b53a;
+      --duck:   #6aa6ea;
+      --model:  #4ac79a;
+      --metric: #f09cbc;
+      --expo:   #f28a5e;
+      --plat:   #a99bf0;
+    }
+  }
+  :root[data-theme="dark"] {
+    --ground:      #15141a;
+    --surface:     #1c1b22;
+    --surface-2:   #232229;
+    --ink:         #f2f1ee;
+    --ink-muted:   #a8a59d;
+    --ink-faint:   #7d7a73;
+    --rule:        #302e3a;
+    --accent:      #a99bf0;
+    --accent-soft: #2b2545;
+    --src:    #f0b53a;
+    --duck:   #6aa6ea;
+    --model:  #4ac79a;
+    --metric: #f09cbc;
+    --expo:   #f28a5e;
+    --plat:   #a99bf0;
+  }
+
+  body {
+    background: var(--ground);
+    color: var(--ink);
+    font-family: var(--font-sans);
+    line-height: 1.6;
+    margin: 0;
+    padding: clamp(1.5rem, 4vw, 4rem) clamp(1rem, 4vw, 2rem) 5rem;
+  }
+  .wrap { max-width: 78rem; margin: 0 auto; display: flex; flex-direction: column; gap: 3rem; }
+  .prose { max-width: 40rem; }
+
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: .7rem;
+    letter-spacing: .14em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    margin: 0 0 .75rem;
+  }
+  h1 {
+    font-size: clamp(1.9rem, 5vw, 2.9rem);
+    line-height: 1.1;
+    letter-spacing: -.02em;
+    font-weight: 640;
+    text-wrap: balance;
+    margin: 0 0 .75rem;
+  }
+  h2 {
+    font-size: 1.25rem; letter-spacing: -.01em; font-weight: 620;
+    text-wrap: balance; margin: 0 0 .5rem;
+  }
+  .lede { font-size: 1.08rem; color: var(--ink-muted); margin: 0; text-wrap: pretty; }
+  p { margin: 0 0 1rem; }
+  p:last-child { margin-bottom: 0; }
+
+  .chips { display: flex; flex-wrap: wrap; gap: .5rem; margin-top: 1.5rem; padding: 0; list-style: none; }
+  .chip {
+    font-family: var(--font-mono); font-size: .78rem;
+    padding: .3rem .7rem; border-radius: 999px;
+    border: 1px solid var(--rule); background: var(--surface); color: var(--ink-muted);
+  }
+  .chip b { color: var(--ink); font-weight: 600; }
+
+  .panel {
+    background: var(--surface); border: 1px solid var(--rule);
+    border-radius: 10px; padding: clamp(1rem, 3vw, 1.75rem);
+  }
+
+  .diagram { background: var(--diagram-bg); overflow-x: auto; padding: 1.25rem; }
+  .diagram pre.mermaid { margin: 0; min-width: 40rem; }
+
+  .legend { display: grid; grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr)); gap: .85rem 1.25rem; padding: 0; margin: 0; list-style: none; }
+  .legend li { display: flex; gap: .6rem; align-items: baseline; font-size: .9rem; }
+  .swatch { width: .85rem; height: .85rem; border-radius: 3px; flex: none; transform: translateY(.1rem); border: 2px solid; }
+  .legend b { font-family: var(--font-mono); font-size: .82rem; font-weight: 600; }
+  .legend span { color: var(--ink-muted); }
+
+  .stages { display: grid; grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr)); gap: 1.25rem; }
+  .stage { border-top: 3px solid; padding-top: .9rem; }
+  .stage h3 { font-size: .95rem; margin: 0 0 .4rem; letter-spacing: -.005em; }
+  .stage p { font-size: .9rem; color: var(--ink-muted); margin: 0; }
+  .stage .who { font-family: var(--font-mono); font-size: .72rem; color: var(--ink-faint); letter-spacing: .06em; text-transform: uppercase; display: block; margin-bottom: .3rem; }
+
+  .rules { margin: 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 1rem; }
+  .rules li { padding-left: 1rem; border-left: 2px solid var(--accent-soft); }
+  .rules strong { display: block; font-size: .95rem; }
+  .rules span { font-size: .92rem; color: var(--ink-muted); }
+
+  code {
+    font-family: var(--font-mono); font-size: .86em;
+    background: var(--surface-2); border: 1px solid var(--rule);
+    padding: .1em .35em; border-radius: 4px;
+  }
+  details { border: 1px solid var(--rule); border-radius: 10px; background: var(--surface); }
+  summary {
+    cursor: pointer; padding: 1rem clamp(1rem, 3vw, 1.75rem);
+    font-family: var(--font-mono); font-size: .82rem;
+    letter-spacing: .06em; text-transform: uppercase; color: var(--ink-muted);
+  }
+  summary:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; border-radius: 10px; }
+  details[open] summary { border-bottom: 1px solid var(--rule); color: var(--ink); }
+  pre.source {
+    margin: 0; padding: clamp(1rem, 3vw, 1.75rem);
+    overflow-x: auto; font-family: var(--font-mono);
+    font-size: .78rem; line-height: 1.55; color: var(--ink);
+  }
+  footer { color: var(--ink-faint); font-size: .84rem; border-top: 1px solid var(--rule); padding-top: 1.25rem; }
+</style>
+
+<div class="wrap">
+
+  <header class="prose">
+    <p class="eyebrow">groups / acme</p>
+    <h1>Acme Pipeline Atlas</h1>
+    <p class="lede">
+      Two sister companies that never read each other, one roll-up that reads both
+      read-only, and a platform layer that owns every piece of wiring the three have
+      in common.
+    </p>
+    <ul class="chips">
+      <li class="chip"><b>dlt</b> ingest</li>
+      <li class="chip"><b>DuckDB</b> warehouse</li>
+      <li class="chip"><b>dbt</b> transform</li>
+      <li class="chip"><b>Dagster</b> orchestrate</li>
+    </ul>
+  </header>
+
+  <section class="panel diagram" aria-label="Acme group architecture diagram">
+<pre class="mermaid">
+flowchart TB
+
+  subgraph PLAT["platform/ — shared by every project, edited by none of them"]
+    direction LR
+    PF2["pf.ontology.annotate<br/>x-ontology-class · x-role · x-links-to"]:::plat
+    PF1["pf.runtime.dlt_runtime<br/>pipeline factory · schema contract"]:::plat
+    PF4["pf.runtime.warehouse<br/>DuckDB path · ATTACH · writer pool"]:::plat
+    PF3["pf.runtime.dagster_runtime<br/>build_definitions · lineage stitch"]:::plat
+  end
+
+  subgraph GUS["acme-us — own warehouse, own pipelines"]
+    direction TB
+    USSRC["stripe_source<br/>dlt.source"]:::src
+    USC["customers<br/>merge on id · Customer"]:::src
+    USS["subscriptions<br/>merge on id · Subscription"]:::src
+    USH["charges<br/>merge on id · Payment"]:::src
+    USDB[("acme_us.duckdb<br/>raw dataset: stripe")]:::duck
+    USG1["stg_stripe__customers"]:::model
+    USG2["stg_stripe__subscriptions"]:::model
+    USG3["stg_stripe__charges"]:::model
+    USM1["dim_customers"]:::model
+    USM2["fct_payments"]:::model
+    USM3["fct_revenue"]:::model
+    USSEM["sem_payments · metrics_revenue<br/>MetricFlow semantic layer"]:::metric
+    USEV["Evidence pages"]:::expo
+
+    USSRC --> USC & USS & USH
+    USC & USS & USH -- "dlt.pipeline · merge" --> USDB
+    USDB -- "dbt source" --> USG1 & USG2 & USG3
+    USG1 --> USM1
+    USG3 --> USM2
+    USG2 --> USM3
+    USM2 --> USM3
+    USM1 & USM3 --> USSEM
+    USSEM --> USEV
+  end
+
+  subgraph GEU["acme-eu — same shape, separate business logic"]
+    direction TB
+    EUSRC["stripe_source<br/>dlt.source"]:::src
+    EURES["3 annotated resources<br/>customers · subscriptions · charges"]:::src
+    EUDB[("acme_eu.duckdb<br/>raw dataset: stripe")]:::duck
+    EUSTG["staging · 3 models"]:::model
+    EUM3["fct_revenue"]:::model
+    EUSEM["semantic layer"]:::metric
+    EUEV["Evidence pages"]:::expo
+
+    EUSRC --> EURES
+    EURES -- "dlt.pipeline · merge" --> EUDB
+    EUDB -- "dbt source" --> EUSTG
+    EUSTG --> EUM3
+    EUM3 --> EUSEM
+    EUSEM --> EUEV
+  end
+
+  subgraph GRU["acme-rollup — cross-entity, reads sisters READ_ONLY"]
+    direction TB
+    RUAS["rollup asset<br/>compute_kind duckdb"]:::orch
+    RUDB[("acme_rollup.duckdb<br/>us · eu attached")]:::duck
+    RUAS --> RUDB
+  end
+
+  USM3 -- "AssetKey dep" --> RUAS
+  EUM3 -- "AssetKey dep" --> RUAS
+  USDB -. "ATTACH AS us (READ_ONLY)" .-> RUAS
+  EUDB -. "ATTACH AS eu (READ_ONLY)" .-> RUAS
+
+  PF2 -.-> USC
+  PF1 -.-> USDB
+  PF3 -.-> USG1
+  PF4 -.-> RUAS
+
+  classDef src    fill:#fbe8bd,stroke:#eda100,stroke-width:2px,color:#0b0b0b
+  classDef duck   fill:#e3eefc,stroke:#2a78d6,stroke-width:2px,color:#0b0b0b
+  classDef model  fill:#d6f2e6,stroke:#1baf7a,stroke-width:2px,color:#0b0b0b
+  classDef metric fill:#fadfe8,stroke:#e87ba4,stroke-width:2px,color:#0b0b0b
+  classDef expo   fill:#fbdccf,stroke:#eb6834,stroke-width:2px,color:#0b0b0b
+  classDef plat   fill:#ded9f7,stroke:#4a3aa7,stroke-width:2px,color:#0b0b0b
+  classDef orch   fill:#ded9f7,stroke:#4a3aa7,stroke-width:2px,color:#0b0b0b
+
+  class PLAT,GUS,GEU,GRU grp
+  classDef grp fill:#f6f6f4,stroke:#898781,stroke-width:1px,color:#0b0b0b
+</pre>
+  </section>
+
+  <section class="panel">
+    <p class="eyebrow">Legend</p>
+    <ul class="legend">
+      <li><span class="swatch" style="background:#fbe8bd;border-color:#eda100"></span><div><b>dlt</b><br><span>Annotated sources and resources</span></div></li>
+      <li><span class="swatch" style="background:#e3eefc;border-color:#2a78d6"></span><div><b>DuckDB</b><br><span>One file per project</span></div></li>
+      <li><span class="swatch" style="background:#d6f2e6;border-color:#1baf7a"></span><div><b>dbt</b><br><span>Staging and mart models</span></div></li>
+      <li><span class="swatch" style="background:#fadfe8;border-color:#e87ba4"></span><div><b>MetricFlow</b><br><span>Semantic models and metrics</span></div></li>
+      <li><span class="swatch" style="background:#fbdccf;border-color:#eb6834"></span><div><b>Evidence</b><br><span>Reporting exposures</span></div></li>
+      <li><span class="swatch" style="background:#ded9f7;border-color:#4a3aa7"></span><div><b>platform / Dagster</b><br><span>Shared runtime and assets</span></div></li>
+    </ul>
+  </section>
+
+  <section>
+    <p class="eyebrow">What each layer owns</p>
+    <div class="stages">
+      <div class="stage" style="border-color:#eda100">
+        <span class="who">dlt</span>
+        <h3>Projects declare, the platform wires</h3>
+        <p>A project writes <code>@dlt.resource</code> plus <code>@annotate</code>. It never names a destination — <code>build_pipeline()</code> does, as <code>{project}_{source}</code> against the project's DuckDB file.</p>
+      </div>
+      <div class="stage" style="border-color:#2a78d6">
+        <span class="who">DuckDB</span>
+        <h3>One file, one entity</h3>
+        <p><code>acme_us.duckdb</code> and <code>acme_eu.duckdb</code> never meet except through the roll-up, which attaches both <code>READ_ONLY</code> and detaches after. Each project gets its own writer pool so sisters never queue behind each other.</p>
+      </div>
+      <div class="stage" style="border-color:#1baf7a">
+        <span class="who">dbt</span>
+        <h3>Staging mirrors the source</h3>
+        <p>One staging model per dlt resource, then marts. The dbt <em>source</em> is what ties back to the dlt asset that landed it.</p>
+      </div>
+      <div class="stage" style="border-color:#4a3aa7">
+        <span class="who">Dagster</span>
+        <h3>One code location per project</h3>
+        <p><code>definitions.py</code> is ten lines; <code>build_definitions()</code> assembles everything. dbt models are emitted through <code>@dbt_assets</code> rather than one shelled-out <code>dbt build</code> — because a single opaque asset draws no edges.</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="panel">
+    <p class="eyebrow">Four decisions worth knowing</p>
+    <ul class="rules">
+      <li>
+        <strong>The annotation is the contract, not a hint.</strong>
+        <span>Roles attached at ingest drive staging generation, PII policy, statistical monitors, graph edges and conformance. <code>money_amount</code> becomes a sum-drift monitor; <code>event_time</code> becomes a freshness check.</span>
+      </li>
+      <li>
+        <strong>Columns evolve, data types freeze.</strong>
+        <span>The default schema contract is <code>tables: evolve, columns: evolve, data_type: freeze</code>. Resilient to a new field; unwilling to let a renamed endpoint quietly create a parallel table nobody models.</span>
+      </li>
+      <li>
+        <strong>Lineage is why dbt is not shelled out.</strong>
+        <span>The translator maps each dbt source onto the dlt asset that lands it. That mapping is the only thing stitching ingestion and transformation into one graph.</span>
+      </li>
+      <li>
+        <strong>The roll-up never imports a sister.</strong>
+        <span>It depends on plain <code>AssetKey</code>s pointing into the sisters' code locations, and reads their data through a read-only <code>ATTACH</code>. Business logic does not cross the boundary — only numbers do.</span>
+      </li>
+    </ul>
+  </section>
+
+  <details>
+    <summary>Mermaid source</summary>
+    <pre class="source"><code>flowchart TB
+
+  subgraph PLAT["platform/ — shared by every project, edited by none of them"]
+    direction LR
+    PF2["pf.ontology.annotate&lt;br/&gt;x-ontology-class · x-role · x-links-to"]:::plat
+    PF1["pf.runtime.dlt_runtime&lt;br/&gt;pipeline factory · schema contract"]:::plat
+    PF4["pf.runtime.warehouse&lt;br/&gt;DuckDB path · ATTACH · writer pool"]:::plat
+    PF3["pf.runtime.dagster_runtime&lt;br/&gt;build_definitions · lineage stitch"]:::plat
+  end
+
+  subgraph GUS["acme-us — own warehouse, own pipelines"]
+    direction TB
+    USSRC["stripe_source&lt;br/&gt;dlt.source"]:::src
+    USC["customers&lt;br/&gt;merge on id · Customer"]:::src
+    USS["subscriptions&lt;br/&gt;merge on id · Subscription"]:::src
+    USH["charges&lt;br/&gt;merge on id · Payment"]:::src
+    USDB[("acme_us.duckdb&lt;br/&gt;raw dataset: stripe")]:::duck
+    USG1["stg_stripe__customers"]:::model
+    USG2["stg_stripe__subscriptions"]:::model
+    USG3["stg_stripe__charges"]:::model
+    USM1["dim_customers"]:::model
+    USM2["fct_payments"]:::model
+    USM3["fct_revenue"]:::model
+    USSEM["sem_payments · metrics_revenue&lt;br/&gt;MetricFlow semantic layer"]:::metric
+    USEV["Evidence pages"]:::expo
+
+    USSRC --&gt; USC &amp; USS &amp; USH
+    USC &amp; USS &amp; USH -- "dlt.pipeline · merge" --&gt; USDB
+    USDB -- "dbt source" --&gt; USG1 &amp; USG2 &amp; USG3
+    USG1 --&gt; USM1
+    USG3 --&gt; USM2
+    USG2 --&gt; USM3
+    USM2 --&gt; USM3
+    USM1 &amp; USM3 --&gt; USSEM
+    USSEM --&gt; USEV
+  end
+
+  subgraph GEU["acme-eu — same shape, separate business logic"]
+    direction TB
+    EUSRC["stripe_source&lt;br/&gt;dlt.source"]:::src
+    EURES["3 annotated resources&lt;br/&gt;customers · subscriptions · charges"]:::src
+    EUDB[("acme_eu.duckdb&lt;br/&gt;raw dataset: stripe")]:::duck
+    EUSTG["staging · 3 models"]:::model
+    EUM3["fct_revenue"]:::model
+    EUSEM["semantic layer"]:::metric
+    EUEV["Evidence pages"]:::expo
+
+    EUSRC --&gt; EURES
+    EURES -- "dlt.pipeline · merge" --&gt; EUDB
+    EUDB -- "dbt source" --&gt; EUSTG
+    EUSTG --&gt; EUM3
+    EUM3 --&gt; EUSEM
+    EUSEM --&gt; EUEV
+  end
+
+  subgraph GRU["acme-rollup — cross-entity, reads sisters READ_ONLY"]
+    direction TB
+    RUAS["rollup asset&lt;br/&gt;compute_kind duckdb"]:::orch
+    RUDB[("acme_rollup.duckdb&lt;br/&gt;us · eu attached")]:::duck
+    RUAS --&gt; RUDB
+  end
+
+  USM3 -- "AssetKey dep" --&gt; RUAS
+  EUM3 -- "AssetKey dep" --&gt; RUAS
+  USDB -. "ATTACH AS us (READ_ONLY)" .-&gt; RUAS
+  EUDB -. "ATTACH AS eu (READ_ONLY)" .-&gt; RUAS
+
+  PF2 -.-&gt; USC
+  PF1 -.-&gt; USDB
+  PF3 -.-&gt; USG1
+  PF4 -.-&gt; RUAS
+
+  classDef src    fill:#fbe8bd,stroke:#eda100,stroke-width:2px,color:#0b0b0b
+  classDef duck   fill:#e3eefc,stroke:#2a78d6,stroke-width:2px,color:#0b0b0b
+  classDef model  fill:#d6f2e6,stroke:#1baf7a,stroke-width:2px,color:#0b0b0b
+  classDef metric fill:#fadfe8,stroke:#e87ba4,stroke-width:2px,color:#0b0b0b
+  classDef expo   fill:#fbdccf,stroke:#eb6834,stroke-width:2px,color:#0b0b0b
+  classDef plat   fill:#ded9f7,stroke:#4a3aa7,stroke-width:2px,color:#0b0b0b
+  classDef orch   fill:#ded9f7,stroke:#4a3aa7,stroke-width:2px,color:#0b0b0b
+
+  class PLAT,GUS,GEU,GRU grp
+  classDef grp fill:#f6f6f4,stroke:#898781,stroke-width:1px,color:#0b0b0b</code></pre>
+  </details>
+
+  <footer>
+    Colours are the repo's own <code>MM_CLASSDEF</code> from <code>platform/src/pf/pr.py</code>, so this reads
+    as one system with the per-PR architecture chart. Pale fill, saturated stroke, near-black ink —
+    theme-invariant by design, which is why the diagram keeps a light canvas on a dark page.
+  </footer>
+
+</div>

--- a/groups/jaffle/projects/jaffle-shop/jaffle-shop-onboarding.html
+++ b/groups/jaffle/projects/jaffle-shop/jaffle-shop-onboarding.html
@@ -1,0 +1,697 @@
+<title>Jaffle Shop Onboarding</title>
+<style>
+:root {
+  --paper:      #F6F8F7;
+  --surface:    #FFFFFF;
+  --ink:        #16201E;
+  --ink-soft:   #3D4B47;
+  --muted:      #66746F;
+  --rule:       #D9E0DD;
+  --rule-soft:  #E8EDEB;
+  --accent:     #0F6F5C;
+  --accent-dim: #E2F0EC;
+  --blocked:    #A3341F;
+  --blocked-dim:#F7E7E2;
+  --decide:     #8A6206;
+  --decide-dim: #F7EEDA;
+  --code-bg:    #EFF3F1;
+
+  --sans: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --paper:      #0D1412;
+    --surface:    #141D1A;
+    --ink:        #E5EBE8;
+    --ink-soft:   #B6C2BE;
+    --muted:      #849690;
+    --rule:       #26332F;
+    --rule-soft:  #1C2724;
+    --accent:     #58C4A7;
+    --accent-dim: #16302A;
+    --blocked:    #E2836B;
+    --blocked-dim:#301A14;
+    --decide:     #D8AA47;
+    --decide-dim: #2C2312;
+    --code-bg:    #182220;
+  }
+}
+:root[data-theme="dark"] {
+  --paper:      #0D1412;
+  --surface:    #141D1A;
+  --ink:        #E5EBE8;
+  --ink-soft:   #B6C2BE;
+  --muted:      #849690;
+  --rule:       #26332F;
+  --rule-soft:  #1C2724;
+  --accent:     #58C4A7;
+  --accent-dim: #16302A;
+  --blocked:    #E2836B;
+  --blocked-dim:#301A14;
+  --decide:     #D8AA47;
+  --decide-dim: #2C2312;
+  --code-bg:    #182220;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 16.5px;
+  line-height: 1.62;
+  margin: 0;
+  padding: 0 24px 120px;
+  -webkit-font-smoothing: antialiased;
+}
+
+.wrap { max-width: 1080px; margin: 0 auto; }
+.col  { max-width: 68ch; }
+
+/* ---------- masthead ---------- */
+.masthead {
+  padding: 72px 0 36px;
+  border-bottom: 2px solid var(--ink);
+  margin-bottom: 0;
+}
+.eyebrow {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0 0 20px;
+}
+h1 {
+  font-size: clamp(34px, 6vw, 54px);
+  line-height: 1.04;
+  letter-spacing: -0.028em;
+  font-weight: 700;
+  margin: 0 0 22px;
+  text-wrap: balance;
+}
+.standfirst {
+  font-size: 20px;
+  line-height: 1.5;
+  color: var(--ink-soft);
+  margin: 0;
+  max-width: 62ch;
+  text-wrap: pretty;
+}
+.route {
+  font-family: var(--mono);
+  font-size: 13px;
+  margin-top: 28px;
+  color: var(--muted);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  align-items: baseline;
+}
+.route b { color: var(--ink); font-weight: 500; }
+.route .arrow { color: var(--accent); }
+
+/* ---------- sections ---------- */
+section { padding-top: 60px; }
+h2 {
+  font-size: 13px;
+  font-family: var(--mono);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 500;
+  color: var(--accent);
+  margin: 0 0 8px;
+}
+h3 {
+  font-size: clamp(23px, 3.2vw, 30px);
+  line-height: 1.16;
+  letter-spacing: -0.02em;
+  font-weight: 700;
+  margin: 0 0 20px;
+  text-wrap: balance;
+}
+h4 {
+  font-size: 17.5px;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+  font-weight: 700;
+  margin: 0 0 6px;
+}
+p { margin: 0 0 16px; text-wrap: pretty; }
+.col > p:last-child { margin-bottom: 0; }
+strong { font-weight: 700; }
+em { font-style: italic; }
+
+code {
+  font-family: var(--mono);
+  font-size: 0.855em;
+  background: var(--code-bg);
+  padding: 1.5px 5px;
+  border-radius: 2px;
+  color: var(--ink);
+  word-break: break-word;
+}
+
+/* ---------- verdict block ---------- */
+.verdict {
+  border-left: 3px solid var(--accent);
+  padding: 4px 0 4px 24px;
+  margin: 0 0 8px;
+}
+.verdict p { font-size: 18.5px; line-height: 1.5; }
+
+/* ---------- data tables ---------- */
+.tablewrap { overflow-x: auto; margin: 28px 0 8px; }
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14.5px;
+  font-variant-numeric: tabular-nums;
+}
+caption {
+  text-align: left;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+  padding-bottom: 10px;
+}
+th {
+  text-align: left;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  font-weight: 500;
+  color: var(--muted);
+  border-bottom: 1px solid var(--ink);
+  padding: 0 16px 8px 0;
+  white-space: nowrap;
+}
+td {
+  padding: 9px 16px 9px 0;
+  border-bottom: 1px solid var(--rule-soft);
+  vertical-align: top;
+}
+td.num, th.num { text-align: right; font-family: var(--mono); padding-right: 22px; }
+tr:last-child td { border-bottom: 1px solid var(--rule); }
+td.mono { font-family: var(--mono); font-size: 13px; }
+.dim { color: var(--muted); }
+
+/* ---------- findings ---------- */
+.finding {
+  display: grid;
+  grid-template-columns: 108px 1fr;
+  gap: 0 24px;
+  padding: 22px 0;
+  border-top: 1px solid var(--rule);
+  align-items: start;
+}
+.finding:last-of-type { border-bottom: 1px solid var(--rule); }
+.chip {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border-radius: 2px;
+  display: inline-block;
+  white-space: nowrap;
+  font-weight: 500;
+}
+.chip.blocked { background: var(--blocked-dim); color: var(--blocked); }
+.chip.decide  { background: var(--decide-dim);  color: var(--decide); }
+.chip.clear   { background: var(--accent-dim);  color: var(--accent); }
+.finding-body p { margin: 0 0 12px; max-width: 66ch; }
+.finding-body p:last-child { margin-bottom: 0; }
+
+/* ---------- phases ---------- */
+.phase {
+  display: grid;
+  grid-template-columns: 64px 1fr;
+  gap: 0 24px;
+  padding: 30px 0;
+  border-top: 1px solid var(--rule);
+}
+.phase:last-of-type { border-bottom: 1px solid var(--rule); }
+.phase-n {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+  padding-top: 5px;
+  font-weight: 500;
+}
+.phase-body { max-width: 68ch; }
+.phase-body > p { margin: 0 0 14px; }
+ul, ol { margin: 0 0 16px; padding-left: 20px; }
+li { margin-bottom: 7px; padding-left: 2px; }
+li:last-child { margin-bottom: 0; }
+
+pre {
+  background: var(--code-bg);
+  border-left: 2px solid var(--rule);
+  padding: 14px 16px;
+  overflow-x: auto;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  line-height: 1.65;
+  margin: 0 0 16px;
+  border-radius: 0 2px 2px 0;
+}
+pre code { background: none; padding: 0; font-size: inherit; }
+.cmt { color: var(--muted); }
+
+.exit {
+  border-top: 1px solid var(--rule-soft);
+  margin-top: 16px;
+  padding-top: 12px;
+  font-size: 14.5px;
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+}
+.exit .lbl {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--muted);
+  white-space: nowrap;
+  padding-top: 2px;
+}
+.exit .txt { color: var(--ink-soft); }
+
+/* ---------- checklist ---------- */
+.checks { list-style: none; padding: 0; margin: 22px 0 0; }
+.checks li {
+  border-top: 1px solid var(--rule-soft);
+  padding: 13px 0 13px 30px;
+  position: relative;
+  margin: 0;
+  max-width: 70ch;
+}
+.checks li:last-child { border-bottom: 1px solid var(--rule-soft); }
+.checks li::before {
+  content: "";
+  position: absolute;
+  left: 2px;
+  top: 20px;
+  width: 11px;
+  height: 11px;
+  border: 1.5px solid var(--accent);
+  border-radius: 2px;
+}
+
+.footnote {
+  margin-top: 64px;
+  padding-top: 20px;
+  border-top: 1px solid var(--rule);
+  font-size: 13.5px;
+  color: var(--muted);
+  max-width: 70ch;
+}
+.footnote p { margin-bottom: 10px; }
+
+a { color: var(--accent); text-decoration-thickness: 1px; text-underline-offset: 2px; }
+a:focus-visible, :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+@media (max-width: 640px) {
+  .finding, .phase { grid-template-columns: 1fr; gap: 10px; }
+  body { padding: 0 18px 80px; }
+}
+</style>
+
+<div class="wrap">
+
+<header class="masthead">
+  <p class="eyebrow">Migration brief · surveyed 14 Aug 2026</p>
+  <h1>Onboarding Jaffle&nbsp;Shop Expanded</h1>
+  <p class="standfirst">A 1,058-model dbt project from <code>DataRecce/jaffle-shop-expand</code>, brought into the platform. The SQL is the easy half. The semantics, and the platform's own scale limits, are the real work.</p>
+  <p class="route">
+    <b>DataRecce/jaffle-shop-expand</b> <span class="arrow">→</span> <b>groups/jaffle/projects/jaffle-shop</b>
+    <span class="dim">· DuckDB first, Snowflake once dev is green</span>
+  </p>
+</header>
+
+<section>
+  <h2>Verdict</h2>
+  <div class="col verdict">
+    <p>Mechanically this lands in about a day, and the tooling to do it is built. The blocker is not code — it is that <strong>the platform's ontology has no concepts for half of what this project models</strong>. That is a platform-tier decision, and it has to be made before a single file is copied.</p>
+    <p>Below it sits one real technical risk, and it is the quiet kind: 128 SQL call sites that run without error on the target and can still return the wrong number.</p>
+  </div>
+</section>
+
+<section>
+  <h2>What the source actually is</h2>
+  <div class="col">
+    <p>Its README is explicit: <em>"a realistic mock data warehouse for testing dbt tools, PR review workflows, and data platform capabilities."</em> This is Recce's scale fixture, built on <code>dbt-labs/jaffle-shop</code> — not a company's warehouse. That matters for how much semantic investment the synthetic domains deserve.</p>
+    <p>It is also unusually clean to move: <strong>no Python whatsoever</strong>. No Airflow, no Prefect, no Dagster, no dlt. Just dbt, seeds and macros.</p>
+  </div>
+
+  <div class="tablewrap">
+    <table>
+      <caption>Surveyed contents</caption>
+      <thead>
+        <tr><th>Layer</th><th class="num">Models</th><th>Shape</th></tr>
+      </thead>
+      <tbody>
+        <tr><td class="mono">staging</td><td class="num">88</td><td>6 domain folders + 30 <code>derived</code> models that join rather than clean 1:1</td></tr>
+        <tr><td class="mono">intermediate</td><td class="num">194</td><td>per-domain and <code>*_deep</code> chains, plus cross-domain</td></tr>
+        <tr><td class="mono">marts</td><td class="num">772</td><td>spread over 38 folders — only 6 are domains, the rest are <em>shapes</em>: trends, kpis, rankings, alerts, wide_tables, mega_wide…</td></tr>
+        <tr><td class="mono">utilities</td><td class="num">4</td><td>date spine and helpers</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="tablewrap">
+    <table>
+      <caption>Everything else</caption>
+      <thead>
+        <tr><th>Resource</th><th class="num">Count</th><th>Note</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>dbt sources</td><td class="num">6</td><td class="mono">ecom, finance, hr_ops, marketing, product, supply_chain</td></tr>
+        <tr><td>Seed CSVs</td><td class="num">59</td><td>16 MB — <code>raw_items</code> 90,901 rows, <code>raw_orders</code> 61,949, <code>raw_customers</code> 936</td></tr>
+        <tr><td>Schema YAML</td><td class="num">87</td><td>3,180 column declarations</td></tr>
+        <tr><td>Tests</td><td class="num">~794</td><td>511 <code>not_null</code>, 275 <code>unique</code>, 4 <code>expression_is_true</code>, 3 <code>relationships</code>, 1 <code>accepted_values</code></td></tr>
+        <tr><td>Macros</td><td class="num">22</td><td>18 helpers + 4 custom generic tests</td></tr>
+        <tr><td>Semantic models</td><td class="num">6</td><td>on the original jaffle core only; 3 files carry metrics</td></tr>
+        <tr><td>Snapshots / analyses / data tests</td><td class="num">2 / 3 / 3</td><td>—</td></tr>
+        <tr><td>Incremental models</td><td class="num">15</td><td>the only non-trivial materialisations</td></tr>
+        <tr><td>Exposures</td><td class="num">1 file</td><td>plus 2 models with contracts, 0 with <code>access</code></td></tr>
+        <tr><td>SQL volume</td><td class="num">57,407</td><td>lines; longest model <code>mega_wide_store_master</code> at 763</td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section>
+  <h2>Where it lands</h2>
+  <div class="col">
+    <p><strong>A new group, <code>jaffle</code>, with one project, <code>jaffle-shop</code>.</strong> Not inside <code>acme</code>, <code>globex</code> or <code>zenith</code>.</p>
+    <p>A group in this platform asserts something specific: sister companies sharing an ontology instance, conformed dimensions and group metrics, with a roll-up that unions across them. Dropping a sandwich-shop chain beside an existing family would assert conformance that does not exist, and the roll-up would be the thing that breaks. A new group costs one <code>pf new-group</code> and keeps the claim honest.</p>
+    <p>Per the repo's own rule I did not read the other groups' business logic to reach this — the argument is structural, not comparative.</p>
+  </div>
+</section>
+
+<section>
+  <h2>What actually blocks</h2>
+  <div class="col"><p>Four things, in the order they have to be resolved.</p></div>
+
+  <div class="finding">
+    <div><span class="chip blocked">Decision</span></div>
+    <div class="finding-body">
+      <h4>The ontology has no concepts for most of this project</h4>
+      <p>Ontology v2 has 16 concepts, shaped for subscription commerce: <code>Customer</code>, <code>Order</code>, <code>Product</code>, <code>Location</code>, <code>Employee</code>, <code>Payment</code>, <code>Subscription</code>, <code>Interaction</code>…</p>
+      <p>Four of the six core jaffle tables map cleanly — customers, orders, products, stores. <strong>Two do not:</strong> <code>raw_items</code> (order lines) and <code>raw_supplies</code> (per-SKU cost inputs) have no concept at all. Beyond the core it gets worse: supply chain needs Supplier, PurchaseOrder, Shipment, Inventory; HR needs Department and Position; marketing needs Campaign. None exist.</p>
+      <p>The 16 <em>roles</em> are fine — they are generic enough to carry any of this. It is purely a concept gap. Extending the ontology is a platform-tier change affecting every existing group, so it is your call, not a step in this plan.</p>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div><span class="chip clear">Withdrawn</span></div>
+    <div class="finding-body">
+      <h4>The context card fits fine — this blocker was mine, and it was wrong</h4>
+      <p>I reported that 1,058 models could not fit the 1,500-token card budget, at roughly 3× over in the most compressed form. That was wrong, and building the check properly disproved it.</p>
+      <p><code>pf kg card</code> does not enumerate every model. Each section truncates at a fixed limit, so its output is <strong>bounded regardless of project size</strong> — measured: 3 marts render in 3 lines, 772 marts in 13 lines and 364 tokens, identical to 100 marts.</p>
+      <p>What is genuinely true is smaller and different: a card naming 12 of 772 marts is inside budget and nearly uninformative. So the card now rolls the remainder up by tag rather than only counting it — <code>…and 760 more — by domain: marketing (128), hr_ops (128), supply_chain (127)…</code> — which costs one line and describes all of them. jaffle's <code>domain:</code> tags make that work out of the box. All seven existing cards regenerate byte-identical.</p>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div><span class="chip decide">Decide</span></div>
+    <div class="finding-body">
+      <h4><code>maxFiles: 12</code> versus a 1,058-model project</h4>
+      <p>The gate caps a loop run at 12 files. That is a sensible ceiling for a 9-model project and an almost meaningless one here — a single tag rename across <code>marts/finance</code> touches 29. Agent loops will be unable to do useful work on this project without either a per-project override or an explicit decision that loops don't run here.</p>
+      <p>I'd leave the cap alone and exclude this project from loops until it earns its way in. Raising a global safety limit to accommodate one imported fixture is the wrong trade.</p>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div><span class="chip blocked">Tooling</span></div>
+    <div class="finding-body">
+      <h4><code>pf onboard</code> is not on this branch</h4>
+      <p>The branch is <code>feat/-project-onboarding-from-github</code>, but the onboarding code lives on <code>feat/adding-context-and-rules</code> — this branch has only a stale <code>__pycache__</code> where <code>platform/src/pf/onboard/</code> should be, and no <code>context.py</code>.</p>
+      <p>Related and worth fixing regardless: <code>TOOLKITS.md</code> and seven <code>kg/tools_card.md</code> files are <em>committed</em> here, but the generator that produces them is not. Nothing on this branch can regenerate or validate them, and on the other branch they are gitignored as build output.</p>
+      <p>Cherry-pick the onboard and context modules across before starting, or Phase 1 is a manual copy with no survey, no capability reconciliation and no plan/apply split.</p>
+    </div>
+  </div>
+</section>
+
+<section>
+  <h2>What looks hard and isn't</h2>
+
+  <div class="finding">
+    <div><span class="chip clear">Built</span></div>
+    <div class="finding-body">
+      <h4>The SQL is portable through a macro toolkit — no per-database rewrite</h4>
+      <p>There is now a <code>dbt-snowflake</code> toolkit on <code>macro-paths</code> for every project. Its <code>sf_*</code> macros compile to whatever the <em>target</em> adapter understands, so one set of models runs on DuckDB in development and Snowflake in production — and on Postgres or ClickHouse without further work.</p>
+      <pre><code>select {{ sf_iff("status = 'paid'", 'amount', '0') }} as paid
+
+<span class="cmt">DuckDB / Postgres → case when status = 'paid' then amount else 0 end
+Snowflake         → iff(status = 'paid', amount, 0)
+ClickHouse        → if(status = 'paid', amount, 0)</span></code></pre>
+      <p>29 macros, each asserted against a real dbt run. Three reproduce Snowflake's semantics <em>against</em> DuckDB's native behaviour, which is the reason the toolkit exists rather than a find-and-replace:</p>
+      <ul>
+        <li><code>sf_least(['a','b'])</code> returns NULL if either is NULL. DuckDB, Postgres and BigQuery would skip the NULL and return the other value.</li>
+        <li><code>sf_div0(a, b)</code> returns <strong>0</strong> on a zero divisor. A hand-written <code>a / nullif(b, 0)</code> returns NULL — on exactly the rows anyone added the guard for.</li>
+        <li><code>sf_datediff(part, start, end)</code> takes the part <strong>first</strong>. dbt-core's own <code>datediff</code> takes it last, so passing Snowflake's arguments through gives a sign-flipped answer in the wrong unit.</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div><span class="chip decide">Corrected</span></div>
+    <div class="finding-body">
+      <h4>Two numbers in my first survey were wrong</h4>
+      <p>Building the detector properly disproved both. I had reported <code>iff</code> at 182 uses and <code>dateadd</code> at 27, from a substring grep.</p>
+      <p><strong><code>iff</code> does not appear in this project at all.</strong> The 182 was <code>datediff(</code> — which ends in the characters <code>iff(</code>. A word-boundary scan finds zero. And all 27 <code>dateadd</code> calls are <code>{{ dbt.dateadd(...) }}</code>, dbt's own cross-database macro, portable already.</p>
+      <p>So the conclusion is better than I first reported: <strong>this project has no unsupported functions.</strong> Its entire portability risk is the ambiguous set below — the half that runs without complaint.</p>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div><span class="chip blocked">Real risk</span></div>
+    <div class="finding-body">
+      <h4>128 call sites resolve on DuckDB and can still be wrong</h4>
+      <p><code>date_trunc</code> ×66, <code>datediff</code> ×30, <code>least</code> ×27, <code>greatest</code> ×7, <code>listagg</code> ×5 — all raw SQL, all resolvable, none of them guaranteed to mean what the author meant. <code>least</code> and <code>greatest</code> disagree about NULLs; <code>date_trunc</code> and <code>datediff</code> disagree about argument order across dialects.</p>
+      <p>These are never translated automatically. <code>pf dialect</code> reports each with the macro that pins the source dialect's semantics, and a human confirms which warehouse the SQL was written for before wrapping. That confirmation is the actual work, and it cannot be skipped — the same text means different things depending on the answer.</p>
+      <p>The remaining 363 <code>date_trunc</code> and 153 <code>datediff</code> occurrences are already <code>{{ dbt.* }}</code> calls and are correctly ignored.</p>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div><span class="chip clear">Trivial</span></div>
+    <div class="finding-body">
+      <h4>The package dependencies are nearly vestigial</h4>
+      <p>Three packages are declared. Actual usage across 1,058 models: <code>dbt_utils</code> <strong>5 call sites</strong> (4 <code>expression_is_true</code> tests, 1 <code>generate_surrogate_key</code>), <code>dbt_date</code> <strong>2</strong> (both <code>get_base_dates</code>), <code>dbt-audit-helper</code> <strong>zero</strong>.</p>
+      <p>So: keep <code>dbt_utils</code> under the platform's existing <code>&gt;=1.3.0,&lt;2.0.0</code> pin — 1.3.3 satisfies it. Drop audit-helper entirely, which is a bonus: it was pinned to git <code>revision: main</code>, i.e. unpinned, which the vendor policy would never accept. That leaves <code>dbt_date</code> as the only genuinely new dependency, for two call sites.</p>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div><span class="chip clear">Nothing to do</span></div>
+    <div class="finding-body">
+      <h4>No orchestrator to migrate, and no ingestion to port</h4>
+      <p>The Airflow/Prefect→Dagster path doesn't apply — there is no Python in the repo at all. Dagster assets come from the platform's <code>dagster-dbt</code> factory once the project is registered. Source data is 59 static seed CSVs behind <code>var('load_source_data')</code>, not a pipeline.</p>
+      <p>Keep them as seeds. Writing dlt pipelines to load static fixture CSVs would be ceremony; add dlt when a real source appears. Note the platform will still expect <code>src/jaffle_shop/</code> to exist, so scaffold it and leave it empty of sources.</p>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div><span class="chip clear">Verified</span></div>
+    <div class="finding-body">
+      <h4>No model name collisions</h4>
+      <p>dbt's namespace is flat, so 1,058 models across 38 mart folders is a real collision risk. Checked: <strong>zero duplicate basenames</strong>. The tree can be flattened or restructured without renaming anything.</p>
+    </div>
+  </div>
+</section>
+
+<section>
+  <h2>What is now built, and reusable</h2>
+  <div class="col">
+    <p>Every finding above came from a generic check, not a jaffle-specific one. Each is registry-driven or discovered at runtime, so the next import gets the same scrutiny without anyone editing code.</p>
+  </div>
+  <div class="tablewrap">
+    <table>
+      <thead>
+        <tr><th>Check</th><th>How it generalises</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="mono">pf dialect</td>
+          <td>Knows no vendor. Scans call sites, resolves them against DuckDB's <em>live</em> catalogue plus a binder probe, then reports against the macro toolkits. A function DuckDB gains natively stops being reported with no list to update.</td>
+        </tr>
+        <tr>
+          <td class="mono">dbt-snowflake toolkit</td>
+          <td>Adapter-dispatched, so it covers DuckDB, Postgres, Redshift, ClickHouse, BigQuery and Snowflake. A BigQuery-origin project gets a <code>bq_*</code> sibling — added to one tuple and one <code>macro-paths</code> entry.</td>
+        </tr>
+        <tr>
+          <td class="mono">reserved macros</td>
+          <td>A registry of dbt built-ins whose override breaks the platform's layout, each with the reason. <code>generate_schema_name</code> is the one that bit here; <code>generate_alias_name</code>, <code>ref</code> and <code>source</code> are the same class.</td>
+        </tr>
+        <tr>
+          <td class="mono">path keys</td>
+          <td>Reads <code>test-paths</code>, <code>snapshot-paths</code> and <code>analysis-paths</code> from the source rather than assuming dbt's defaults, then normalises into this platform's layout. This is what found jaffle's 3 tests, 2 snapshots and 3 analyses — all previously dropped in silence.</td>
+        </tr>
+        <tr>
+          <td class="mono">config re-keying</td>
+          <td>The source's per-directory config follows its models through the layer mapping, so <code>bronze:</code> becomes <code>staging:</code> and two layers collapsing onto one merge. Without it every tag and materialisation is silently lost.</td>
+        </tr>
+        <tr>
+          <td class="mono">card rollup</td>
+          <td>Any section over its limit is summarised by tag namespace — <code>domain</code>, then <code>type</code>, then <code>criticality</code> — instead of truncated to a count. Falls back cleanly when a project has no tags, and refuses to "group" into a single bucket.</td>
+        </tr>
+        <tr>
+          <td class="mono">scale guard</td>
+          <td>Reports density rather than budget, and says whether the project carries tags the card can roll up by. Kept in step with the card's own section limit by a test, so the advice cannot drift from the behaviour.</td>
+        </tr>
+        <tr>
+          <td class="mono">package audit</td>
+          <td>Counts real call sites per package and flags git pins on a moving branch. Found audit-helper at zero uses and unpinned.</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="col" style="margin-top:24px">
+    <p><code>pf onboard</code> refuses to apply while any blocking finding stands, unless you pass <code>--force</code>. 73 tests cover it, including every toolkit macro compiled through dbt against a real adapter.</p>
+  </div>
+</section>
+
+<section>
+  <h2>Conflicts needing an explicit call</h2>
+  <div class="tablewrap">
+    <table>
+      <thead>
+        <tr><th>Conflict</th><th>Why it bites</th><th>Recommendation</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="mono">generate_schema_name</td>
+          <td>The source ships its own override. On any non-<code>prod</code> target it collapses every model into <code>target.schema</code>, ignoring <code>+schema</code>. The platform's <code>dbt_project.yml</code> relies on <code>staging</code>/<code>marts</code> schema separation.</td>
+          <td><strong>Do not import it.</strong> Silent, and it breaks layer separation on exactly the dev target you want green first.</td>
+        </tr>
+        <tr>
+          <td class="mono">pf gen-staging</td>
+          <td>Generates staging from annotations. The source has 88 hand-written staging models, 30 of which are joins, not 1:1 cleans — generation would fight them.</td>
+          <td>Suppress for this project initially. Revisit only for the 6 <code>ecom</code> tables once annotated.</td>
+        </tr>
+        <tr>
+          <td class="mono">macro-paths</td>
+          <td>Source declares <code>["macros"]</code>; the platform needs <code>../../../../../platform/dbt/macros</code> for <code>pf_clean</code> dispatch.</td>
+          <td>Merge, keeping both. Only collision is <code>generate_schema_name</code>, handled above.</td>
+        </tr>
+        <tr>
+          <td class="mono">data-tests/</td>
+          <td>Source uses <code>test-paths: ["data-tests"]</code>; platform scaffolds <code>tests</code>. Also needs <code>snapshot-paths</code> and <code>analysis-paths</code>, which the platform template omits.</td>
+          <td>Carry the source's paths into the merged <code>dbt_project.yml</code>. Cheaper than moving 3 files and 2 snapshots.</td>
+        </tr>
+        <tr>
+          <td class="mono">target-base/</td>
+          <td>Checked-in Recce base artifacts. Regenerable, large, and <code>gate.yaml</code> denies <code>**/target/**</code> but not this.</td>
+          <td>Don't import. Regenerate from a base build if Recce comparison is wanted.</td>
+        </tr>
+        <tr>
+          <td class="mono">profiles.yml</td>
+          <td>Source defaults to <code>target: snowflake-current</code> with 6 outputs. Platform uses <code>DBT_TARGET</code> with <code>PF_DUCKDB_PATH</code>.</td>
+          <td>Take the platform's wholesale. Add the Snowflake output in Phase 5, from your credentials.</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section>
+  <h2>The plan</h2>
+  <div class="col"><p>Five phases. Each has an exit criterion that is checkable, not a judgement call — the point is that you can tell whether a phase is actually finished.</p></div>
+
+  <div class="phase">
+    <div class="phase-n">PHASE&nbsp;1</div>
+    <div class="phase-body">
+      <h4>Clear the platform-tier decisions</h4>
+      <p>Nothing else can start. All three are edits to shared infra, so they happen while <em>not</em> in a project session.</p>
+      <ul>
+        <li>Decide the ontology question — extend v2 with retail and supply-chain concepts, or scope the import to what fits.</li>
+        <li>Restore the context generator, or stop committing its output — <code>TOOLKITS.md</code> and seven <code>tools_card.md</code> files are checked in here without the code that produces them.</li>
+      </ul>
+      <p class="dim" style="font-size:14.5px">Everything else in this phase is done: <code>pf onboard</code>, <code>pf dialect</code>, the macro toolkit and the card rollup are all on this branch, with 92 tests.</p>
+      <div class="exit"><span class="lbl">Exit</span><span class="txt"><code>pf ontology</code> shows the agreed concept set; <code>pf tokens</code> still green on the seven existing projects.</span></div>
+    </div>
+  </div>
+
+  <div class="phase">
+    <div class="phase-n">PHASE&nbsp;2</div>
+    <div class="phase-body">
+      <h4>Scaffold and land the code</h4>
+      <p>Mechanical, and the fast part. Survey first, apply second.</p>
+      <pre><code>uv run pf new-group jaffle
+uv run pf new-project jaffle jaffle-shop --with evidence,github
+uv run pf onboard jaffle jaffle-shop \
+  https://github.com/DataRecce/jaffle-shop-expand   <span class="cmt"># plan</span>
+uv run pf onboard jaffle jaffle-shop &lt;src&gt; --apply</code></pre>
+      <p>The config merge, the reserved-macro exclusion and the toolkit wiring all happen in the apply. What is left by hand: drop audit-helper, add <code>dbt_date</code> and its <code>dbt_date:time_zone</code> var, then work the <code>pf dialect</code> report — confirm the source dialect, and wrap the 128 ambiguous call sites in their <code>sf_*</code> macros.</p>
+      <div class="exit"><span class="lbl">Exit</span><span class="txt"><code>pf dialect</code> clean; <code>dbt deps</code>, <code>dbt seed --vars 'load_source_data: true'</code> and <code>dbt build</code> all green on DuckDB — 1,058 models and ~794 tests passing.</span></div>
+    </div>
+  </div>
+
+  <div class="phase">
+    <div class="phase-n">PHASE&nbsp;3</div>
+    <div class="phase-body">
+      <h4>Make it legible to the platform</h4>
+      <p>This is where the real cost sits, and it is annotation work no tool can infer. Write <code>contracts/annotations.yaml</code> for the raw tables in scope — concept, roles, renames, FK links, grain and description per resource.</p>
+      <p>Start with the 6 <code>ecom</code> tables. They are the original jaffle core, they carry the semantic models and metrics, and they are the only ones with a genuine business shape. The other five domains are synthetic; decide domain by domain whether they earn annotations or stay unannotated mass.</p>
+      <p>Be aware of the trap: <code>validate_project</code> only <em>warns</em> on missing annotations. The project will pass <code>pf check</code> while contributing nothing to the graph, the metrics or the gate. Passing is not the same as onboarded.</p>
+      <div class="exit"><span class="lbl">Exit</span><span class="txt">Every in-scope resource resolves to a concept; <code>pf kg build</code> produces a graph with real edges; <code>pf tokens</code> green with the summarised card.</span></div>
+    </div>
+  </div>
+
+  <div class="phase">
+    <div class="phase-n">PHASE&nbsp;4</div>
+    <div class="phase-body">
+      <h4>Wire the platform's machinery</h4>
+      <ul>
+        <li><code>pf dagster-workspace</code> to register the code location; assets come from the <code>dagster-dbt</code> factory.</li>
+        <li>Evidence reporting from the semantic layer — the 6 existing semantic models and 3 metric files are a real head start.</li>
+        <li>The GitHub impact gate on PRs. Expect <code>pf impact</code> blast radius to be large and slow here; measure it before trusting it in CI.</li>
+        <li>Settle the <code>maxFiles</code> question — my recommendation is to exclude this project from loops rather than raise the cap.</li>
+      </ul>
+      <div class="exit"><span class="lbl">Exit</span><span class="txt"><code>pf check</code> clean; the project appears in <code>pf status</code>; a test PR touching one mart produces a correct, bounded impact report.</span></div>
+    </div>
+  </div>
+
+  <div class="phase">
+    <div class="phase-n">PHASE&nbsp;5</div>
+    <div class="phase-body">
+      <h4>Snowflake</h4>
+      <p>Only once DuckDB is green, per your call. Add a <code>snowflake</code> output to the project's <code>profiles.yml</code> from your credentials. The <code>sf_*</code> macros dispatch on the adapter, so they compile to native Snowflake functions with nothing to switch off.</p>
+      <p>Because the models were made portable rather than rewritten, this is a connection change and a full build — not a migration. Compare row counts per model between the two targets; that diff is the actual proof the macros were faithful, and it is the only proof that counts.</p>
+      <div class="exit"><span class="lbl">Exit</span><span class="txt">Identical model and test results on both targets, with per-model row-count parity on the seeded data.</span></div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <h2>What no tool can do for you</h2>
+  <div class="col">
+    <p>Everything above that a command can perform, a command performs. This is the residue — the judgement that decides whether the project is genuinely part of the platform or merely stored in it.</p>
+  </div>
+  <ul class="checks">
+    <li>Which of the six domains deserve ontology concepts, and which stay unannotated fixture mass.</li>
+    <li>The grain of each mart — 772 of them, and <code>meta.grain</code> is what makes the impact gate meaningful rather than decorative.</li>
+    <li>Which foreign keys are real relationships versus incidental shared column names.</li>
+    <li>Whether <code>raw_items</code> is a first-class concept (<code>OrderLine</code>) or a grain of <code>Order</code> — this shapes every downstream fact table.</li>
+    <li>Which of the 38 mart folders are business outputs and which are synthetic shape-tests that should never reach a dashboard.</li>
+    <li>Whether the 3 existing metric definitions are correct under this platform's semantics, particularly any ratio metric — those must re-divide as <code>sum(num)/sum(den)</code>, never <code>avg(ratio)</code>.</li>
+  </ul>
+</section>
+
+<div class="footnote">
+  <p><strong>Method.</strong> Every number came from a shallow clone surveyed on 14 Aug 2026, then re-derived by the tooling described above rather than by grep. That re-derivation is what corrected the <code>iff</code> and <code>dateadd</code> figures, and what raised <code>date_trunc</code> from a portable footnote to the main finding.</p>
+  <p><strong>On catalogue lookups.</strong> <code>duckdb_functions()</code> is authoritative when a name is present and unreliable when it is absent: <code>coalesce</code>, <code>percentile_cont</code> and <code>grouping</code> all work and none of them appear in it. The detector therefore layers three sources — the catalogue, an allowlist for parser-level forms and ordered-set aggregates, and a binder probe that separates "no such function" from "wrong arguments". A single-source lookup reports problems that do not exist, which is how a tool teaches people to ignore it.</p>
+</div>
+
+</div>


### PR DESCRIPTION
Part **7 of 16** of a stack. Base is `stack/07-settings-format`, so this diff is only its
own commits. Merge in order.

**Tests on this branch: 372 passing.** Every branch in the stack is green
on its own, not only the tip.

## Commits

- `5d3c8b9` Keep each published artifact beside the thing it describes

`3 files changed, 2022 insertions(+)`

---

<details><summary>The whole stack</summary>

| # | Branch | Tests |
|--:|---|--:|
| 1 | `stack/02-project-policy-layer` — a project carries its own policy | 356 |
| 2 | `stack/03-graph-project-scope` — graph from the project ontology | 359 |
| 3 | `stack/04-kg-atlas` — the atlas | 359 |
| 4 | `stack/05-graph-rebuild` — rebuild graphs and cards | 359 |
| 5 | `stack/06-kg-currency` — currency, and a stale-graph check | 372 |
| 6 | `stack/07-settings-format` — settings format migration | 372 |
| 7 | `stack/08-artifacts-by-scope` — artifacts beside what they describe | 372 |
| 8 | `stack/09-test-suite-layout` — group the suite, generate its index | 384 |
| 9 | `stack/10-script-folders` — name the script folders | 384 |
| 10 | `stack/11-gate-and-platform-ci` — gate renames, suite on PRs | 387 |
| 11 | `stack/12-architecture-map` — draw the repository | 397 |
| 12 | `stack/13-data-quality-toolkits` — expectations and anomalies | 401 |
| 13 | `stack/14-settings-schema` — align the scaffolder | 426 |
| 14 | `stack/15-ducklake-target` — DuckLake, warehouse MCP | 441 |
| 15 | `stack/16-capability-policies` — declare what must hold | 453 |
| 16 | `stack/17-platform-graph-mcp` — graph the platform layer | 453 |

</details>

<details><summary>This stack was reordered — what changed, and what did not</summary>

Branches 09–15 were red when first pushed, for three ordering defects. All three
are fixed and **the tip tree is byte-identical to before the reorder** — only
the order in which the work arrives changed.

**Two untracked test files were swept in five branches early.** `1ddd90b`'s own
message admits it: *"Also tracks two test files that existed only on disk"*.
`test_claude_settings.py` imports `pf.scaffold.claude_settings`, added at
stack/14; `test_warehouse_mcp.py` needs the warehouse MCP payloads, added at
stack/15. Both now arrive with their subjects. Until then the whole suite died
at collection.

**A consumer landed before its producer.** `54bc6c1` (stack/14) calls
`warehouse_capability`, which reads `ProductionWarehouse.mcp` — a field
declared by `dfaa46d` in stack/15. The field declaration moved back to the
commit that needs it; the per-warehouse payloads and DuckLake stayed put.

**Generated indexes described a future tree.** `platform/tests/README.md` at
stack/15 listed `test_capability_policies.py`, which does not exist until
stack/16. Both generated artefacts are now regenerated per branch, so each one
describes its own tree.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
