### PR TITLE
feat(kg): graph the platform layer, and serve it over MCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,8 @@ connection.json
 # is 200MB of dependencies; both are reproducible from package-lock.json.
 **/ui/static/dist/
 **/ui/web/node_modules/
+
+# The platform knowledge graph, rebuilt by `graphify extract . --code-only`.
+# Generated like every artefact above, and 3.3MB of it — `.graphifyignore`
+# defines what goes in, which is the part worth reviewing in a diff.
+graphify-out/

--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,0 +1,35 @@
+# What the platform graph does not index.
+#
+# Scope: this graph describes the **shared** layer — `platform/`, `docs/`, repo
+# tooling. It is what an agent working *on the platform* asks before reading
+# files, and it is served over MCP by `graphify-mcp`.
+#
+# `groups/` is excluded on purpose, and not for size. CLAUDE.md's rule is that a
+# session never reads another group or another sister project, because business
+# logic does not transfer between entities and an assumption carried across is a
+# bug. One graph spanning acme, globex, jaffle and zenith would hand any session
+# a queryable index of all four — the isolation rule, undone by a retrieval tool.
+# A project that wants its own graph has one: `pf kg build` writes it per project,
+# and `kg_search` serves it scoped.
+groups/
+
+# Fourteen pinned upstreams, ~389MB. Read them directly, or graph one on its own
+# with `graphify extract vendor/<name>` into its own graphify-out — which is what
+# vendor/evidence-bi already does.
+vendor/
+
+# Build output and environments.
+node_modules/
+.venv/
+__pycache__/
+.git/
+graphify-out/
+
+# Generated artefacts. These mirror .gitignore: indexing a compiled manifest
+# teaches the graph the output rather than the source that produced it.
+**/target/
+**/target-*/
+**/logs/
+**/dbt_packages/
+*.duckdb
+*.pyc

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "graphify": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "graphifyy",
+        "graphify-mcp",
+        "${CLAUDE_PROJECT_DIR}/graphify-out/graph.json"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Part **16 of 16** of a stack. Base is `stack/16-capability-policies`, so this diff is only its
own commits. Merge in order.

**Tests on this branch: 453 passing.** Every branch in the stack is green
on its own, not only the tip.

## Commits

- `f2e7659` Graph the platform layer, and serve it over MCP

`3 files changed, 53 insertions(+)`

---

<details><summary>The whole stack</summary>

| # | Branch | Tests |
|--:|---|--:|
| 1 | `stack/02-project-policy-layer` — a project carries its own policy | 356 |
| 2 | `stack/03-graph-project-scope` — graph from the project ontology | 359 |
| 3 | `stack/04-kg-atlas` — the atlas | 359 |
| 4 | `stack/05-graph-rebuild` — rebuild graphs and cards | 359 |
| 5 | `stack/06-kg-currency` — currency, and a stale-graph check | 372 |
| 6 | `stack/07-settings-format` — settings format migration | 372 |
| 7 | `stack/08-artifacts-by-scope` — artifacts beside what they describe | 372 |
| 8 | `stack/09-test-suite-layout` — group the suite, generate its index | 384 |
| 9 | `stack/10-script-folders` — name the script folders | 384 |
| 10 | `stack/11-gate-and-platform-ci` — gate renames, suite on PRs | 387 |
| 11 | `stack/12-architecture-map` — draw the repository | 397 |
| 12 | `stack/13-data-quality-toolkits` — expectations and anomalies | 401 |
| 13 | `stack/14-settings-schema` — align the scaffolder | 426 |
| 14 | `stack/15-ducklake-target` — DuckLake, warehouse MCP | 441 |
| 15 | `stack/16-capability-policies` — declare what must hold | 453 |
| 16 | `stack/17-platform-graph-mcp` — graph the platform layer | 453 |

</details>

<details><summary>This stack was reordered — what changed, and what did not</summary>

Branches 09–15 were red when first pushed, for three ordering defects. All three
are fixed and **the tip tree is byte-identical to before the reorder** — only
the order in which the work arrives changed.

**Two untracked test files were swept in five branches early.** `1ddd90b`'s own
message admits it: *"Also tracks two test files that existed only on disk"*.
`test_claude_settings.py` imports `pf.scaffold.claude_settings`, added at
stack/14; `test_warehouse_mcp.py` needs the warehouse MCP payloads, added at
stack/15. Both now arrive with their subjects. Until then the whole suite died
at collection.

**A consumer landed before its producer.** `54bc6c1` (stack/14) calls
`warehouse_capability`, which reads `ProductionWarehouse.mcp` — a field
declared by `dfaa46d` in stack/15. The field declaration moved back to the
commit that needs it; the per-warehouse payloads and DuckLake stayed put.

**Generated indexes described a future tree.** `platform/tests/README.md` at
stack/15 listed `test_capability_policies.py`, which does not exist until
stack/16. Both generated artefacts are now regenerated per branch, so each one
describes its own tree.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
