### PR TITLE
Feat(proverance)  included asqv module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -84,3 +84,8 @@
 	path = vendor/public-sector-ai-playbook
 	url = https://github.com/PackMaaan/public-sector-ai-playbook
 	branch = main
+	shallow = true
+[submodule "vendor/ai-governance-framework"]
+	path = vendor/ai-governance-framework
+	url = https://github.com/Atomz-org/ai-governance-framework
+	branch = main

--- a/platform/src/pf/checks.py
+++ b/platform/src/pf/checks.py
@@ -1,0 +1,60 @@
+"""The three-state check — one condition, its verdict, and the evidence for it.
+
+Lifted out of `pf.onboard.ladder`, which defined it first and still re-exports it.
+The move happened when `pf.air` needed the same vocabulary to report control
+coverage: importing it from `ladder` would have dragged `dialect`, `survey` and
+`audit` into every `pf air` invocation to reuse a 12-line dataclass, and defining
+a second one would have made three (`pf.loops.audit.Check` is a different thing —
+a weighted pass/fail for a readiness *score*, not a gate condition).
+
+## Why three states and not two
+
+`unexercised` is not a polite failure. It is the honest answer when the thing
+that would decide is absent — the tool is not installed, the ledger has no
+records yet, the submodule is not checked out — and it is reported loudly rather
+than counted as either. Collapsing it into `fail` walls a project off over a
+missing binary; collapsing it into `pass` is how a control that has never run
+reads as a control that works.
+
+**Only `fail` closes a gate.** That rule lives in `ok` and every caller inherits
+it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+Status = Literal["pass", "fail", "unexercised"]
+
+__all__ = ["Check", "Status", "failed", "passed", "unexercised"]
+
+
+@dataclass(frozen=True)
+class Check:
+    """One gate condition, with the evidence for its verdict.
+
+    `evidence` is not a restatement of `name`. A check that says only "failed"
+    forces whoever reads it to reproduce the check by hand, which is how a gate
+    stops being read at all.
+    """
+
+    name: str
+    status: Status
+    evidence: str
+
+    @property
+    def ok(self) -> bool:
+        return self.status != "fail"
+
+
+def passed(name: str, evidence: str) -> Check:
+    return Check(name, "pass", evidence)
+
+
+def failed(name: str, evidence: str) -> Check:
+    return Check(name, "fail", evidence)
+
+
+def unexercised(name: str, evidence: str) -> Check:
+    return Check(name, "unexercised", evidence)

--- a/platform/src/pf/onboard/ladder.py
+++ b/platform/src/pf/onboard/ladder.py
@@ -49,15 +49,13 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from functools import cached_property
 from pathlib import Path
-from typing import Literal
 
 import yaml
 
+from pf.checks import Check, Status, failed, passed, unexercised  # noqa: F401 — Status re-exported
 from pf.onboard.audit import Risk
 from pf.onboard.dialect import Report, analyse
 from pf.onboard.survey import RESERVED_MACROS
-
-Status = Literal["pass", "fail", "unexercised"]
 
 #: The layers this platform reasons about. `semantic` is not a model directory in
 #: the same sense as the others — it holds MetricFlow YAML — but it lives under
@@ -78,34 +76,11 @@ _REF = re.compile(r"\{\{\s*(?:ref|source)\s*\(([^)]*)\)", re.IGNORECASE)
 
 
 # ------------------------------------------------------------------ checks --
-@dataclass(frozen=True)
-class Check:
-    """One gate condition, with the evidence for its verdict.
-
-    `evidence` is not a restatement of `name`. A check that says only "failed"
-    forces whoever reads it to reproduce the check by hand, which is how a gate
-    stops being read at all.
-    """
-
-    name: str
-    status: Status
-    evidence: str
-
-    @property
-    def ok(self) -> bool:
-        return self.status != "fail"
-
-
-def passed(name: str, evidence: str) -> Check:
-    return Check(name, "pass", evidence)
-
-
-def failed(name: str, evidence: str) -> Check:
-    return Check(name, "fail", evidence)
-
-
-def unexercised(name: str, evidence: str) -> Check:
-    return Check(name, "unexercised", evidence)
+# `Check`, `Status`, `passed`, `failed` and `unexercised` now live in
+# `pf.checks` — imported above and re-exported here, because this module defined
+# them first and `from pf.onboard.ladder import Check` is what the callers write.
+# `pf.air` needed the same vocabulary without this module's imports; the move is
+# the whole change.
 
 
 @dataclass


### PR DESCRIPTION
----
## Summary by Gitar

- **Refactoring:**
    - Lifted the three-state `Check` dataclass and status helpers out of `pf.onboard.ladder` into `pf.checks`
- **Submodules:**
    - Added `vendor/ai-governance-framework` submodule and enabled shallow clones

<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for an AI governance framework.
  - Checks now clearly distinguish between passed, failed, and unexercised controls.
  - Unexercised checks are reported explicitly rather than treated as passes or failures.

- **Behavior Updates**
  - Only failed checks prevent a gate from passing; unexercised checks remain visible for follow-up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->